### PR TITLE
switch to https version of :repo_url, now that repo is public

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -3,7 +3,7 @@ lock '3.4.0'
 
 set :rvm_ruby_version, '2.2.4'      # Defaults to: 'default'
 set :application, 'pre-assembly'
-set :repo_url, 'git@github.com:sul-dlss/pre-assembly.git'
+set :repo_url, 'https://github.com/sul-dlss/pre-assembly.git'
 
 set :ssh_options, {
   keys: [Capistrano::OneTimeKey.temporary_ssh_private_key_path],


### PR DESCRIPTION
this fixes a deployment error in environments which don't have SSH key auth setup for github