### PR TITLE
allow a pause time to be set in remediation scripts

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -819,7 +819,10 @@ You can re-run the remediation with the same CSV file and it will automatically 
 You can also add optional parameters to override defaults for checking if items are in accessioning or if they require versioning and set to false.
 Only do this if you are sure you know what you are doing for scripts that for some reason will not work with versioning!
 
-ROBOT_ENVIRONMENT=production bin/remediate INPUT_FILE.csv REMEDIATE_LOGIC_FILENAME.rb ignore_versioning ignore_accessioning
+ROBOT_ENVIRONMENT=production bin/remediate INPUT_FILE.csv REMEDIATE_LOGIC_FILENAME.rb [PAUSE_TIME_IN_SECONDS] ignore_versioning ignore_accessioning
+
+Finally, you can specify a pause time in seconds per object. This can be useful for large remediation jobs that are a low priority, which allows them
+to run at a slower pace and thus generating less concurrent load on the system while other higher priority jobs are running concurrently.
 
 === MODs Remediation
 

--- a/bin/remediate
+++ b/bin/remediate
@@ -5,14 +5,17 @@
 # The code handles all logging and versioning as needed.
 
 # Run with
-# ROBOT_ENVIRONMENT=production bin/remediate INPUT_FILE.csv REMEDIATE_LOGIC_FILENAME.rb
+# ROBOT_ENVIRONMENT=production bin/remediate INPUT_FILE.csv REMEDIATE_LOGIC_FILENAME.rb [PAUSE_TIME_IN_SECONDS]
 
 # eg. ROBOT_ENVIRONMENT=production bin/remediate /dor/preassembly/remediation/revs_all_pids.csv /dor/preassembly/remediation/scripts/revs_rights_remediate.rb
 
-# Add in optional parameters to override defaults for checking if items are in accessioning or if they require versioning and set to false.
-# Only do this if you are sure you know what you are doing for scripts that for some reason will not work with versioning!
+# You can specify an optional number of seconds to pause between each object (in seconds) after the remediation logic filename.  If left off, no
+# pause between objects will occur.
+# You can also add in optional parameters to override defaults for checking if items are in accessioning or if they require versioning and set to false.
+# Only do this if you are sure you know what you are doing for scripts that for some reason will not work with versioning!  If you want to add these
+# parameters, you must also specify the pause time (which could be 0).
 
-# ROBOT_ENVIRONMENT=production bin/remediate INPUT_FILE.csv REMEDIATE_LOGIC_FILENAME.rb ignore_versioning ignore_accessioning
+# ROBOT_ENVIRONMENT=production bin/remediate INPUT_FILE.csv REMEDIATE_LOGIC_FILENAME.rb [PAUSE_TIME_IN_SECONDS] ignore_versioning ignore_accessioning
 
 # INPUT_FILE can be either a pre-assembly generated YAML log file or a CSV file with one column containing at least a list of druids
 # If a pre-assembly YAML log file is passed in, the successfully accessioned druids will be used.
@@ -41,12 +44,17 @@ require 'csv'
 require 'csv-mapper'
 
 def help(error_msg)
-  abort "#{error_msg}\n\nUsage:\n  ROBOT_ENVIRONMENT=XXXXX remediate INPUT_FILE REMEDIATE_LOGIC_FILENAME\n"
+  abort "#{error_msg}\n\nUsage:\n  ROBOT_ENVIRONMENT=XXXXX remediate INPUT_FILE REMEDIATE_LOGIC_FILENAME [PAUSE_TIME_SECONDS]\n"
 end
 
 help "Incorrect N of arguments." if ARGV.size < 2
 input_file = ARGV[0]
 remediate_logic_file = ARGV[1]
+if ARGV.size > 2
+  pause_time = ARGV[2].to_i
+else
+  pause_time = 0
+end
 
 ignore_accessioning = true if ARGV.include? 'ignore_accessioning' # override config file if supplied
 ignore_versioning = true if ARGV.include? 'ignore_versioning'  # override config file if supplied
@@ -91,6 +99,7 @@ total_to_process=total_druids-total_completed
 
 puts "Input file: #{input_file}"
 puts "Found #{total_to_process} to remediate.  Total in file: #{total_druids}.  Already completed: #{total_completed}"
+puts "Pausing #{pause_time} seconds between objects" if pause_time > 0
 puts "Started at #{Time.now}"
 puts ""
 $stdout.flush
@@ -119,6 +128,8 @@ druids.each do |druid|
     end
     total_time=Time.now-start_time
 
+    sleep pause_time if pause_time > 0
+
     remaining_to_process=total_to_process-count
     avg_time_per_object=total_time/count
     total_time_remaining=(avg_time_per_object * remaining_to_process).floor
@@ -137,7 +148,7 @@ total_time=((end_time-start_time) / 1.hour).round(2)
 puts ""
 puts "Input file: #{input_file}"
 puts "Output file: #{csv_out}"
-puts "Ended at #{end_time}.  Total time: #{total_time} hours.  Average time per object: #{(total_time*3600/total_to_process).round(2)} seconds"
+puts "Ended at #{end_time}.  Total time: #{total_time} hours.  Average time per object: #{(total_time*3600/total_to_process).round(2)} seconds (includes any pause time).  Pause time: #{pause_time} seconds"
 puts "Total in file: #{total_druids}. Total processed: #{total_to_process}. Successful: #{total_success}. Completed previously: #{total_completed}.  Failed: #{total_failure}"
 
 $stdout.flush

--- a/bin/remediate
+++ b/bin/remediate
@@ -10,7 +10,8 @@
 # eg. ROBOT_ENVIRONMENT=production bin/remediate /dor/preassembly/remediation/revs_all_pids.csv /dor/preassembly/remediation/scripts/revs_rights_remediate.rb
 
 # You can specify an optional number of seconds to pause between each object (in seconds) after the remediation logic filename.  If left off, no
-# pause between objects will occur.
+# pause between objects will occur. This can be useful for large remediation jobs that are a low priority, which allows them to run at a slower pace
+# and thus generating less concurrent load on the system while other higher priority jobs are running concurrently.
 # You can also add in optional parameters to override defaults for checking if items are in accessioning or if they require versioning and set to false.
 # Only do this if you are sure you know what you are doing for scripts that for some reason will not work with versioning!  If you want to add these
 # parameters, you must also specify the pause time (which could be 0).


### PR DESCRIPTION
This can be useful for large remediation jobs that are a low priority, which allows them to run at a slower pace and thus generating less concurrent load on the system while other higher priority jobs are running concurrently.