### PR TITLE
Replace publish_attr configuration with file_attr

### DIFF
--- a/lib/pre_assembly/bundle.rb
+++ b/lib/pre_assembly/bundle.rb
@@ -31,7 +31,7 @@ module PreAssembly
       :apply_tag,
       :apo_druid_id,
       :set_druid_id,
-      :publish_attr,
+      :file_attr,
       :compute_checksum,
       :init_assembly_wf,
       :content_md_creation,
@@ -84,6 +84,7 @@ module PreAssembly
       Assembly::Utils.values_to_symbols! params[:project_style]
       cmc          = params[:content_md_creation]
       cmc[:style]  = cmc[:style].to_sym
+      params[:file_attr] ||= params[:publish_attr]
       @user_params = params
       YAML_PARAMS.each { |p| instance_variable_set "@#{p.to_s}", params[p] }
 
@@ -115,8 +116,8 @@ module PreAssembly
       @manifest_rows          = nil
       @content_exclusion      = Regexp.new(@content_exclusion) if @content_exclusion
       @validate_bundle_dir  ||= {}
-      @publish_attr           = {} if @publish_attr.nil?
-      @publish_attr.delete_if { |k,v| v.nil? }
+      @file_attr              = {} if @file_attr.nil?
+      @file_attr.delete_if { |k,v| v.nil? }
       @set_druid_id = [@set_druid_id] if @set_druid_id && @set_druid_id.class == String # convert set_druid_id to 1 element array if its single valued and exists
     end
 
@@ -428,7 +429,7 @@ module PreAssembly
           :apply_tag            => @apply_tag,
           :apo_druid_id         => @apo_druid_id,
           :set_druid_id         => @set_druid_id,
-          :publish_attr         => @publish_attr,
+          :file_attr            => @file_attr,
           :init_assembly_wf     => @init_assembly_wf,
           :content_md_creation  => @content_md_creation,
           :container            => container,

--- a/lib/pre_assembly/digital_object.rb
+++ b/lib/pre_assembly/digital_object.rb
@@ -20,7 +20,7 @@ module PreAssembly
       :apply_tag,
       :apo_druid_id,
       :set_druid_id,
-      :publish_attr,
+      :file_attr,
       :bundle_dir,
       :staging_dir,
       :desc_md_template_xml,
@@ -58,6 +58,7 @@ module PreAssembly
 
     def initialize(params = {})
       INIT_PARAMS.each { |p| instance_variable_set "@#{p.to_s}", params[p] }
+      @file_attr ||= params[:publish_attr]
       setup
     end
 
@@ -463,7 +464,7 @@ module PreAssembly
         # otherwise use the content metadata generation gem
         params={:druid=>@druid.id,:objects=>content_object_files,:add_exif=>false,:bundle=>@content_md_creation[:style].to_sym,:style=>content_md_creation_style}
 
-        params.merge!(:add_file_attributes=>true,:file_attributes=>@publish_attr.stringify_keys) unless @publish_attr.nil?
+        params.merge!(:add_file_attributes=>true,:file_attributes=>@file_attr.stringify_keys) unless @file_attr.nil?
 
         @content_md_xml = Assembly::ContentMetadata.create_content_metadata(params)
 

--- a/lib/pre_assembly/project/salt.rb
+++ b/lib/pre_assembly/project/salt.rb
@@ -12,7 +12,7 @@ module PreAssembly
          # otherwise use the content metadata generation gem
          params={:druid=>@druid.id,:objects=>content_object_files,:add_exif=>false,:bundle=>:filename,:style=>content_md_creation_style}
 
-         params.merge!(:add_file_attributes=>true,:file_attributes=>@publish_attr.stringify_keys) unless @publish_attr.nil?
+         params.merge!(:add_file_attributes=>true,:file_attributes=>@file_attr.stringify_keys) unless @file_attr.nil?
 
          content_md_xml = Assembly::ContentMetadata.create_content_metadata(params)
 

--- a/spec/bundle_spec.rb
+++ b/spec/bundle_spec.rb
@@ -55,15 +55,15 @@ describe PreAssembly::Bundle do
       expect(template.size).to be > 0
     end
 
-    it "setup_other() should prune @publish_attr" do
+    it "setup_other() should prune @file_attr" do
       # All keys are present.
-      ks = @b.publish_attr.keys.map { |k| k.to_s }
+      ks = @b.file_attr.keys.map { |k| k.to_s }
       expect(ks.sort).to eq(%w(preserve publish shelve))
       # Keys with nil values should be removed.
-      @b.publish_attr[:preserve] = nil
-      @b.publish_attr[:publish]  = nil
+      @b.file_attr[:preserve] = nil
+      @b.file_attr[:publish]  = nil
       @b.setup_other
-      expect(@b.publish_attr.keys).to eq([:shelve])
+      expect(@b.file_attr.keys).to eq([:shelve])
     end
 
   end

--- a/spec/digital_object_spec.rb
+++ b/spec/digital_object_spec.rb
@@ -426,7 +426,7 @@ describe PreAssembly::DigitalObject do
       @dobj.druid = @druid
       @dobj.content_md_creation[:style]='none'
       @dobj.project_style[:content_structure]='simple_book'
-      @dobj.publish_attr=nil
+      @dobj.file_attr=nil
       add_object_files('tif')
       add_object_files('jp2')
       @dobj.create_content_metadata
@@ -448,7 +448,7 @@ describe PreAssembly::DigitalObject do
       @dobj.druid = @druid
       @dobj.content_md_creation[:style]='filename'
       @dobj.project_style[:content_structure]='simple_book'
-      @dobj.publish_attr=nil
+      @dobj.file_attr=nil
       add_object_files('tif')
       add_object_files('jp2')
       @dobj.create_content_metadata
@@ -494,7 +494,7 @@ describe PreAssembly::DigitalObject do
       @dobj.project_style[:content_tag_override]=true        # this allows override of content structure
       allow(@dobj).to receive(:content_type_tag).and_return('File')       # this is what the object tag says, so we should get the file type out
       @dobj.project_style[:should_register]=false
-      @dobj.publish_attr=nil
+      @dobj.file_attr=nil
       add_object_files('tif')
       add_object_files('jp2')
       @dobj.create_content_metadata
@@ -563,7 +563,7 @@ describe PreAssembly::DigitalObject do
       @dobj.project_style[:content_structure]='simple_image' # this is the default
       allow(@dobj).to receive(:content_type_tag).and_return('File')       # this is what the object tag says, but it should be ignored since overriding is not allowed
       @dobj.project_style[:should_register]=false
-      @dobj.publish_attr={'image/jp2'=>{:publish=>'yes',:shelve=>'yes',:preserve=>'no'},'image/tiff'=>{:publish=>'no',:shelve=>'no',:preserve=>'yes'}}
+      @dobj.file_attr={'image/jp2'=>{:publish=>'yes',:shelve=>'yes',:preserve=>'no'},'image/tiff'=>{:publish=>'no',:shelve=>'no',:preserve=>'yes'}}
       add_object_files('tif')
       add_object_files('jp2')
       @dobj.create_content_metadata


### PR DESCRIPTION
This makes it clear(er) that preassembly can pass through non-publish attributes (like the new `role` attribute, see https://github.com/sul-dlss/dor-services/pull/338).