### PR TITLE
README out of date and sent spec environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,13 +304,6 @@ git clone git@github.com:sul-dlss/pre-assembly.git
 cd pre-assembly
 ```
 
-Copy the default configs and use them for local and test.
-
-```bash
-cp config/environments/test.example.rb config/environments/test.rb
-cp config/environments/test.example.rb config/environments/development.rb
-```
-
 You will need to have a certificate to access DOR-test in order to run integration tests from your laptop.  The certificates are placed
 in your laptop's "config/certs" folder and are referenced in the "config/environments/test.rb" file.  Talk to DevOps to get a certificate.
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,7 @@ SimpleCov.formatter = Coveralls::SimpleCov::Formatter
 SimpleCov.start do
   track_files "bin/**/*"
 end
-
+ENV['ROBOT_ENVIRONMENT'] ||= "test"
 puts "running in #{ENV['ROBOT_ENVIRONMENT']} mode"
 bootfile = File.expand_path(File.dirname(__FILE__) + '/../config/boot')
 require bootfile


### PR DESCRIPTION
README was telling us to cp a non existent file

set ROBOT_ENV to test, so tests are not trying to run in dev