### PR TITLE
Use attributes

### DIFF
--- a/spec/digital_object_spec.rb
+++ b/spec/digital_object_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe PreAssembly::DigitalObject do
-  before(:each) do
+  before do
     @ps = {
       :apo_druid_id  => 'druid:qq333xx4444',
       :set_druid_id  => 'druid:mm111nn2222',
@@ -47,7 +47,7 @@ describe PreAssembly::DigitalObject do
   ####################
 
   describe "determining druid: get_pid_from_container_barcode()" do
-    before(:each) do
+    before do
       @druids = %w(druid:aa00aaa0000 druid:cc11bbb1111 druid:dd22eee2222)
       apos = %w(druid:aa00aaa9999 druid:bb00bbb9999 druid:cc00ccc9999)
       apos = apos.map { |a| double('apo', :pid => a) }
@@ -223,7 +223,7 @@ describe PreAssembly::DigitalObject do
   ####################
 
   describe "unregister()" do
-    before(:each) do
+    before do
       @dobj.dor_object = 1234
       allow(Assembly::Utils).to receive :delete_from_dor
       allow(Assembly::Utils).to receive :set_workflow_step_to_error
@@ -303,7 +303,7 @@ describe PreAssembly::DigitalObject do
   ####################
 
   describe "default content metadata" do
-    before(:each) do
+    before do
       @dobj.druid = @druid
       @dobj.content_md_creation[:style] = 'default'
       @dobj.project_style[:content_structure] = 'simple_image'
@@ -398,7 +398,7 @@ describe PreAssembly::DigitalObject do
   ####################
 
   describe "no content metadata generated" do
-    before(:each) do
+    before do
       @dobj.druid = @druid
       @dobj.content_md_creation[:style] = 'none'
       @dobj.project_style[:content_structure] = 'simple_book'
@@ -418,7 +418,7 @@ describe PreAssembly::DigitalObject do
   ####################
 
   describe "bundled by filename, simple book content metadata without file attributes" do
-    before(:each) do
+    before do
       @dobj.druid = @druid
       @dobj.content_md_creation[:style] = 'filename'
       @dobj.project_style[:content_structure] = 'simple_book'
@@ -459,7 +459,7 @@ describe PreAssembly::DigitalObject do
   ####################
 
   describe "content metadata generated from object tag in DOR if present and overriding is allowed" do
-    before(:each) do
+    before do
       @dobj.druid = @druid
       @dobj.content_md_creation[:style] = 'default'
       @dobj.project_style[:content_structure] = 'simple_image' # this is the default
@@ -528,7 +528,7 @@ describe PreAssembly::DigitalObject do
 
   ####################
   describe "content metadata generated from object tag in DOR if present but overriding is not allowed" do
-    before(:each) do
+    before do
       @dobj.druid = @druid
       @dobj.content_md_creation[:style] = 'default'
       @dobj.project_style[:content_structure] = 'simple_image' # this is the default
@@ -604,7 +604,7 @@ describe PreAssembly::DigitalObject do
   ####################
 
   describe "descriptive metadata" do
-    before(:each) do
+    before do
       @dobj.druid = @druid
       @dobj.manifest_row = {
         :sourceid    => 'foo-1',

--- a/spec/object_file_spec.rb
+++ b/spec/object_file_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe PreAssembly::ObjectFile do
-  before(:each) do
+  before do
     @f = PreAssembly::ObjectFile.new(
       :path => 'spec/test_data/bundle_input_a/image1.tif'
     )

--- a/spec/remediate_spec.rb
+++ b/spec/remediate_spec.rb
@@ -9,7 +9,7 @@ describe PreAssembly::Remediation::Item do
     end
   end
   context "logging" do
-    before(:each) do
+    before do
       @pid = "druid:cs575bk5522"
       @item = PreAssembly::Remediation::Item.new(@pid)
       @log_dir = File.dirname(__FILE__) + "/test_data/logging"

--- a/spec/revs_project_specific_spec.rb
+++ b/spec/revs_project_specific_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'revs-utils'
 
 describe PreAssembly::DigitalObject do
-  before(:each) do
+  before do
     @ps = { :apo_druid_id => 'druid:qq333xx4444', :set_druid_id => 'druid:mm111nn2222', :source_id => 'SourceIDFoo', :project_name => 'ProjectBar', :label => 'LabelQuux', :project_style => {}, :content_md_creation => {} }
     @dobj         = PreAssembly::DigitalObject.new @ps
 
@@ -168,7 +168,7 @@ describe PreAssembly::DigitalObject do
   ####################
 
   describe "revs specific descriptive metadata using special lookup methods, with a hidden image" do
-    before(:each) do
+    before do
       @dobj.druid = @druid
       @dobj.manifest_row = {
         :sourceid    => 'foo-1',
@@ -245,7 +245,7 @@ describe PreAssembly::DigitalObject do
   end
 
   describe "revs specific descriptive metadata using other lookup methods for location tags with just the country known" do
-    before(:each) do
+    before do
       @dobj.druid = @druid
       @dobj.manifest_row = {
         :sourceid    => 'foo-1',
@@ -302,7 +302,7 @@ describe PreAssembly::DigitalObject do
   end
 
   describe "revs specific descriptive metadata using other lookup methods for location tags with no known entities and multiple formats with format correction, and preserving some odd date value" do
-    before(:each) do
+    before do
       @dobj.druid = @druid
       @dobj.manifest_row = {
         :sourceid    => 'foo-1',

--- a/spec/smpl_project_specific_spec.rb
+++ b/spec/smpl_project_specific_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe PreAssembly::DigitalObject do
   describe 'SMPL content metadata generation and techMetadata generation - no thumb declaration' do
-    before(:each) do
+    before do
       @bundle_dir = File.join(PRE_ASSEMBLY_ROOT, 'spec/test_data/bundle_input_e')
       @smpl_manifest = PreAssembly::Smpl.new(:csv_filename => 'smpl_manifest.csv', :bundle_dir => @bundle_dir, :verbose => false)
       @dobj1         = setup_dobj('aa111aa1111')
@@ -30,7 +30,7 @@ describe PreAssembly::DigitalObject do
   end # end no thumb declaration
 
   describe 'SMPL content metadata generation with thumb declaration' do
-    before(:each) do
+    before do
       @bundle_dir = File.join(PRE_ASSEMBLY_ROOT, 'spec/test_data/bundle_input_e')
     end
 


### PR DESCRIPTION
The accessors were already declared... then not used.

Note the economy of just using a getting method for `dor_object` rather than a special method to get the object and set `@dor_object`.

There was no benefit to enumerating a bunch of symbols, then iterating through them in a loop declaring `attr_accessor` for each vs. just calling `attr_accessor` once with the same symbols.  