### PR TITLE
Layout and cleanup fixes

### DIFF
--- a/bin/mods_report
+++ b/bin/mods_report
@@ -50,5 +50,5 @@ puts "limiting to #{limit}" unless limit.blank?
     puts "Saving MODs for sourceID #{identifier}  [#{x} of #{@items.size}]"
   else
     puts "Error: cannot generate desc md xml for #{identifier} [#{x} of #{@items.size}]"
-   end
+  end
 end

--- a/bin/mods_report2
+++ b/bin/mods_report2
@@ -44,5 +44,5 @@ puts "Generating #{@items.size} MODs files from #{manifest_file} using MODs temp
     puts "Saving MODs for sourceID #{identifier}  [#{x} of #{@items.size}]"
   else
     puts "Error: cannot generate desc md xml for #{identifier} [#{x} of #{@items.size}]"
-   end
+  end
 end

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -15,7 +15,6 @@ require_relative "cli_environments/#{environment}.rb"
 Dor::Config.dor_services.url ||= Dor::Config.dor.service_root
 Dor::Config.workflow.client.configure(Dor::Config.workflow.url, :dor_services_url => Dor::Config.dor_services.url.gsub('/v1', ''))
 
-
 # Project dir in load path.
 $LOAD_PATH.unshift(PRE_ASSEMBLY_ROOT + '/lib')
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -54,7 +54,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store

--- a/devel/mjf_transform.rb
+++ b/devel/mjf_transform.rb
@@ -164,12 +164,8 @@ Dir.chdir(content_path)
       f = File.open(output_dm, 'w') { |fh| fh.puts mods.to_xml.gsub(/^\s*\n/, "") }
       FileUtils.chmod(0644, output_dm)
       puts "...Writing #{descriptive_xml_filename}"
-
     end # end finding XML file
-
   else
-
     puts "**** ERROR: Could not locate content folder within the '#{folder}/data' folder"
-
-   end # end check for content subfolder
+  end # end check for content subfolder
 end # end loop over all input rows in spreadsheet

--- a/devel/revs_get_druid_from_sourceid.rb
+++ b/devel/revs_get_druid_from_sourceid.rb
@@ -20,10 +20,8 @@ source_path = File.dirname(csv_in)
 
 # read input manifest
 @items = CsvMapper.import(csv_in) do read_attributes_from_file end
-
 all_pids = []
 all_filenames = []
-
 @items.each_with_index do |row, _x|
   pids = Dor::SearchService.query_by_id("Revs:#{row.sourceid}")
   if pids.size != 1
@@ -31,7 +29,7 @@ all_filenames = []
   else
     all_filenames << "\"#{row.sourceid}.tif\""
     all_pids << "\"#{pids.first}\""
-   end
+  end
 end
 
 puts

--- a/devel/revs_update_images.rb
+++ b/devel/revs_update_images.rb
@@ -38,25 +38,25 @@ completed_druids = PreAssembly::Remediation::Item.get_druids(progress_log_file)
   pids = Dor::SearchService.query_by_id("Revs:#{row.sourceid}")
   if pids.size != 1
     puts "cannot find single pid for source id #{row.sourceid}"
+    next
+  end
+  pid = pids.first
+  done = completed_druids.include?(pid)
+  if done
+    puts "#{pid} : skipping, already completed"
+    next
+  end
+  if row.respond_to?(:filename) && !row.filename.blank?
+    filename = row.filename
   else
-    pid = pids.first
-    done = completed_druids.include?(pid)
-    if done
-      puts "#{pid} : skipping, already completed"
-    else
-      if row.respond_to?(:filename) && !row.filename.blank?
-        filename = row.filename
-      else
-        filename = "#{row.sourceid}.tif"
-      end
-      data = { :source_path => source_path, :filename => filename }
-      item = PreAssembly::Remediation::Item.new(pid, data)
-      item.description = "Updating image from #{csv_in}" # added to the version description
-      item.extend(RemediationLogic) # add in our project specific methods
-      success = item.remediate
-      item.log_to_progress_file(progress_log_file)
-      item.log_to_csv(csv_out)
-      puts "#{pid} : #{success}"
-    end
-   end
+    filename = "#{row.sourceid}.tif"
+  end
+  data = { :source_path => source_path, :filename => filename }
+  item = PreAssembly::Remediation::Item.new(pid, data)
+  item.description = "Updating image from #{csv_in}" # added to the version description
+  item.extend(RemediationLogic) # add in our project specific methods
+  success = item.remediate
+  item.log_to_progress_file(progress_log_file)
+  item.log_to_csv(csv_out)
+  puts "#{pid} : #{success}"
 end

--- a/devel/revs_update_metadata.rb
+++ b/devel/revs_update_metadata.rb
@@ -57,5 +57,5 @@ mods_template_xml = IO.read(mods_template_file)
       item.log_to_csv(csv_out)
       puts "#{pid} : #{success}"
     end
-   end
+  end
 end

--- a/lib/pre_assembly/bundle.rb
+++ b/lib/pre_assembly/bundle.rb
@@ -254,7 +254,7 @@ module PreAssembly
             validation_errors << "Manifest does not have a column called '#{manifest_cols[:source_id]}'" if !manifest_cols[:source_id].blank? && !manifest_rows.first.keys.include?(manifest_cols[:source_id].to_s)
             validation_errors << "Manifest does not have a column called '#{manifest_cols[:label]}'" if !manifest_cols[:label].blank? && !manifest_rows.first.keys.include?(manifest_cols[:label].to_s)
             validation_errors << "You must have a column labeled 'druid' in your manifest if you want to use project_style:get_druid_from=manifest" if project_style[:get_druid_from] == :manifest && !manifest_rows.first.keys.include?('druid')
-           end
+          end
         end
       else # if we are not using a manifest, check some stuff
         validation_errors << "The glob for object_discovery must be set if object_discovery:use_manifest=false." if object_discovery[:glob].blank? # glob must be set

--- a/lib/pre_assembly/digital_object.rb
+++ b/lib/pre_assembly/digital_object.rb
@@ -201,7 +201,7 @@ module PreAssembly
     def register
       return unless project_style[:should_register]
       log "    - register(#{pid})"
-      self.dor_object      = register_in_dor(registration_params)
+      self.dor_object = register_in_dor(registration_params)
       self.reg_by_pre_assembly = true
     end
 

--- a/lib/pre_assembly/smpl_precontent_metadata.rb
+++ b/lib/pre_assembly/smpl_precontent_metadata.rb
@@ -42,7 +42,7 @@ module PreAssembly
       load_manifest # this will cache the entire manifest in @rows and @manifest
 
       puts "found #{@rows.size} rows in manifest" if @verbose
-     end
+    end
 
     def load_manifest
       # load file into @rows and then build up @manifest
@@ -61,27 +61,24 @@ module PreAssembly
         thumb = (defined?(row[:thumb]) && row[:thumb] && ['true', 'yes', 'thumb'].include?(row[:thumb].downcase)) ? true : false
 
         # set the publish/preserve/shelve if available, otherwise we'll use the defaults
-        publish = defined?(row[:publish]) ? row[:publish] || nil : nil
-        shelve = defined?(row[:shelve]) ? row[:shelve] || nil : nil
+        publish  = defined?(row[:publish])  ? row[:publish]  || nil : nil
+        shelve   = defined?(row[:shelve])   ? row[:shelve]   || nil : nil
         preserve = defined?(row[:preserve]) ? row[:preserve] || nil : nil
 
         @manifest[druid] = { :source_id => '', :files => [] } if manifest[druid].nil?
         @manifest[druid][:source_id] = row[:source_id] if (defined?(row[:source_id]) && row[:source_id])
         @manifest[druid][:files] << { :thumb => thumb, :publish => publish, :shelve => shelve, :preserve => preserve, :resource_type => resource_type, :role => role, :file_extention => file_extension, :filename => row[:filename], :label => row[:label], :sequence => row[:sequence] }
       end # loop over all rows
-     end # load_manifest
+    end # load_manifest
 
     # actually generate content metadata for a specific druid in the manifest
     def generate_cm(druid)
       pid = druid.gsub!('druid:', '')
 
       if @manifest[druid]
-
         current_directory = Dir.pwd
-
-        files = @manifest[druid][:files]
+        files     = @manifest[druid][:files]
         source_id = @manifest[druid][:source_id]
-
         current_seq = ''
         resources = {}
 
@@ -114,9 +111,9 @@ module PreAssembly
                   role = file[:role]
                   file_attributes = @file_attributes[role.downcase] || @file_attributes['default']
 
-                  publish = file[:publish] || file_attributes[:publish] || "true"
+                  publish  = file[:publish] || file_attributes[:publish] || "true"
                   preserve = file[:preserve] || file_attributes[:preserve] || "true"
-                  shelve = file[:shelve] || file_attributes[:shelve] || "true"
+                  shelve   = file[:shelve] || file_attributes[:shelve] || "true"
 
                   # look for a checksum file named the same as this file
                   checksum = nil
@@ -136,42 +133,32 @@ module PreAssembly
         FileUtils.cd(current_directory)
 
         return builder.to_xml
-
       else # no druid found in mainfest
-
         return ""
-
-      end # end if druid found in manifest
-     end # end generate_cm
+      end
+    end
 
     def get_checksum(md5_file)
       s = IO.read(md5_file)
       checksums = s.scan(/[0-9a-fA-F]{32}/)
       checksums.first ? checksums.first.strip : ""
-     end # end get_checksum
+    end
 
     def get_role(filename)
       matches = filename.scan(/_pm|_sl|_sh/)
       if matches.size == 0
-        if ['.tif', '.tiff', '.jpg', '.jpeg', '.jp2'].include? File.extname(filename).downcase
-          return 'Images'
-        elsif ['.pdf', '.txt', '.doc'].include? File.extname(filename).downcase
-          return "Transcript"
-        else
-          return ""
-         end
+        return 'Images' if ['.tif', '.tiff', '.jpg', '.jpeg', '.jp2'].include? File.extname(filename).downcase
+        return 'Transcript' if ['.pdf', '.txt', '.doc'].include? File.extname(filename).downcase
+        return ''
       else
         matches.first.sub('_', '').strip.upcase
       end
-     end # end get_role
+    end
 
     def get_druid(filename)
       matches = filename.scan(/[0-9a-zA-Z]{11}/)
-      if matches.size == 0
-        return ""
-      else
-        matches.first.strip
-      end
-     end # get_druid
-  end # Smpl class
-end # preassembly module
+      return '' if matches.size == 0
+      matches.first.strip
+    end
+  end
+end


### PR DESCRIPTION
After this PR, `rubocop --only=Layout` runs cleanly.

Changes with more substantive (manual) refactoring are in their own commits.  