### PR TITLE
Remove now-redundant RAILS_ENV=test in travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ notifications:
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
-    - RAILS_ENV=test
 
 rvm:
   - 2.3.7 # deployed


### PR DESCRIPTION
This is already provided by default:
  https://docs.travis-ci.com/user/environment-variables/#default-environment-variables