### PR TITLE
Do not double-assign RAILS_ENV

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -2,7 +2,7 @@ require 'rubygems'
 require 'bundler/setup'
 require 'logger'
 
-environment = ENV['RAILS_ENV'] ||= 'development'
+environment = ENV['RAILS_ENV'] || 'development'
 PRE_ASSEMBLY_ROOT = File.expand_path(File.dirname(__FILE__) + '/..')
 CERT_DIR = File.join(File.dirname(__FILE__), ".", "certs")
 


### PR DESCRIPTION
Effectively, boot was assigning RAILS_ENV, which is counterproductive.  Having a default value is fine, but otherwise allow `Rails.env` to take its own default.