### PR TITLE
Baseline deploy.rb should suit new systems, not lyberservices

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,5 @@
 set :application, 'pre-assembly'
-set :repo_url, 'https://github.com/sul-dlss/pre-assembly.git'
+set :repo_url, 'ssh://git@github.com/sul-dlss/pre-assembly'
 
 set :ssh_options, {
   keys: [Capistrano::OneTimeKey.temporary_ssh_private_key_path],
@@ -11,7 +11,7 @@ set :ssh_options, {
 ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }.call
 
 # Default deploy_to directory is /var/www/my_app
-set :deploy_to, '/home/lyberadmin/pre-assembly'
+set :deploy_to, '/opt/app/preassembly/pre-assembly'
 
 # Default value for :scm is :git
 # set :scm, :git
@@ -25,7 +25,7 @@ set :deploy_to, '/home/lyberadmin/pre-assembly'
 # Default value for :pty is false
 # set :pty, true
 
-# update shared_configs before restarting app 
+# update shared_configs before restarting app
 before 'deploy:restart', 'shared_configs:update'
 
 # Default value for :linked_files is []

--- a/config/deploy/old_prod.rb
+++ b/config/deploy/old_prod.rb
@@ -2,3 +2,4 @@ server 'sul-lyberservices-prod.stanford.edu', user: 'lyberadmin', roles: %w{web 
 
 Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, "production"
+set :deploy_to, '/home/lyberadmin/pre-assembly'

--- a/config/deploy/old_stage.rb
+++ b/config/deploy/old_stage.rb
@@ -2,3 +2,4 @@ server 'sul-lyberservices-test.stanford.edu', user: 'lyberadmin', roles: %w{web 
 
 Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, "test"
+set :deploy_to, '/home/lyberadmin/pre-assembly'

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,9 +1,5 @@
 server 'sul-preassembly-prod.stanford.edu', user: 'preassembly', roles: %w{web app db}
 
 Capistrano::OneTimeKey.generate_one_time_key!
-set :rails_env, "production"
-
-set :rvm_ruby_version, '2.4.4'
-set :deploy_to, '/opt/app/preassembly/pre-assembly'
+set :rails_env, 'production'
 set :linked_files, []
-set :repo_url, 'ssh://git@github.com/sul-dlss/pre-assembly'

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,9 +1,5 @@
 server 'sul-preassembly-stage.stanford.edu', user: 'preassembly', roles: %w{web app db}
 
 Capistrano::OneTimeKey.generate_one_time_key!
-set :rails_env, "production"
-
-set :rvm_ruby_version, '2.4.4'
-set :deploy_to, '/opt/app/preassembly/pre-assembly'
+set :rails_env, 'production'
 set :linked_files, []
-set :repo_url, 'ssh://git@github.com/sul-dlss/pre-assembly'


### PR DESCRIPTION
Effectively, this treats the "old" sets as the exception rather than the rule.  Note: deploying master to `lyberservices` will break things.  Use the `v3-legacy` branch for that.

Remove ignored/redundant rvm lines (we have `.ruby-version` file).

Use ssh to access github.