### PR TITLE
Removing scope: unused options and logic

### DIFF
--- a/app/lib/pre_assembly/reporting.rb
+++ b/app/lib/pre_assembly/reporting.rb
@@ -51,7 +51,6 @@ module PreAssembly
       puts "Using SMPL manifest for contentMetadata: #{File.join(@bundle_dir, @content_md_creation[:smpl_manifest])}" if using_smpl_manifest
 
       if @accession_items
-        puts "NOTE: reaccessioning with object cleanup" if @accession_items[:reaccession]
         puts "You are processing specific objects only" if @accession_items[:only]
         puts "You are processing all discovered except for specific objects" if @accession_items[:except]
       end

--- a/config/projects/TEMPLATE.yaml
+++ b/config/projects/TEMPLATE.yaml
@@ -21,8 +21,7 @@ progress_log_file: ~                        # Optional - if left as nil a progre
                                             #  NOTE: you probably won't be able to write to the thumper drives.  Beware if that's where your config file is.
                                             # In that case, you can specify /dor/preassembly, which is a good alternative and writable.
                                             # Typically based on project name.  A fully qualified path.
-                                            # Be sure to keep your progress log file somewhere useful and be aware
-                                            # if you restart pre-assembly without using the --resume switch, it will be overwritten.
+                                            # Be sure to keep your progress log file somewhere useful and be aware.
                                             # You will need the progress log for cleanup and restarting.
                                             # PLEASE DO NOT PLACE THIS IN THE LOG FOLDER OF THE PRE-ASSEMBLY CODE FOLDER ON THE SERVER.  IT MAY BE DELETED IF YOU DO THIS.
                     '/dor/preassembly/progress_foo.yaml'  # this is an example of specifying an alternate location
@@ -199,8 +198,7 @@ accession_items:   ~         # Only valid for projects that do *not* use a manif
                             # In the "only" and "except" list, you should use names that exactly match the folder names in your bundle_dir,
                             # one per line, indented under "only" or "except" and preceeded by a dash as shown in the examples below.
                             # For a normal run, set "accession_items" to ~, which will process all items.
-                            # Note that you can run a full re-accession for all items by simply leaving off the "only" and "except" lists, but
-                            # still specifying a "reaccession: true".  Do not specify both "only" and "except" unless you like flying experimental homebuilt aircraft.
+                            # Do not specify both "only" and "except" unless you like flying experimental homebuilt aircraft.
                             # Examples below:
   only:
     - 'aa111aa1111'
@@ -208,8 +206,6 @@ accession_items:   ~         # Only valid for projects that do *not* use a manif
   except:
     - 'aa111aa1111'
     - 'bb222bb2222'             # this is an example of two objects that will be ignored, put them one per line, prefixed by a space, a dash, and space, add quotes around each item
-
-  reaccession: true            # If running a re-accession, set this to true so that a cleanup will be performed, if this is a first accession attempt for these objects, set it to false or ~ or leave it off
                                # If set to true, the the files will be removed for /dor/assembly, /dor/workspace and the stacks before accessioning again.  Objects will *not* be re-registered.
 
 ####
@@ -283,49 +279,3 @@ publish_attr:  ~  # Most projects should set this to nil.  If not specified or n
     publish:             'no'
     shelve:              'no'
     preserve:            'yes'
-
-####
-# Run options.
-#
-# The typical values used in production are shown.
-####
-
-resume:           false  # If true, pre-assembly will skip objects that were
-                         # already successfully pre-assembled, as indicated by
-                         # the information in the project's progress_log_file.
-                         # Normally, this option is false in the YAML file and
-                         # is set to true on the command line with the --resume
-                         # option.
-
-limit_n:          ~      # Set to an integer if you want to process only a limited
-                         # number of the discovered objects.  Useful for testing.
-
-init_assembly_wf: true   # Whether pre-assembly should initiate the assembly
-                         # workflow for the object.  Should always be true except for testing purposes.
-						 # If set to false, the assembly robots will not operate.
-
-####
-# Other run options, mainly relevant for developers.
-#
-# The typical values used in production are shown.
-####
-throttle_time        :  ~     # The number of seconds to sleep between each object.  Can be used to throttle the speed at which
-                              #  pre-assembly runs.  If set to nil (or not set at all), no throttling is performed.
-
-new_druid_tree_format:  true # Determines druid tree directory format (defaults to "true").
-                              # Check with Lyberteam to determine appropriate style to use.  As of August 20, 2012, only old style is supported in production.
-                              # old style: /oo/000/oo/0001
-                              # new style  /oo/000/oo/0001/oo000oo0001/content and /oo/000/oo/0001/oo000oo0001/metadata
-
-compute_checksum:       true   # Whether pre-assembly should compute checksums.
-
-validate_usage:         true   # Whether pre-assembly should confirm that all expected
-                           # YAML parameters have been supplied.
-
-show_progress:          true   # Whether to print druids as they are pre-assembled on the command line.
-
-uniqify_source_ids:     false  # If true, pre-assembly attacheds a timestamp to source
-                           # IDs. Used during integration testing to avoid duplicate source ID errors that come from DOR.
-
-cleanup:                 false  # If true, pre-assembly deletes objects from DOR after
-                           # pre-assembly finishes. Relevant only during development.

--- a/config/projects/reg_example.yaml
+++ b/config/projects/reg_example.yaml
@@ -39,12 +39,3 @@ content_md_creation:
   style:       'default'
 
 publish_attr: ~
-
-resume:           false
-limit_n:          ~
-init_assembly_wf: true
-compute_checksum:   true
-validate_usage:     true
-show_progress:      true
-uniqify_source_ids: false
-cleanup:            false

--- a/spec/lib/pre_assembly/bundle_spec.rb
+++ b/spec/lib/pre_assembly/bundle_spec.rb
@@ -36,13 +36,7 @@ describe PreAssembly::Bundle do
   end
 
   describe '#load_skippables' do
-    it "does nothing if @resume is false" do
-      allow(rumsey).to receive(:resume).and_return(false)
-      expect(rumsey.load_skippables).to be_nil
-    end
-
     it "returns expected hash of skippable items" do
-      allow(rumsey).to receive(:resume).and_return(true)
       allow(rumsey).to receive(:progress_log_file).and_return('spec/test_data/input/mock_progress_log.yaml')
       expect(rumsey.skippables).to eq({})
       rumsey.load_skippables
@@ -92,12 +86,6 @@ describe PreAssembly::Bundle do
       expect(revs_context.required_files.size).to eq(1)
       revs_context.desc_md_template = nil
       expect(revs_context.required_files.size).to eq(0)
-    end
-
-    it "does nothing if @validate_usage is false" do
-      revs_context.validate_usage = false
-      expect(revs_context).not_to receive(:required_user_params)
-      revs_context.validate_usage
     end
 
     it "does not raise an exception if requirements are satisfied" do
@@ -156,6 +144,7 @@ describe PreAssembly::Bundle do
     end
 
     it "finds the correct N objects, stageables, and files" do
+      allow_any_instance_of(PreAssembly::BundleContext).to receive(:validate_usage) # req'd for :sohp_files_and_folders
       tests.each do |proj, n_dobj, n_stag, n_file|
         b = described_class.new(context_from_proj(proj))
         b.discover_objects
@@ -180,14 +169,6 @@ describe PreAssembly::Bundle do
   end
 
   describe "object discovery: containers" do
-    it "@pruned_containers should limit N of discovered objects if @limit_n is defined" do
-      items = [0, 11, 22, 33, 44, 55, 66, 77]
-      revs_context.limit_n = nil
-      expect(revs.pruned_containers(items)).to eq(items)
-      revs_context.limit_n = 3
-      expect(revs.pruned_containers(items)).to eq(items[0..2])
-    end
-
     it "object_containers() should dispatch the correct method" do
       exp = {
         :discover_containers_via_manifest => true,
@@ -395,7 +376,6 @@ describe PreAssembly::Bundle do
       it "returns provider checksum when it is available" do
         fake_md5 = 'a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1'
         revs.provider_checksums = { file_path => fake_md5 }
-        expect(revs).not_to receive(:compute_checksum)
         expect(revs.retrieve_checksum(file)).to eq(fake_md5)
       end
     end
@@ -403,19 +383,8 @@ describe PreAssembly::Bundle do
     describe '#retrieve_checksum' do
       it "computes checksum when checksum is not available" do
         revs.provider_checksums = {}
-        expect(revs).to receive(:compute_checksum)
+        expect(file).to receive(:md5)
         revs.retrieve_checksum(file)
-      end
-    end
-
-    describe '#compute_checksum' do
-      it "returns nil if @compute_checksum is false" do
-        allow(revs).to receive(:compute_checksum?).and_return(false)
-        expect(revs.compute_checksum(file)).to be_nil
-      end
-
-      it "returns an md5 checksum" do
-        expect(revs.compute_checksum(file)).to be_a(String).and match(md5_regex)
       end
     end
   end
@@ -565,13 +534,7 @@ describe PreAssembly::Bundle do
   describe "#delete_digital_objects" do
     before { revs.digital_objects = [] }
 
-    it "does nothing if cleanup == false" do
-      allow(revs).to receive(:cleanup?).and_return(false)
-      expect(revs.digital_objects).not_to receive :each
-      revs.delete_digital_objects
-    end
-
-    it "does something if cleanup == true" do
+    it 'iterates over digital_objects' do
       expect(revs.digital_objects).to receive :each
       revs.delete_digital_objects
     end
@@ -587,14 +550,6 @@ describe PreAssembly::Bundle do
 
     it "#relative_path returns expected value" do
       expect(revs.relative_path(revs.bundle_dir, full)).to eq(relative)
-    end
-
-    it "#relative_path raises error if given bogus arguments" do
-      path = "foo/bar/fubb.txt"
-      exp_msg = /^Bad args to relative_path/
-      expect { revs.relative_path('',   path) }.to raise_error(ArgumentError, exp_msg)
-      expect { revs.relative_path(path, path) }.to raise_error(ArgumentError, exp_msg)
-      expect { revs.relative_path('xx', path) }.to raise_error(ArgumentError, exp_msg)
     end
 
     it "#get_base_dir returns expected value" do
@@ -642,16 +597,6 @@ describe PreAssembly::Bundle do
   end
 
   describe "misc utilities" do
-    it '#source_id_suffix is empty if not making unique source IDs' do
-      revs_context.uniqify_source_ids = false
-      expect(revs.source_id_suffix).to eq('')
-    end
-
-    it '#source_id_suffix looks like an integer if making unique source IDs' do
-      revs_context.uniqify_source_ids = true
-      expect(revs.source_id_suffix).to match(/^_\d+$/)
-    end
-
     it '#symbolize_keys handles various data structures correctly' do
       tests = [
         [{}, {}],

--- a/spec/lib/pre_assembly/digital_object_spec.rb
+++ b/spec/lib/pre_assembly/digital_object_spec.rb
@@ -12,7 +12,6 @@ describe PreAssembly::DigitalObject do
       :project_style => {},
       :content_md_creation => {},
       :bundle_dir => 'spec/test_data/bundle_input_g',
-      :new_druid_tree_format => true,
       :staging_style => 'copy'
     }
   }
@@ -206,21 +205,12 @@ describe PreAssembly::DigitalObject do
     end
   end
 
-  describe "check the druid tree directories and content and metadata locations using both the new style and the old style" do
-    it "has the correct druid tree folders using the new style" do
+  describe 'druid tree' do
+    it 'has the correct folders (using the contemporary style)' do
       dobj.druid = druid
-      dobj.new_druid_tree_format = true
       expect(dobj.druid_tree_dir).to eq('gn/330/dv/6119/gn330dv6119')
       expect(dobj.metadata_dir).to eq('gn/330/dv/6119/gn330dv6119/metadata')
       expect(dobj.content_dir).to eq('gn/330/dv/6119/gn330dv6119/content')
-    end
-
-    it "has the correct druid tree folders using the old style" do
-      dobj.druid = druid
-      dobj.new_druid_tree_format = false
-      expect(dobj.druid_tree_dir).to eq('gn/330/dv/6119')
-      expect(dobj.metadata_dir).to eq('gn/330/dv/6119')
-      expect(dobj.content_dir).to eq('gn/330/dv/6119')
     end
   end
 
@@ -581,19 +571,13 @@ describe PreAssembly::DigitalObject do
     end
   end
 
-  describe "initiate assembly workflow" do
-    it '#initialize_assembly_workflow should do nothing if init_assembly_wf is false' do
-      dobj.init_assembly_wf = false
-      expect(dobj).not_to receive :assembly_workflow_url
-      dobj.initialize_assembly_workflow
-    end
-
-    it '#assembly_workflow_url should return expected value' do
+  describe '#assembly_workflow_url' do
+    it 'returns expected value' do
       dobj.pid = pid
       expect(dobj.assembly_workflow_url).to match(/^http.+assemblyWF$/).and include(pid)
     end
 
-    it '#assembly_workflow_url should add the druid: prefix to the pid if it is missing, like it might be in the manifest' do
+    it 'adds the druid: prefix to the pid if it is missing' do
       dobj.pid = pid.gsub('druid:', '')
       expect(dobj.assembly_workflow_url).to match(/^http.+assemblyWF$/).and include(pid)
     end

--- a/spec/test_data/project_config_files/folder_manifest.yaml
+++ b/spec/test_data/project_config_files/folder_manifest.yaml
@@ -25,9 +25,6 @@ publish_attr:
   shelve:             ~
   preserve:           ~
 
-compute_checksum:     false
-init_assembly_wf:     false
-
 content_md_creation:
   style:              'default'
 
@@ -47,10 +44,3 @@ manifest_cols:
   label:              'label'
 
 content_exclusion:    ~
-
-validate_usage:       true
-show_progress:        true
-limit_n:              5
-uniqify_source_ids:   true
-cleanup:              true
-resume:               false

--- a/spec/test_data/project_config_files/local_dev_folder_manifest_noreg.yaml
+++ b/spec/test_data/project_config_files/local_dev_folder_manifest_noreg.yaml
@@ -31,9 +31,6 @@ publish_attr:
     shelve:    ~
     preserve:  ~
 
-compute_checksum:     false
-init_assembly_wf:     false
-
 content_md_creation:
   style:              'joined'
 
@@ -53,10 +50,3 @@ manifest_cols:
   label:              'label'
 
 content_exclusion:    ~
-
-validate_usage:       true
-show_progress:        true
-limit_n:              5
-uniqify_source_ids:   true
-cleanup:              true
-resume:               false

--- a/spec/test_data/project_config_files/local_dev_gould.yaml
+++ b/spec/test_data/project_config_files/local_dev_gould.yaml
@@ -24,9 +24,6 @@ publish_attr:
   shelve:             ~
   preserve:           ~
 
-compute_checksum:     true
-init_assembly_wf:     false
-
 content_md_creation:
   style:              'default'
 
@@ -46,11 +43,3 @@ manifest_cols:
   label:              ~
 
 content_exclusion:    ~
-
-new_druid_tree_format: true
-validate_usage:       true
-show_progress:        true
-limit_n:              10
-uniqify_source_ids:   true
-cleanup:              true
-resume:               false

--- a/spec/test_data/project_config_files/local_dev_reid_dennis.yaml
+++ b/spec/test_data/project_config_files/local_dev_reid_dennis.yaml
@@ -24,9 +24,6 @@ publish_attr:
   shelve:             ~
   preserve:           ~
 
-compute_checksum:     true
-init_assembly_wf:     false
-
 content_md_creation:
   style:              'default'
 
@@ -46,11 +43,3 @@ manifest_cols:
   label:              'Title1'
 
 content_exclusion:    ~
-
-new_druid_tree_format: true
-validate_usage:       true
-show_progress:        true
-limit_n:              5
-uniqify_source_ids:   true
-cleanup:              true
-resume:               false

--- a/spec/test_data/project_config_files/local_dev_sohp.yaml
+++ b/spec/test_data/project_config_files/local_dev_sohp.yaml
@@ -23,9 +23,6 @@ publish_attr:
   shelve:             ~
   preserve:           ~
 
-compute_checksum:     false
-init_assembly_wf:     false
-
 content_md_creation:
   style:              'smpl'
   smpl_manifest:    'smpl_manifest.csv'  # The manifest file for use in SMPL projects.  Typically set to ~ unless style='smpl'
@@ -47,11 +44,3 @@ manifest_cols:
   label:              ~
 
 content_exclusion:    ~
-
-new_druid_tree_format: true
-validate_usage:       false
-show_progress:        true
-limit_n:              10
-uniqify_source_ids:   true
-cleanup:              true
-resume:               false

--- a/spec/test_data/project_config_files/local_dev_sohp_discovery_manifest.yaml
+++ b/spec/test_data/project_config_files/local_dev_sohp_discovery_manifest.yaml
@@ -23,9 +23,6 @@ publish_attr:
   shelve:             ~
   preserve:           ~
 
-compute_checksum:     false
-init_assembly_wf:     false
-
 content_md_creation:
   style:              'smpl'
   smpl_manifest:      'smpl_manifest.csv'  # The manifest file for use in SMPL projects.  Typically set to ~ unless style='smpl'
@@ -47,11 +44,3 @@ manifest_cols:
   label:              'label'
 
 content_exclusion:    ~
-
-new_druid_tree_format: true
-validate_usage:       false
-show_progress:        true
-limit_n:              10
-uniqify_source_ids:   true
-cleanup:              true
-resume:               false

--- a/spec/test_data/project_config_files/local_dev_sohp_via_symlink.yaml
+++ b/spec/test_data/project_config_files/local_dev_sohp_via_symlink.yaml
@@ -23,9 +23,6 @@ publish_attr:
   shelve:             ~
   preserve:           ~
 
-compute_checksum:     false
-init_assembly_wf:     false
-
 content_md_creation:
   style:              'smpl'
 
@@ -46,11 +43,3 @@ manifest_cols:
   label:              ~
 
 content_exclusion:    ~
-
-new_druid_tree_format: true
-validate_usage:       false
-show_progress:        true
-limit_n:              10
-uniqify_source_ids:   true
-cleanup:              true
-resume:               false

--- a/spec/test_data/project_config_files/proj_revs.yaml
+++ b/spec/test_data/project_config_files/proj_revs.yaml
@@ -19,9 +19,6 @@ publish_attr:
   shelve:             'no'
   preserve:           'yes'
 
-compute_checksum:     true
-init_assembly_wf:     false
-
 content_md_creation:
   style:              'default'
 
@@ -41,11 +38,3 @@ manifest_cols:
   label:              'label'
 
 content_exclusion:    ~
-
-new_druid_tree_format: true
-validate_usage:       true
-show_progress:        true
-limit_n:              10
-uniqify_source_ids:   true
-cleanup:              true
-resume:               false

--- a/spec/test_data/project_config_files/proj_revs_bad_manifest.yaml
+++ b/spec/test_data/project_config_files/proj_revs_bad_manifest.yaml
@@ -26,9 +26,6 @@ publish_attr:
   shelve:             'no'
   preserve:           'yes'
 
-compute_checksum:     true
-init_assembly_wf:     false
-
 content_md_creation:
   style:              'default'
 
@@ -48,11 +45,3 @@ manifest_cols:
   label:              'label'
 
 content_exclusion:    ~
-
-new_druid_tree_format: true
-validate_usage:       true
-show_progress:        true
-limit_n:              10
-uniqify_source_ids:   true
-cleanup:              true
-resume:               false

--- a/spec/test_data/project_config_files/proj_revs_no_cm.yaml
+++ b/spec/test_data/project_config_files/proj_revs_no_cm.yaml
@@ -24,9 +24,6 @@ publish_attr:
   shelve:             'no'
   preserve:           'yes'
 
-compute_checksum:     true
-init_assembly_wf:     false
-
 content_md_creation:
   style:              'none'
 
@@ -46,11 +43,3 @@ manifest_cols:
   label:              'label'
 
 content_exclusion:    ~
-
-validate_usage:       true
-show_progress:        true
-limit_n:              10
-uniqify_source_ids:   true
-cleanup:              true
-resume:               false
-new_druid_tree_format: false

--- a/spec/test_data/project_config_files/proj_revs_old_druid.yaml
+++ b/spec/test_data/project_config_files/proj_revs_old_druid.yaml
@@ -24,9 +24,6 @@ publish_attr:
   shelve:             'no'
   preserve:           'yes'
 
-compute_checksum:     true
-init_assembly_wf:     false
-
 content_md_creation:
   style:              'default'
 
@@ -46,11 +43,3 @@ manifest_cols:
   label:              'label'
 
 content_exclusion:    ~
-
-validate_usage:       true
-show_progress:        true
-limit_n:              10
-uniqify_source_ids:   true
-cleanup:              true
-resume:               false
-new_druid_tree_format: false

--- a/spec/test_data/project_config_files/proj_rumsey.yaml
+++ b/spec/test_data/project_config_files/proj_rumsey.yaml
@@ -24,9 +24,6 @@ publish_attr:
   shelve:             ~
   preserve:           ~
 
-compute_checksum:     true
-init_assembly_wf:     false
-
 content_md_creation:
   style:              'default'
 
@@ -46,11 +43,3 @@ manifest_cols:
   label:              ~
 
 content_exclusion:    '(?ix) descMetadata\.xml $'
-
-new_druid_tree_format: true
-validate_usage:       true
-show_progress:        true
-limit_n:              10
-uniqify_source_ids:   true
-cleanup:              true
-resume:               false

--- a/spec/test_data/project_config_files/proj_sohp2.yaml
+++ b/spec/test_data/project_config_files/proj_sohp2.yaml
@@ -22,9 +22,6 @@ publish_attr:
   shelve:             ~
   preserve:           ~
 
-compute_checksum:     false
-init_assembly_wf:     false
-
 content_md_creation:
   style:              'smpl'
 
@@ -45,10 +42,3 @@ manifest_cols:
   label:              ~
 
 content_exclusion:    ~
-
-validate_usage:       true
-show_progress:        true
-limit_n:              10
-uniqify_source_ids:   true
-cleanup:              true
-resume:               false

--- a/spec/test_data/project_config_files/proj_sohp3.yaml
+++ b/spec/test_data/project_config_files/proj_sohp3.yaml
@@ -10,7 +10,6 @@ validate_files:       true
 accession_items:
  only:
    - 'aa111aa1111'
- reaccession: true
 
 manifest:             ~
 checksums_file:       ~
@@ -25,9 +24,6 @@ publish_attr:
   publish:            ~
   shelve:             ~
   preserve:           ~
-
-compute_checksum:     false
-init_assembly_wf:     false
 
 content_md_creation:
   style:              'smpl'
@@ -49,10 +45,3 @@ manifest_cols:
   label:              ~
 
 content_exclusion:    ~
-
-validate_usage:       false
-show_progress:        true
-limit_n:              10
-uniqify_source_ids:   true
-cleanup:              true
-resume:               false

--- a/spec/test_data/project_config_files/proj_sohp4.yaml
+++ b/spec/test_data/project_config_files/proj_sohp4.yaml
@@ -26,9 +26,6 @@ publish_attr:
   shelve:             ~
   preserve:           ~
 
-compute_checksum:     false
-init_assembly_wf:     false
-
 content_md_creation:
   style:              'smpl'
 
@@ -49,10 +46,3 @@ manifest_cols:
   label:              ~
 
 content_exclusion:    ~
-
-validate_usage:       false
-show_progress:        true
-limit_n:              10
-uniqify_source_ids:   true
-cleanup:              true
-resume:               false

--- a/spec/test_data/project_config_files/sohp_files_and_folders.yaml
+++ b/spec/test_data/project_config_files/sohp_files_and_folders.yaml
@@ -22,9 +22,6 @@ publish_attr:
   shelve:             ~
   preserve:           ~
 
-compute_checksum:     false
-init_assembly_wf:     false
-
 content_md_creation:
   style:              'smpl'
 
@@ -45,10 +42,3 @@ manifest_cols:
   label:              ~
 
 content_exclusion:    ~
-
-validate_usage:       false
-show_progress:        true
-limit_n:              10
-uniqify_source_ids:   true
-cleanup:              true
-resume:               false

--- a/spec/test_data/project_config_files/sohp_files_only.yaml
+++ b/spec/test_data/project_config_files/sohp_files_only.yaml
@@ -22,9 +22,6 @@ publish_attr:
   shelve:             ~
   preserve:           ~
 
-compute_checksum:     false
-init_assembly_wf:     false
-
 content_md_creation:
   style:              'smpl'
 
@@ -45,10 +42,3 @@ manifest_cols:
   label:              ~
 
 content_exclusion:    ~
-
-validate_usage:       false
-show_progress:        true
-limit_n:              10
-uniqify_source_ids:   true
-cleanup:              true
-resume:               false


### PR DESCRIPTION
The following options are removed because their values can be assumed:
- `cleanup: false`
- `compute_checksum: true`
- `new_druid_tree_format: true`
- `init_assembly_wf: true`
- `limit_n` (no limit)
- `reaccession: false`
- `resume: true`
- `show_progress: false` (irrelevant)
- `throttle_time: 0`
- `uniqify_source_ids: false`
- `validate_usage: true`

Update YAML fixtures.  Resolve setup failure of one test object.

Only PART of #133, which is amazing given that so much logic is already removed here, especially many "developer only" features. 