### PR TITLE
need to explicitly require dor-services in cli_environment configs for rails console to work

### DIFF
--- a/config/cli_environments/development.rb
+++ b/config/cli_environments/development.rb
@@ -1,3 +1,5 @@
+require 'dor-services'
+
 Dor::Config.configure do
   dor do
     service_root 'https://example.com/dor/v1'

--- a/config/cli_environments/test.rb
+++ b/config/cli_environments/test.rb
@@ -1,4 +1,5 @@
 require 'dor-services'
+
 Dor::Config.configure do
   dor do
     service_root 'https://example.com/dor/v1'


### PR DESCRIPTION
this was working for me when i pulled the branch used in #130, but then it wasn't w/o the modifications mentioned once it got merged to master.  🤷‍♂️ 

but works again with this change.