### PR TITLE
add more context to honeybadger notification problem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,20 +1,18 @@
 source 'https://rubygems.org'
 
-gem 'nokogiri'
-gem 'rake'
-gem 'retries'
-gem 'roo' # for processing spreadsheets
-gem 'ruby-prof'
+gem 'config'
 gem 'honeybadger', '~> 3.1'
-
+gem 'nokogiri'
 gem 'rails', '~> 5.2', '>= 5.2.1'
-gem 'sqlite3'
-gem 'turbolinks'
-
+gem 'rake'
 gem 'resque', '~> 1.27' # needs to match redis on VM
 gem 'resque-lock'
 gem 'resque-pool'
-gem 'config'
+gem 'retries'
+gem 'roo' # for processing spreadsheets
+gem 'ruby-prof'
+gem 'sqlite3'
+gem 'turbolinks'
 
 # Stanford gems
 gem 'assembly-image'
@@ -24,8 +22,8 @@ gem 'dor-services', '~> 5.29'
 gem 'modsulator'
 
 group :test do
-  gem 'equivalent-xml'
   gem 'coveralls', require: false
+  gem 'equivalent-xml'
   # gem 'solr_wrapper' # for running integration structure locally
   # gem 'jettywrapper' # for running integration structure locally
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -42,11 +42,22 @@ set :linked_dirs, %w{log config/certs config/cli_environments tmp vendor/bundle}
 
 set :honeybadger_env, fetch(:stage)
 
-
 Rake::Task["honeybadger:deploy"].clear
 namespace :honeybadger do
   desc 'Notify Honeybadger of the deployment.'
   task :deploy => [:'deploy:set_current_revision'] do
-    puts "Temoporarily disabling honeybadger deploy notification, until we fix it."
+    puts "Temporarily disabling honeybadger deploy notification due to bug with Haml::ActionView. See issue https://github.com/sul-dlss/pre-assembly/issues/98"
+    #  from capistrano messages, we get:
+    #  "NameError: uninitialized constant Haml::ActionView
+    # 01     /opt/app/preassembly/pre-assembly/shared/bundle/ruby/2.4.0/gems/haml-4.0.7/lib/haml/helpers/safe_erubis_template.rb:3:in `<module:Haml>"
+    #
+    # see https://github.com/haml/haml/issues/974
+    #
+    # from bundler, can't update to haml 5.0.4:
+    # dor-services (~> 5.29) was resolved to 5.29.0, which depends on
+    #   active-fedora (< 9.a, >= 6.0) was resolved to 8.5.0, which depends on
+    #     rdf-rdfxml (~> 1.1) was resolved to 1.99.0, which depends on
+    #       rdf-rdfa (~> 1.99) was resolved to 1.99.1, which depends on
+    #         haml (~> 4.0)
   end
 end


### PR DESCRIPTION
Connects to #98  (which I didn't realize until I wasted time on it ...)

I tried to fix it, but gave up.  Hopefully there is enough context now to help the next person.  I worry this will bite us when we try to actually execute code ... but we'll cross that bridge later.

Here's what I put in the code:

```ruby
    #  from capistrano messages, we get:
    #  "NameError: uninitialized constant Haml::ActionView
    # 01     /opt/app/preassembly/pre-assembly/shared/bundle/ruby/2.4.0/gems/haml-4.0.7/lib/haml/helpers/safe_erubis_template.rb:3:in `<module:Haml>"
    #
    # see https://github.com/haml/haml/issues/974
    #
    # from bundler, can't update to haml 5.0.4:
    # dor-services (~> 5.29) was resolved to 5.29.0, which depends on
    #   active-fedora (< 9.a, >= 6.0) was resolved to 8.5.0, which depends on
    #     rdf-rdfxml (~> 1.1) was resolved to 1.99.0, which depends on
    #       rdf-rdfa (~> 1.99) was resolved to 1.99.1, which depends on
    #         haml (~> 4.0)
```