### PR TITLE
Content tag override logic

### DIFF
--- a/lib/pre_assembly/digital_object.rb
+++ b/lib/pre_assembly/digital_object.rb
@@ -94,9 +94,11 @@ module PreAssembly
 
     def content_md_creation_style
       # set this object's content_md_creation_style
-      if (@project_style[:should_register]) || (!@project_style[:content_tag_override]) || (@project_style[:content_tag_override] && content_type_tag.blank?) # if this object needs to be registered or has no content type tag for a registered object, use the default set in the YAML file
+      # if this object needs to be registered, we will set the content type specified in YAML config no matter what
+      # if this object does NOT to be registered (:should_register == false) and the user has NOT asked for overrides (content_tag_override == false), we will also just set the content type specified in YAML config
+      if @project_style[:should_register] || !@project_style[:content_tag_override]
         default_content_md_creation_style
-      else # if the object is already registered and there is a content type tag and we allow overrides, use it if we know what it means (else use the default)
+      else # this means the object is pre-registered and the user has asked us to set the content type from the object if possible (if object type can't be determined, use the content type specified in YAML config)
         CONTENT_TYPE_TAG_MAPPING[content_type_tag] || default_content_md_creation_style
       end
     end

--- a/spec/digital_object_spec.rb
+++ b/spec/digital_object_spec.rb
@@ -617,14 +617,20 @@ describe PreAssembly::DigitalObject do
       expect(ofiles.map { |f| f.relative_path }).to eq(files[m .. -1].sort)
     end
 
-    it "should generate the expected xml text when overriding is explicitly not allowed or not specified" do
-     [false, nil].each do |content_tag_override|
-       @dobj.project_style[:content_tag_override] = content_tag_override # nil or false prevents override of content structure
-       expect(@dobj.content_type_tag).to eq('File') # object is listed as type file
-       expect(@dobj.project_style[:content_structure]).to eq('simple_image') # YAML is configured for image
-       expect(@dobj.content_md_creation_style).to eq(:simple_image) # so we override md creation style to the value set in the YAML file
-       expect(noko_doc(@dobj.content_md_xml)).to be_equivalent_to @exp_xml # should be image content metadata
-      end
+    it "should generate the expected xml text when overriding is explicitly not allowed" do
+      @dobj.project_style[:content_tag_override] = false # false prevents override of content structure
+      expect(@dobj.content_type_tag).to eq('File') # object is listed as type file
+      expect(@dobj.project_style[:content_structure]).to eq('simple_image') # YAML is configured for image
+      expect(@dobj.content_md_creation_style).to eq(:simple_image) # so we override md creation style to the value set in the YAML file
+      expect(noko_doc(@dobj.content_md_xml)).to be_equivalent_to @exp_xml # should be image content metadata
+    end
+
+    it "should generate the expected xml text when overriding is not specified" do
+      @dobj.project_style[:content_tag_override] = nil # nil prevents override of content structure
+      expect(@dobj.content_type_tag).to eq('File') # object is listed as type file
+      expect(@dobj.project_style[:content_structure]).to eq('simple_image') # YAML is configured for image
+      expect(@dobj.content_md_creation_style).to eq(:simple_image) # so we override md creation style to the value set in the YAML file
+      expect(noko_doc(@dobj.content_md_xml)).to be_equivalent_to @exp_xml # should be image content metadata
     end
 
   end

--- a/spec/digital_object_spec.rb
+++ b/spec/digital_object_spec.rb
@@ -550,7 +550,7 @@ describe PreAssembly::DigitalObject do
 
     it "should generate the expected xml text" do
       expect(@dobj.content_md_creation_style).to eq(:file)
-      expect(noko_doc(@dobj.content_md_xml)).to be_equivalent_to @exp_xml
+      expect(noko_doc(@dobj.content_md_xml)).to be_equivalent_to @exp_xml  # should be file content metadata
     end
   end
 
@@ -617,16 +617,14 @@ describe PreAssembly::DigitalObject do
       expect(ofiles.map { |f| f.relative_path }).to eq(files[m .. -1].sort)
     end
 
-    it "should generate the expected xml text when overriding is explicitly not allowed" do
-      @dobj.project_style[:content_tag_override]=false       # this prevents override of content structure
-      expect(@dobj.content_md_creation_style).to eq(:simple_image)
-      expect(noko_doc(@dobj.content_md_xml)).to be_equivalent_to @exp_xml
-    end
-
-    it "should generate the expected xml text when overriding is not specified" do
-      @dobj.project_style[:content_tag_override]=nil       # this prevents override of content structure
-      expect(@dobj.content_md_creation_style).to eq(:simple_image)
-      expect(noko_doc(@dobj.content_md_xml)).to be_equivalent_to @exp_xml
+    it "should generate the expected xml text when overriding is explicitly not allowed or not specified" do
+     [false, nil].each do |content_tag_override|
+       @dobj.project_style[:content_tag_override] = content_tag_override # nil or false prevents override of content structure
+       expect(@dobj.content_type_tag).to eq('File') # object is listed as type file
+       expect(@dobj.project_style[:content_structure]).to eq('simple_image') # YAML is configured for image
+       expect(@dobj.content_md_creation_style).to eq(:simple_image) # so we override md creation style to the value set in the YAML file
+       expect(noko_doc(@dobj.content_md_xml)).to be_equivalent_to @exp_xml # should be image content metadata
+      end
     end
 
   end


### PR DESCRIPTION
Simplify the logic around the content tag override method for the v3-legacy branch (already done in master)