### PR TITLE
validate_files one-character fix

### DIFF
--- a/app/lib/pre_assembly/bundle.rb
+++ b/app/lib/pre_assembly/bundle.rb
@@ -575,7 +575,7 @@ module PreAssembly
         begin
           # Try to pre_assemble the digital object.
           load_checksums(dobj)
-          validate_files(dobj) if validate_files
+          validate_files(dobj) if @validate_files
           dobj.pre_assemble
           # Indicate that we finished.
           dobj.pre_assem_finished = true


### PR DESCRIPTION
This is an instance of the problem described in a FIXME earlier in the file, namely using the same name for a method and an attribute.