### PR TITLE
Pa console runnable

### DIFF
--- a/app/lib/pre_assembly/bundle.rb
+++ b/app/lib/pre_assembly/bundle.rb
@@ -290,7 +290,6 @@ module PreAssembly
       discover_objects
       process_manifest
       process_digital_objects
-      delete_digital_objects
       puts "#{Time.now}: Pre-assembly completed for #{project_name}"
       processed_pids
     end
@@ -633,12 +632,6 @@ module PreAssembly
         :pre_assem_finished   => dobj.pre_assem_finished,
         :timestamp            => Time.now.strftime('%Y-%m-%d %H:%I:%S')
       }
-    end
-
-    def delete_digital_objects
-      # During development, delete objects that we register.
-      log "delete_digital_objects()"
-      digital_objects.each(&:unregister)
     end
 
     ####

--- a/app/lib/pre_assembly/bundle.rb
+++ b/app/lib/pre_assembly/bundle.rb
@@ -583,7 +583,7 @@ module PreAssembly
           dobj.pre_assemble
           # Indicate that we finished.
           dobj.pre_assem_finished = true
-          log_and_show "Completed #{dobj.druid.druid}"
+          log_and_show "Completed #{dobj.druid}"
         rescue Exception => e
           # For now, just re-raise any exceptions.
           #

--- a/app/lib/pre_assembly/digital_object.rb
+++ b/app/lib/pre_assembly/digital_object.rb
@@ -136,6 +136,7 @@ module PreAssembly
       manifest_row[:druid]
     end
 
+    # TODO: remove this method:  given that we expect our druids to already be there, we should never call this method
     def get_pid_from_suri
       with_retries(max_tries: Dor::Config.dor.num_attempts, rescue: Exception, handler: retry_handler('GET_PID_FROM_SURI', method(:log))) do
         result = Dor::SuriService.mint_id
@@ -306,6 +307,7 @@ module PreAssembly
     # Call web service to add assemblyWF to the object in DOR.
     def initialize_assembly_workflow
       log "    - initialize_assembly_workflow()"
+      # TODO: use dor-workflow-service gem for this (see #194)
       with_retries(max_tries: Dor::Config.dor.num_attempts, rescue: Exception, handler: retry_handler('INITIALIZE_ASSEMBLY_WORKFLOW', method(:log))) do
         result = RestClient.post(assembly_workflow_url, {})
         raise PreAssembly::UnknownError unless result && [200, 201, 202, 204].include?(result.code)

--- a/config/initializers/dor_services.rb
+++ b/config/initializers/dor_services.rb
@@ -1,0 +1,10 @@
+require 'dor-services'
+
+Dor::Config.dor_services.url ||= Dor::Config.dor.service_root
+
+# TODO: use dor-workflow-service gem (see #194)
+# require 'dor-workflow-service'
+# Dor::WorkflowService.configure(
+#   Settings.workflow_services_url,
+#   :dor_services_url => Dor::Config.dor_services.url.gsub('/v1', '')
+# )

--- a/config/initializers/dor_workflow_service.rb
+++ b/config/initializers/dor_workflow_service.rb
@@ -1,9 +1,0 @@
-require 'dor-services'
-require 'dor-workflow-service'
-
-Dor::Config.dor_services.url ||= Dor::Config.dor.service_root
-Dor::WorkflowService.configure(
-  Settings.workflow_services_url,
-  :dor_services_url => Dor::Config.dor_services.url.gsub('/v1', '')
-)
-

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,1 +1,2 @@
-workflow_services_url: 'https://workflows.example.org/workflow/'
+# TODO: use dor-workflow-service gem (see #194)
+# workflow_services_url: 'https://workflows.example.org/workflow/'

--- a/spec/lib/pre_assembly/bundle_spec.rb
+++ b/spec/lib/pre_assembly/bundle_spec.rb
@@ -30,12 +30,10 @@ RSpec.describe PreAssembly::Bundle do
       allow(RestClient).to receive(:post).with(a_string_matching(exp_workflow_svc_url), {}).and_return(instance_double(RestClient::Response, code: 200))
     end
     it 'runs cleanly using smoke_test.yaml for options' do
-      yaml_file = 'spec/test_data/project_config_files/smoke_test.yaml'
-      params = YAML.load_file(yaml_file)
-      File.delete(params['progress_log_file']) if File.exist?(params['progress_log_file'])
+      bc = context_from_proj('smoke_test')
+      File.delete(bc.user_params[:progress_log_file]) if File.exist?(bc.user_params[:progress_log_file])
       pids = []
       expect {
-        bc = PreAssembly::BundleContext.new params
         b = PreAssembly::Bundle.new bc
         pids = b.run_pre_assembly
       }.not_to raise_error

--- a/spec/lib/pre_assembly/bundle_spec.rb
+++ b/spec/lib/pre_assembly/bundle_spec.rb
@@ -24,6 +24,25 @@ RSpec.describe PreAssembly::Bundle do
     end
   end
 
+  describe '#run_pre_assembly' do
+    let(:exp_workflow_svc_url) { Regexp.new("^#{Dor::Config.dor_services.url}/objects/.*/apo_workflows/assemblyWF$") }
+    before do
+      allow(RestClient).to receive(:post).with(a_string_matching(exp_workflow_svc_url), {}).and_return(instance_double(RestClient::Response, code: 200))
+    end
+    it 'runs cleanly using smoke_test.yaml for options' do
+      yaml_file = 'spec/test_data/project_config_files/smoke_test.yaml'
+      params = YAML.load_file(yaml_file)
+      File.delete(params['progress_log_file']) if File.exist?(params['progress_log_file'])
+      pids = []
+      expect {
+        bc = PreAssembly::BundleContext.new params
+        b = PreAssembly::Bundle.new bc
+        pids = b.run_pre_assembly
+      }.not_to raise_error
+      expect(pids).to eq ["druid:jy812bp9403", "druid:tz250tk7584", "druid:gn330dv6119"]
+    end
+  end
+
   describe '#load_skippables' do
     it "returns expected hash of skippable items" do
       allow(rumsey).to receive(:progress_log_file).and_return('spec/test_data/input/mock_progress_log.yaml')

--- a/spec/lib/pre_assembly/bundle_spec.rb
+++ b/spec/lib/pre_assembly/bundle_spec.rb
@@ -518,15 +518,6 @@ RSpec.describe PreAssembly::Bundle do
     end
   end
 
-  describe "#delete_digital_objects" do
-    before { revs.digital_objects = [] }
-
-    it 'iterates over digital_objects' do
-      expect(revs.digital_objects).to receive :each
-      revs.delete_digital_objects
-    end
-  end
-
   describe "file and directory utilities" do
     let(:relative) { 'abc/def.jpg' }
     let(:full) { revs.path_in_bundle(relative) }

--- a/spec/lib/pre_assembly/bundle_spec.rb
+++ b/spec/lib/pre_assembly/bundle_spec.rb
@@ -30,7 +30,9 @@ RSpec.describe PreAssembly::Bundle do
       allow(RestClient).to receive(:post).with(a_string_matching(exp_workflow_svc_url), {}).and_return(instance_double(RestClient::Response, code: 200))
     end
     it 'runs cleanly using smoke_test.yaml for options' do
+      # TODO: as we switch to using models (#172, #175, etc) this test should also switch
       bc = context_from_proj('smoke_test')
+      # need to delete progress log to ensure this test doesn't skip objects already run
       File.delete(bc.user_params[:progress_log_file]) if File.exist?(bc.user_params[:progress_log_file])
       pids = []
       expect {

--- a/spec/support/bundle_setup.rb
+++ b/spec/support/bundle_setup.rb
@@ -8,6 +8,5 @@ def context_from_proj(proj)
   filename = "spec/test_data/project_config_files/#{proj}.yaml"
   ps = YAML.load(File.read(filename))
   ps['config_filename'] = filename
-  ps['show_progress'] = false
   PreAssembly::BundleContext.new(ps)
 end

--- a/spec/test_data/project_config_files/smoke_test.yaml
+++ b/spec/test_data/project_config_files/smoke_test.yaml
@@ -18,8 +18,6 @@ desc_md_template:     'mods_template.xml'
 
 progress_log_file:    'log/progress_folder_smoke_test.yaml'
 project_name:         'SmokeTest'
-apo_druid_id:         ~
-set_druid_id:         ~
 
 publish_attr:
   'image/jp2':

--- a/spec/test_data/project_config_files/smoke_test.yaml
+++ b/spec/test_data/project_config_files/smoke_test.yaml
@@ -1,0 +1,52 @@
+# An example of a project which has already registered objects, but for which
+# you want to provide a manifest to provide descriptive metadata and a MODS template.
+# Object discovery also occurs via the manifest.
+
+project_style:
+  content_structure:  'simple_image'
+  get_druid_from:     'manifest'
+
+bundle_dir:           'spec/test_data/bundle_input_g'
+staging_dir:          'tmp'
+accession_items:       ~
+
+validate_files:       true
+
+manifest:             'manifest.csv'
+checksums_file:        ~
+desc_md_template:     'mods_template.xml'
+
+progress_log_file:    'log/progress_folder_smoke_test.yaml'
+project_name:         'SmokeTest'
+apo_druid_id:         ~
+set_druid_id:         ~
+
+publish_attr:
+  'image/jp2':
+    publish:            'yes'
+    shelve:             'yes'
+    preserve:           'no'
+  'default':
+    publish:   ~
+    shelve:    ~
+    preserve:  ~
+
+content_md_creation:
+  style:              'default'
+
+object_discovery:
+  use_manifest:       true
+  glob:               ~
+  regex:              ~
+
+stageable_discovery:
+  use_container:      false
+  glob:               '**/*'
+  regex:              '(?ix) \. (tif|jp2) $'
+
+manifest_cols:
+  object_container:   'folder'
+  source_id:          'sourceid'
+  label:              'label'
+
+content_exclusion:    ~


### PR DESCRIPTION
Makes bundle.run_pre_assembly runnable from the console and adds a smoke test sort of spec for that.

Also comments out the currently unused config stuff to talk to workflow services -- we are currently set up to go via dor services url.  Ticket #194 is for converting us to use dor-workflow-services gem for this instead.

Note that given the development and test configurations, I am certain that the only external thing we need in this rails app for `run_pre_assembly` is the url to the dor workflow service.

Closes #165 
Closes #181