### PR TITLE
Add libimage-exiftool-perl to Travis-CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ sudo: false
 notifications:
   email: false
 
+addons:
+  apt:
+    packages:
+      - libimage-exiftool-perl
+
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true


### PR DESCRIPTION
This apt package is already on their whitelist:
https://github.com/travis-ci/apt-package-safelist/blob/master/ubuntu-trusty

This should help address our hangups in #195 