### PR TITLE
BundleContext Active Record Model

### DIFF
--- a/app/lib/bundle_context_temporary.rb
+++ b/app/lib/bundle_context_temporary.rb
@@ -3,7 +3,8 @@ class BundleUsageError < StandardError
   # back to users of the bin/pre-assemble script.
 end
 
-class BundleContext
+# This is a temporary BundleConext class that will be replaced with the BundleContext ActiveRecord Model.
+class BundleContextTemporary
   # Paramaters passed via YAML config files.
   YAML_PARAMS = [
     :project_style,

--- a/app/lib/pre_assembly/bundle.rb
+++ b/app/lib/pre_assembly/bundle.rb
@@ -39,7 +39,7 @@ module PreAssembly
            to: :bundle_context
 
     class << self
-      delegate :import_csv, to: BundleContext
+      delegate :import_csv, to: BundleContextTemporary
     end
 
     def initialize(bundle_context)

--- a/app/models/bundle_context.rb
+++ b/app/models/bundle_context.rb
@@ -1,0 +1,7 @@
+class BundleContext < ApplicationRecord
+  validates :project_name, presence: true, null: false
+  validates :content_structure, presence: true, null: false
+  validates :bundle_dir, presence: true, null: false
+  validates :staging_style_symlink, presence: true, null: false
+  validates :content_metadata_creation, presence: true, null: false
+end

--- a/app/models/bundle_context.rb
+++ b/app/models/bundle_context.rb
@@ -1,7 +1,24 @@
 class BundleContext < ApplicationRecord
+  belongs_to :user
+
   validates :project_name, presence: true, null: false
   validates :content_structure, presence: true, null: false
   validates :bundle_dir, presence: true, null: false
   validates :staging_style_symlink, presence: true, null: false
   validates :content_metadata_creation, presence: true, null: false
+
+  enum content_structure: {
+    "simple_image" => 1,
+    "simple_book" => 2,
+    "book_as_iamge" => 3,
+    "file" => 4,
+    "smpl" => 5
+  }
+
+  enum content_metadata_creation: {
+    "default" => 1,
+    "filename" => 2,
+    "smpl" => 3
+  }
+
 end

--- a/app/models/bundle_context.rb
+++ b/app/models/bundle_context.rb
@@ -4,21 +4,21 @@ class BundleContext < ApplicationRecord
   validates :project_name, presence: true, null: false
   validates :content_structure, presence: true, null: false
   validates :bundle_dir, presence: true, null: false
-  validates :staging_style_symlink, presence: true, null: false
+  validates :staging_style_symlink, inclusion: { in: [ true, false ] }
   validates :content_metadata_creation, presence: true, null: false
 
   enum content_structure: {
-    "simple_image" => 1,
-    "simple_book" => 2,
-    "book_as_iamge" => 3,
-    "file" => 4,
-    "smpl" => 5
+    "simple_image_structure" => 0,
+    "simple_book_structure" => 1,
+    "book_as_iamge_structure" => 2,
+    "file_structure" => 3,
+    "smpl_structure" => 4
   }
 
   enum content_metadata_creation: {
-    "default" => 1,
-    "filename" => 2,
-    "smpl" => 3
+    "default_style" => 0,
+    "filename_style" => 1,
+    "smpl_style" => 2
   }
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,4 @@
 class User < ApplicationRecord
+  has_many :bundle_contexts
   validates :sunet_id, presence: true, uniqueness: true, null: false
 end

--- a/db/migrate/20180905214414_create_bundle_contexts.rb
+++ b/db/migrate/20180905214414_create_bundle_contexts.rb
@@ -1,0 +1,14 @@
+class CreateBundleContexts < ActiveRecord::Migration[5.2]
+  def change
+    create_table :bundle_contexts do |t|
+      t.string :project_name, null: false
+      t.integer :content_structure, null: false
+      t.string :bundle_dir, null: false
+      t.boolean :staging_style_symlink, default: false, null: false
+      t.integer :content_metadata_creation, null: false
+      t.references :user, foreign_key: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_04_183131) do
+ActiveRecord::Schema.define(version: 2018_09_05_214414) do
+
+  create_table "bundle_contexts", force: :cascade do |t|
+    t.string "project_name", null: false
+    t.integer "content_structure", null: false
+    t.string "bundle_dir", null: false
+    t.boolean "staging_style_symlink", default: false, null: false
+    t.integer "content_metadata_creation", null: false
+    t.integer "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_bundle_contexts_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "sunet_id", null: false

--- a/spec/lib/bundle_context_temporary_spec.rb
+++ b/spec/lib/bundle_context_temporary_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe BundleContext do
+RSpec.describe BundleContextTemporary do
   let(:revs_context) { context_from_proj(:proj_revs) }
 
   describe "initialize() and other setup" do

--- a/spec/lib/pre_assembly/bundle_spec.rb
+++ b/spec/lib/pre_assembly/bundle_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe PreAssembly::Bundle do
     end
 
     it "finds the correct N objects, stageables, and files" do
-      allow_any_instance_of(BundleContext).to receive(:validate_usage) # req'd for :sohp_files_and_folders
+      allow_any_instance_of(BundleContextTemporary).to receive(:validate_usage) # req'd for :sohp_files_and_folders
       tests.each do |proj, n_dobj, n_stag, n_file|
         b = described_class.new(context_from_proj(proj))
         b.discover_objects

--- a/spec/models/bundle_context_spec.rb
+++ b/spec/models/bundle_context_spec.rb
@@ -1,5 +1,70 @@
 require 'rails_helper'
 
 RSpec.describe BundleContext, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context "validation" do
+    let(:user) { User.new(sunet_id: "Jdoe")}
+    subject(:bc) { BundleContext.new(project_name: "SmokeTest",
+                                     content_structure: 1,
+                                     bundle_dir: "spec/test_data/bundle_input_g",
+                                     staging_style_symlink: false,
+                                     content_metadata_creation: 1,
+                                     user: user) }
+
+    it "is not valid unless it has all required attributes" do
+      expect(BundleContext.new).not_to be_valid
+      expect(bc).to be_valid
+    end
+
+    context "defines enum with expected values" do
+      it "content_structure enum" do
+        is_expected.to define_enum_for(:content_structure).with(
+          "simple_image_structure" => 0,
+          "simple_book_structure" => 1,
+          "book_as_iamge_structure" => 2,
+          "file_structure" => 3,
+          "smpl_structure" => 4
+        )
+      end
+
+      it "content_metadata_creation enum" do
+        is_expected.to define_enum_for(:content_metadata_creation).with(
+          "default_style" => 0,
+          "filename_style" => 1,
+          "smpl_style" => 2
+        )
+      end
+    end
+
+    describe "#content_structure=" do
+      it "validation rejects a value if it does not match the enum" do
+        expect { described_class.new(content_structure: 654) }
+          .to raise_error(ArgumentError, "'654' is not a valid content_structure")
+        expect { described_class.new(content_structure: 'book_as_pdf') }
+          .to raise_error(ArgumentError, "'book_as_pdf' is not a valid content_structure")
+      end
+
+      it "will accept a symbol, but will always return a string" do
+        expect(described_class.new(content_structure: :smpl_structure).content_structure).to eq 'smpl_structure'
+      end
+    end
+
+    describe "#content_metadata_creation=" do
+      it "validation rejects a value if it does not match the enum" do
+        expect { described_class.new(content_metadata_creation: 654) }
+          .to raise_error(ArgumentError, "'654' is not a valid content_metadata_creation")
+        expect { described_class.new(content_metadata_creation: 'dpg') }
+          .to raise_error(ArgumentError, "'dpg' is not a valid content_metadata_creation")
+      end
+
+      it "will accept a symbol, but will always return a string" do
+        expect(described_class.new(content_metadata_creation: :smpl_style).content_metadata_creation).to eq 'smpl_style'
+      end
+    end
+
+    it { is_expected.to validate_presence_of(:project_name) }
+    it { is_expected.to validate_presence_of(:content_structure) }
+    it { is_expected.to validate_presence_of(:bundle_dir) }
+    it { is_expected.to validate_presence_of(:content_metadata_creation) }
+    it { is_expected.to belong_to(:user) }
+  end
 end

--- a/spec/models/bundle_context_spec.rb
+++ b/spec/models/bundle_context_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe BundleContext, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe User, type: :model do
 
     it { is_expected.to validate_uniqueness_of(:sunet_id) }
     it { is_expected.to validate_presence_of(:sunet_id) }
+    it { is_expected.to have_many(:bundle_contexts) }
     
     describe 'enforces unique constraint on sunet_id' do
       let(:required_attributes) do

--- a/spec/support/bundle_setup.rb
+++ b/spec/support/bundle_setup.rb
@@ -8,5 +8,5 @@ def context_from_proj(proj)
   filename = "spec/test_data/project_config_files/#{proj}.yaml"
   ps = YAML.load(File.read(filename))
   ps['config_filename'] = filename
-  BundleContext.new(ps)
+  BundleContextTemporary.new(ps)
 end


### PR DESCRIPTION
In the `db/migration` these are the following attributes I used and why:

form website: https://sul-preassembly-stage.stanford.edu/bundle_context

`project_name` as a `string` => instead of just `project` on the website (thought adding name might be more clear.)

`content_structure` as an `integer` => this used to be `project_style`. In the code `project_style` is a hash of hashes that contains `content_structure` and `get_druid_from`. `Get_druid_from` is going to be hard coded, and so I thought we could use `content_structure` as the name here instead of `project_style`. This will be easier to use it as an enum. So it isn't like this: 
```
 {
      :project_style => {
        :content_structure => [:simple_image, :simple_book, :book_as_image, :book_with_pdf, :file, :smpl]
      }
}
```

but instead:
```
{  :content_structure => [:simple_image, :simple_book, :book_as_image, :book_with_pdf, :file, :smpl] }
```

`bundle_dir` as a `string` => this is the same as the form on the website, user input

`staging_style_symlink` as a `boolean` => this used to be just `staging_style` however since it only has 2 options (`copy` or `symlink`), and is almost always going to be `copy`, putting this as a `boolean` and defaulting to false, seems like a logical solution. Happy to change this to an enum, if that is easier.

`content_metadata_creation` as an `integer` => enum, same as the form on the website


in the Enum section in the `app/models/bundle_context.rb` i had to add a suffix to end of the enum values because of the name space collision between `smpl`. I found out you can't have two different enum attributes w/ the same enum value.  

Please let me know what everyone thinks of the naming I chose,  happy to change any of the names. 

connects #172 