### PR TITLE
Resque/pool config, initialization and tasks

### DIFF
--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -1,0 +1,17 @@
+require 'resque/failure/redis_multi_queue'
+
+# load environment specific configuration
+config_file = Rails.root.join('config', 'resque.yml')
+resque_config = YAML.safe_load(ERB.new(IO.read(config_file)).result)
+Resque.redis = resque_config[Rails.env.to_s]
+
+# configure a separate failure queue per job queue
+Resque::Failure.backend = Resque::Failure::RedisMultiQueue
+
+# see https://github.com/resque/resque/issues/1591#issuecomment-403805957
+# this silences a burdensome deprecation warning, while we wait for the gem to update
+Redis::Namespace.class_eval do
+  def client
+    _client
+  end
+end

--- a/config/resque-pool.yml
+++ b/config/resque-pool.yml
@@ -1,0 +1,3 @@
+# These are queue names (like would be passed as QUEUES=... rake resque:work)
+# and the count of workers that should be spun up to service them.
+'*': 5

--- a/config/resque.yml
+++ b/config/resque.yml
@@ -1,0 +1,3 @@
+development: localhost:6379
+test:        localhost:6379
+production:  localhost:6379

--- a/lib/tasks/resque.rake
+++ b/lib/tasks/resque.rake
@@ -1,0 +1,10 @@
+require 'resque/tasks'
+task 'resque:setup' => :environment
+
+require 'resque/pool/tasks'
+task "resque:pool:setup" do
+  ActiveRecord::Base.connection.disconnect! # close any sockets or files in pool manager
+  Resque::Pool.after_prefork do |_job|
+    ActiveRecord::Base.establish_connection # and re-open them in the resque worker parent
+  end
+end


### PR DESCRIPTION
`resque-pool` now runs. This PR is non-conflicty.

Closes #208 