### PR TITLE
Honeybadger/erubis dependency issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem 'uglifier' # compressor for JavaScript assets
 # Stanford gems
 gem 'assembly-image'
 gem 'assembly-objectfile', '~> 1.7'
-gem 'assembly-utils'
 gem 'dor-services', '~> 5.29'
 gem 'modsulator'
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'bootstrap', '~> 4.1.3'
 gem 'config'
+gem 'erubis' # implicit dependency for (old) rdf-rdfa, no longer default in Rails 5.1+
 gem 'honeybadger', '~> 3.1'
 gem 'jquery-rails'
 gem 'nokogiri'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,10 +75,6 @@ GEM
       mime-types
       mini_exiftool
       nokogiri
-    assembly-utils (1.5.0)
-      dor-services (~> 5.5)
-      druid-tools (>= 0.2.6)
-      nokogiri
     ast (2.4.0)
     autoprefixer-rails (9.1.4)
       execjs
@@ -497,7 +493,6 @@ PLATFORMS
 DEPENDENCIES
   assembly-image
   assembly-objectfile (~> 1.7)
-  assembly-utils
   bootstrap (~> 4.1.3)
   capistrano-bundler
   capistrano-passenger

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,6 +205,7 @@ GEM
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     erubi (1.7.1)
+    erubis (2.7.0)
     execjs (2.7.0)
     faraday (0.15.2)
       multipart-post (>= 1.2, < 3)
@@ -506,6 +507,7 @@ DEPENDENCIES
   dlss-capistrano (~> 3.1)
   dor-services (~> 5.29)
   equivalent-xml
+  erubis
   honeybadger (~> 3.1)
   jquery-rails
   listen

--- a/app/lib/bundle_context_temporary.rb
+++ b/app/lib/bundle_context_temporary.rb
@@ -87,7 +87,7 @@ class BundleContextTemporary
   def setup_paths
     bundle_dir.chomp!('/') # get rid of any trailing slash on the bundle directory
     self.manifest &&= path_in_bundle(manifest)
-    self.staging_dir ||= Assembly::ASSEMBLY_WORKSPACE
+    self.staging_dir ||= '/dor/assembly'
     self.progress_log_file ||= File.join(File.dirname(config_filename), File.basename(config_filename, '.yaml') + '_progress.yaml')
   end
 

--- a/app/lib/pre_assembly/bundle.rb
+++ b/app/lib/pre_assembly/bundle.rb
@@ -46,7 +46,8 @@ module PreAssembly
     end
 
     def load_skippables
-      docs = YAML.load_stream(Assembly::Utils.read_file(progress_log_file))
+      return unless File.readable?(progress_log_file)
+      docs = YAML.load_stream(IO.read(progress_log_file))
       docs = docs.documents if docs.respond_to? :documents
       docs.each do |yd|
         skippables[yd[:unadjusted_container]] = true if yd[:pre_assem_finished]

--- a/app/lib/pre_assembly/digital_object.rb
+++ b/app/lib/pre_assembly/digital_object.rb
@@ -49,8 +49,8 @@ module PreAssembly
 
     def setup
       self.label              = Dor::Config.dor.default_label
-      self.content_md_file    = Assembly::CONTENT_MD_FILE
-      self.technical_md_file  = Assembly::TECHNICAL_MD_FILE
+      self.content_md_file    = 'contentMetadata.xml'
+      self.technical_md_file  = 'technicalMetadata.xml'
       self.content_md_xml     = ''
       self.technical_md_xml   = ''
       self.content_structure  = (project_style ? project_style[:content_structure] : 'file')

--- a/app/lib/pre_assembly/reporting.rb
+++ b/app/lib/pre_assembly/reporting.rb
@@ -143,10 +143,6 @@ module PreAssembly
           end # end if object exists
         end # end confirming registration
 
-        if checking_sourceids # let's check for global source ID uniqueness
-          message += (Assembly::Utils.get_druids_by_sourceid(dobj.source_id).size == 0 ? " yes , " : report_error_message("**DUPLICATE**"))
-        end
-
         puts message
 
         if show_staged # let's show all files that will be staged

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,8 @@
 require_relative 'boot'
 require 'rails/all'
-require 'assembly-utils'
+require_relative 'erubis_monkeypatch.rb'
+
+CERT_DIR = File.join(File.dirname(__FILE__), ".", "certs")
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,3 +19,6 @@ module PreAssembly
     # the framework and any gems in your application.
   end
 end
+
+# Old Environment.
+require_relative "cli_environments/#{Rails.env}.rb"

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,11 +1,3 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
-require 'rubygems'
-
-environment = ENV['RAILS_ENV'] || 'development'
-PRE_ASSEMBLY_ROOT = File.expand_path(File.dirname(__FILE__) + '/..')
-CERT_DIR = File.join(File.dirname(__FILE__), ".", "certs")
-
-# Environment.
-require_relative "cli_environments/#{environment}.rb"

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -26,8 +26,8 @@ set :deploy_to, '/opt/app/preassembly/pre-assembly'
 # set :pty, true
 
 # Default value for :linked_files is []
-append :linked_files, 'config/master.key'
-# TODO: 'config/honeybadger.yml', database.yml ...
+append :linked_files, 'config/master.key', 'config/honeybadger.yml'
+# TODO: database.yml ...
 
 # Default value for linked_dirs is []
 append :linked_dirs, 'log', 'config/certs', 'config/cli_environments', 'tmp', 'vendor/bundle'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -42,23 +42,3 @@ append :linked_dirs, 'log', 'config/certs', 'config/cli_environments', 'tmp', 'v
 before 'deploy:restart', 'shared_configs:update'
 
 set :honeybadger_env, fetch(:stage)
-
-Rake::Task["honeybadger:deploy"].clear
-namespace :honeybadger do
-  desc 'Notify Honeybadger of the deployment.'
-  task :deploy => [:'deploy:set_current_revision'] do
-    puts "Temporarily disabling honeybadger deploy notification due to bug with Haml::ActionView. See issue https://github.com/sul-dlss/pre-assembly/issues/98"
-    #  from capistrano messages, we get:
-    #  "NameError: uninitialized constant Haml::ActionView
-    # 01     /opt/app/preassembly/pre-assembly/shared/bundle/ruby/2.4.0/gems/haml-4.0.7/lib/haml/helpers/safe_erubis_template.rb:3:in `<module:Haml>"
-    #
-    # see https://github.com/haml/haml/issues/974
-    #
-    # from bundler, can't update to haml 5.0.4:
-    # dor-services (~> 5.29) was resolved to 5.29.0, which depends on
-    #   active-fedora (< 9.a, >= 6.0) was resolved to 8.5.0, which depends on
-    #     rdf-rdfxml (~> 1.1) was resolved to 1.99.0, which depends on
-    #       rdf-rdfa (~> 1.99) was resolved to 1.99.1, which depends on
-    #         haml (~> 4.0)
-  end
-end

--- a/config/erubis_monkeypatch.rb
+++ b/config/erubis_monkeypatch.rb
@@ -1,0 +1,87 @@
+require 'erubis'
+
+# This is essentially a modified copy of
+# https://raw.githubusercontent.com/rails/rails/v4.2.10/actionview/lib/action_view/template/handlers/erb.rb
+# It restores ActionView::Template::Handlers::Erubis removed in Rails 5.x
+# It also monkey-patches ERB to default to Erubis
+# relates to: https://github.com/haml/haml/issues/695
+
+module ActionView
+  class Template
+    module Handlers
+      class Erubis < ::Erubis::Eruby
+        def add_preamble(src)
+          @newline_pending = 0
+          src << "@output_buffer = output_buffer || ActionView::OutputBuffer.new;"
+        end
+
+        def add_text(src, text)
+          return if text.empty?
+
+          if text == "\n"
+            @newline_pending += 1
+          else
+            src << "@output_buffer.safe_append='"
+            src << "\n" * @newline_pending if @newline_pending > 0
+            src << escape_text(text)
+            src << "'.freeze;"
+
+            @newline_pending = 0
+          end
+        end
+
+        # Erubis toggles <%= and <%== behavior when escaping is enabled.
+        # We override to always treat <%== as escaped.
+        def add_expr(src, code, indicator)
+          case indicator
+          when '=='
+            add_expr_escaped(src, code)
+          else
+            super
+          end
+        end
+
+        BLOCK_EXPR = /\s*((\s+|\))do|\{)(\s*\|[^|]*\|)?\s*\Z/
+
+        def add_expr_literal(src, code)
+          flush_newline_if_pending(src)
+          if code =~ BLOCK_EXPR
+            src << '@output_buffer.append= ' << code
+          else
+            src << '@output_buffer.append=(' << code << ');'
+          end
+        end
+
+        def add_expr_escaped(src, code)
+          flush_newline_if_pending(src)
+          if code =~ BLOCK_EXPR
+            src << "@output_buffer.safe_expr_append= " << code
+          else
+            src << "@output_buffer.safe_expr_append=(" << code << ");"
+          end
+        end
+
+        def add_stmt(src, code)
+          flush_newline_if_pending(src)
+          super
+        end
+
+        def add_postamble(src)
+          flush_newline_if_pending(src)
+          src << '@output_buffer.to_s'
+        end
+
+        def flush_newline_if_pending(src)
+          if @newline_pending > 0
+            src << "@output_buffer.safe_append='#{"\n" * @newline_pending}'.freeze;"
+            @newline_pending = 0
+          end
+        end
+      end
+
+      class ERB # monkey-patch: restoring the default from rails 4
+        class_attribute :erb_implementation, default: Erubis
+      end
+    end
+  end
+end

--- a/spec/lib/bundle_context_temporary_spec.rb
+++ b/spec/lib/bundle_context_temporary_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe BundleContextTemporary do
 
   describe '#staging_dir' do
     it 'takes default value' do
-      expect(context_from_proj(:proj_sohp2).staging_dir).to eq(Assembly::ASSEMBLY_WORKSPACE)
+      expect(context_from_proj(:proj_sohp2).staging_dir).to eq('/dor/assembly')
     end
   end
 end


### PR DESCRIPTION
Replaces #216 

Here I take a very literal approach to resolving the dependency issue, which basically is a complaint about a class not existing anymore because Rails has removed it. So I put it back.

After this PR, `boot.rb` looks stock.  `Assembly::Utils` dependency removed.

Fixes #215
Fixes #98 
Fixes #184
Fixes #99