### PR TITLE
Job history active record

### DIFF
--- a/app/models/bundle_context.rb
+++ b/app/models/bundle_context.rb
@@ -1,5 +1,6 @@
 class BundleContext < ApplicationRecord
   belongs_to :user
+  has_many :job_runs
 
   validates :project_name, presence: true, null: false
   validates :content_structure, presence: true, null: false

--- a/app/models/job_run.rb
+++ b/app/models/job_run.rb
@@ -1,0 +1,8 @@
+class JobRun < ApplicationRecord
+  belongs_to :bundle_context
+
+  enum job_type: {
+    "discovery_report" => 0,
+    "pre_assembly" => 1
+  }
+end

--- a/db/migrate/20180910225753_create_job_runs.rb
+++ b/db/migrate/20180910225753_create_job_runs.rb
@@ -1,0 +1,10 @@
+class CreateJobRuns < ActiveRecord::Migration[5.2]
+  def change
+    create_table :job_runs do |t|
+      t.string :output_location
+      t.integer :job_type
+      t.references :bundle_context, foreign_key: true, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_05_214414) do
+ActiveRecord::Schema.define(version: 2018_09_10_225753) do
 
   create_table "bundle_contexts", force: :cascade do |t|
     t.string "project_name", null: false
@@ -22,6 +22,15 @@ ActiveRecord::Schema.define(version: 2018_09_05_214414) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_bundle_contexts_on_user_id"
+  end
+
+  create_table "job_runs", force: :cascade do |t|
+    t.string "output_location"
+    t.integer "job_type"
+    t.integer "bundle_context_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["bundle_context_id"], name: "index_job_runs_on_bundle_context_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/models/job_run_spec.rb
+++ b/spec/models/job_run_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe JobRun, type: :model do
+  context "validation" do
+    let(:user) do
+      User.new(sunet_id: "Jdoe")
+    end
+
+    let(:bc) do
+      BundleContext.new(project_name: "SmokeTest",
+                        content_structure: 1,
+                        bundle_dir: "spec/test_data/bundle_input_g",
+                        staging_style_symlink: false,
+                        content_metadata_creation: 1,
+                        user: user)
+    end
+
+    let(:discovery_report_run) do
+      JobRun.new(output_location: "Report available at /path/to/report",
+                 bundle_context: bc,
+                 job_type: "discovery_report")
+    end
+
+    it "is not valid if it doesn't have the required fields" do
+      expect(JobRun.new).not_to be_valid
+      expect(discovery_report_run).to be_valid
+    end
+    context "#job_type enum" do
+      it "defines expected values" do
+        is_expected.to define_enum_for(:job_type).with(
+          "discovery_report" => 0,
+          "pre_assembly" => 1
+        )
+      end
+    end
+
+    it { is_expected.to belong_to(:bundle_context) }
+  end
+end


### PR DESCRIPTION
Creates a single ActiveRecord model `JobRun` that will be created when the ActiveJob is run with the a `BundleContext` instance, when the ActiveJob is completed, the `output_location` where either the Discovery Report or the Pre Assembly results are stored on the file system. 

This commit also removes the `DiscoveryReportRun` and `JobAssemblyRun` classes in favor of the single class `JobRun` that now has a `job_type` enum for the type of report.

Closes #175 