### PR TITLE
make the output_location in the discovery_report_run test fixture more realistic

### DIFF
--- a/spec/models/job_run_spec.rb
+++ b/spec/models/job_run_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe JobRun, type: :model do
     end
 
     let(:discovery_report_run) do
-      JobRun.new(output_location: "Report available at /path/to/report",
+      JobRun.new(output_location: "/path/to/report",
                  bundle_context: bc,
                  job_type: "discovery_report")
     end


### PR DESCRIPTION
spawned by a nitpick on #239: https://github.com/sul-dlss/pre-assembly/pull/239/files#r216867660