### PR TITLE
DiscoveryReport templates

### DIFF
--- a/app/services/discovery_report.rb
+++ b/app/services/discovery_report.rb
@@ -45,11 +45,7 @@ class DiscoveryReport
     errors[:empty_object] = true if counts[:total_size] > 0
     errors[:missing_files] = true unless dobj.object_files_exist?
     errors[:dupes] = true unless object_filenames_unique?(dobj)
-    counts[:source_ids][dobj.source_id] += 1
     errors.merge!(registration_check(dobj.druid))
-    if using_manifest? # check global uniqueness
-      errors[:source_id_dup] = true if dobj.source_id.any? { |id| Dor::SearchService.query_by_id(id) }
-    end
     return { errors: errors, counts: counts }
   end
 
@@ -67,27 +63,11 @@ class DiscoveryReport
     return { apo_not_registered: true }
   end
 
-  # @return [String] primitive version
-  def header
-    fields = ['Object Container', 'Number of Items', 'Files with no ext', 'Files with 0 Size', 'Total Size', 'Files Readable']
-    fields.concat ['Label', 'Source ID'] if using_manifest?
-    fields.concat ['Num Files in CM Manifest', 'All CM files found'] if using_smpl_manifest?
-    fields.concat ['Duplicate Filenames?', 'DRUID', 'Registered?', 'APO exists?']
-    fields << 'SourceID unique in DOR?' if using_manifest?
-    fields.join(' , ')
-  end
-
   # For use by template
   def skipped_files
-    files = ['Thumbs.db', '.DS_Store'] # if these files are in the bundle directory but not in the manifest, they will be ignorned and not reported as missing
+    files = ['Thumbs.db', '.DS_Store', manifest] # if these files are in the bundle directory but not in the manifest, they will be ignorned and not reported as missing
     files << File.basename(content_md_creation[:smpl_manifest]) if using_smpl_manifest?
-    files << File.basename(manifest) if using_manifest?
     files
-  end
-
-  # @return [Boolean]
-  def using_manifest?
-    manifest.present?
   end
 
   # @return [Boolean]
@@ -99,5 +79,4 @@ class DiscoveryReport
   def smpl
     @smpl ||= PreAssembly::Smpl.new(csv_filename: content_md_creation[:smpl_manifest], bundle_dir: bundle_dir)
   end
-
 end

--- a/app/views/discovery_report/_row.text.erb
+++ b/app/views/discovery_report/_row.text.erb
@@ -1,0 +1,1 @@
+Example row output

--- a/app/views/discovery_report/show.text.erb
+++ b/app/views/discovery_report/show.text.erb
@@ -1,0 +1,5 @@
+Discovery Report
+=====================
+<%= render partial: 'row', collection: @discovery_report.each_row %>
+=====================
+Possible summary data

--- a/spec/services/discover_report_spec.rb
+++ b/spec/services/discover_report_spec.rb
@@ -30,4 +30,20 @@ RSpec.describe DiscoveryReport do
       report.each_row { |_r| } # no-op
     end
   end
+
+  describe '#process_dobj' do
+    let(:dobj) { report.bundle.objects_to_process.first }
+
+    before do
+      allow(dobj).to receive(:pid).and_return('kk203bw3276')
+      allow(report).to receive(:registration_check).and_return({}) # pretend everything is in Dor
+    end
+
+    it 'converts a DigtialObject to structured data (Hash)' do
+      expect(report.process_dobj(dobj)).to match a_hash_including(
+        counts: a_hash_including(total_size: 0),
+        errors: a_hash_including(missing_files: true)
+      )
+    end
+  end
 end

--- a/spec/views/discovery_report/show.text.erb_spec.rb
+++ b/spec/views/discovery_report/show.text.erb_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe 'discovery_report/show.text.erb' do
+  let(:bundle) { bundle_setup(:proj_revs) }
+  subject(:report) { DiscoveryReport.new(bundle) }
+
+  before do
+    allow_any_instance_of(BundleContextTemporary).to receive(:validate_usage) # replace w/ AR validation
+    report.bundle.digital_objects.each { |dobj| allow(dobj).to receive(:pid).and_return('kk203bw3276') }
+    allow(report).to receive(:registration_check).and_return({}) # pretend everything is in Dor
+  end
+
+  it 'renders the wrapper and a row per DigitalObject' do
+    assign(:discovery_report, report)
+    render
+    expect(rendered).to match(/Discovery Report/)
+    expect(rendered).to match(/^Example row output\nExample row output\nExample row output\n[^E]/) # 3 rows
+  end
+end


### PR DESCRIPTION
These are stub templates, but show structure and test it.  I don't mind if reviewers prefer to wait for them to be further fleshed out, but they are mergeable as is.  Since there is some confusion about how these components might work together, this may be clarifying.

Note: because of the Enumerator, we can use the form:
```ruby
render partial: 'row', collection: @discovery_report.each_row
```
That knows to iterate over the Enumerator.

We can also imagine other template outputs (JSON, HTML, etc.) based on the same structure.