### PR TITLE
use yml settings and dor_services initializer for configuration

### DIFF
--- a/app/lib/pre_assembly/reporting_old.rb
+++ b/app/lib/pre_assembly/reporting_old.rb
@@ -1,7 +1,7 @@
 # encoding: UTF-8
 
 module PreAssembly
-  module Reporting
+  module ReportingOld
     def discovery_report(params = {})
       # Runs a confirmation for each digital object and confirms:
       # a) there are no duplicate filenames contained within the object. This is useful if you will be flattening the folder structure during pre-assembly.

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -30,7 +30,9 @@ append :linked_files, 'config/master.key', 'config/honeybadger.yml'
 # TODO: database.yml ...
 
 # Default value for linked_dirs is []
-append :linked_dirs, 'log', 'config/certs', 'config/cli_environments', 'tmp', 'vendor/bundle'
+# TODO: config/cli_environments can be removed after PRs addressing #169 are merged
+#   and no deployments will need them (and shared_configs PRs for it too)
+append :linked_dirs, 'log', 'config/certs', 'config/cli_environments', 'config/settings', 'tmp', 'vendor/bundle'
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }

--- a/config/initializers/dor_services.rb
+++ b/config/initializers/dor_services.rb
@@ -1,10 +1,30 @@
 require 'dor-services'
 
-Dor::Config.dor_services.url ||= Dor::Config.dor.service_root
+Dor::Config.configure do
+  ssl do
+    cert_file Settings.dor_client_cert
+    key_file Settings.dor_client_cert_key
+  end
 
-# TODO: use dor-workflow-service gem (see #194)
+  # used to make dor-workflow-service call for a druid
+  #   this is done at end of preassembly to kick off assembly
+  # TODO: use dor-workflow-service gem instead (see #194)
+  dor_services do
+    url Settings.dor_services_url
+    num_attempts Settings.dor_services_num_attempts
+    sleep_time Settings.dor_services_sleep_time # time between attempts
+  end
+
+  # used to look up object existence in DOR for discovery report
+  fedora do
+    # used to look up objects in DOR
+    url Settings.fedora_url
+  end
+end
+
+# TODO: use dor-workflow-service gem (see #194) instead of dor_services gem
 # require 'dor-workflow-service'
 # Dor::WorkflowService.configure(
 #   Settings.workflow_services_url,
-#   :dor_services_url => Dor::Config.dor_services.url.gsub('/v1', '')
+#   dor_services_url: Dor::Config.dor_services.url.gsub('/v1', '')
 # )

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,2 +1,17 @@
-# TODO: use dor-workflow-service gem (see #194)
+dor_client_cert:
+dor_client_cert_key:
+
+# used to make dor-workflow-service call for a druid
+#   this is done at end of preassembly to kick off assembly
+# TODO: use dor-workflow-service gem instead (see #194)
 # workflow_services_url: 'https://workflows.example.org/workflow/'
+dor_services_url: 'https://example.com/dor/v1'
+dor_services_num_attempts: 1 # how many attempts to contact dor before throwing exception
+dor_services_sleep_time: 0 # how long, in seconds, between attempts
+
+# used to look up object existence in DOR for discovery report
+# TODO: can we use dor-services-app instead? (see #226)
+fedora_url: 'https://example.com/fedora'
+
+# writable directory where job run artifacts will live
+job_output_parent_dir:  'log/jobs'

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,0 +1,2 @@
+# writable directory where job run artifacts will live
+job_output_parent_dir:  'log/dev_jobs'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,0 +1,2 @@
+# writable directory where job run artifacts will live
+job_output_parent_dir:  'log/test_jobs'


### PR DESCRIPTION
The impetus for this PR is #78 -- have job outputs in an appropriate location.   This should be a configuration setting, and has nothing to do with dor-services.

It seemed a propitious time address #169 to move config data into config/settings/#{RAILS_ENV}.yml file and having the dor_services initializer turn the settings into ruby code.

Connects to #169 which will be complete when config/cli_environments is removed from shared_configs and from preassembly code base.

Connects to #78 which will use the `job_output_parent_dir` setting.

Note that the edit to reporting_old class helped me test this on the console on -stage;  I know the class is going away.