### PR TITLE
Job wire up

### DIFF
--- a/app/jobs/discovery_report_job.rb
+++ b/app/jobs/discovery_report_job.rb
@@ -1,7 +1,8 @@
 class DiscoveryReportJob < ApplicationJob
   queue_as :discovery_report
 
-  def perform(*args)
+  # @param [JobRun] job_run
+  def perform(job_run)
     logger.info("DiscoveryReportJob perform method doesn't do anything yet")
   end
 end

--- a/app/jobs/preassembly_job.rb
+++ b/app/jobs/preassembly_job.rb
@@ -1,7 +1,8 @@
 class PreassemblyJob < ApplicationJob
-  # queue_as :preassembly
+  queue_as :preassembly
 
-  def perform(*args)
+  # @param [JobRun] job_run
+  def perform(job_run)
     logger.info("PreassemblyJob perform method doesn't do anything yet")
   end
 end

--- a/app/models/bundle_context.rb
+++ b/app/models/bundle_context.rb
@@ -2,11 +2,8 @@ class BundleContext < ApplicationRecord
   belongs_to :user
   has_many :job_runs
 
-  validates :project_name, presence: true, null: false
-  validates :content_structure, presence: true, null: false
-  validates :bundle_dir, presence: true, null: false
+  validates :bundle_dir, :content_metadata_creation, :content_structure, :project_name, presence: true
   validates :staging_style_symlink, inclusion: { in: [true, false] }
-  validates :content_metadata_creation, presence: true, null: false
 
   validate :verify_bundle_directory
   validate :verify_content_metadata_creation
@@ -26,6 +23,11 @@ class BundleContext < ApplicationRecord
     "filename" => 1,
     "smpl_cm_style" => 2
   }
+
+  # return [PreAssembly::Bundle]
+  def bundle
+    @bundle ||= PreAssembly::Bundle.new(self)
+  end
 
   def content_md_creation
     content_metadata_creation

--- a/app/models/job_run.rb
+++ b/app/models/job_run.rb
@@ -1,10 +1,17 @@
 class JobRun < ApplicationRecord
   belongs_to :bundle_context
-
   validates :job_type, presence: true
+  after_create :enqueue!
 
   enum job_type: {
     "discovery_report" => 0,
     "preassembly" => 1
   }
+
+  # throw to asynchronous processing via correct Job class for job_type
+  # @return [ApplicationJob, nil] nil if unpersisted
+  def enqueue!
+    return nil unless persisted?
+    "#{job_type.camelize}Job".constantize.perform_later(self)
+  end
 end

--- a/spec/models/bundle_context_spec.rb
+++ b/spec/models/bundle_context_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe BundleContext, type: :model do
       expect(BundleContext.new).not_to be_valid
       expect(bc).to be_valid
     end
+    it 'is not valid without a User' do
+      expect { bc.user = nil }.to change(bc, :valid?).to(false)
+    end
+    it 'is not valid unless bundle_dir exists on filesystem' do
+      expect { bc.bundle_dir = 'does/not/exist' }.to change(bc, :valid?).to(false)
+    end
   end
 
   it do
@@ -36,17 +42,20 @@ RSpec.describe BundleContext, type: :model do
     )
   end
 
-  context "bundle_dir path does not exist" do
-    it "object does not pass validation" do
-      expect { bc.bundle_dir = 'does/not/exist' }.to change(bc, :valid?).to(false)
-    end
-  end
-
   it { is_expected.to validate_presence_of(:project_name) }
   it { is_expected.to validate_presence_of(:content_structure) }
   it { is_expected.to validate_presence_of(:bundle_dir) }
   it { is_expected.to validate_presence_of(:content_metadata_creation) }
   it { is_expected.to belong_to(:user) }
+
+  describe '#bundle' do
+    it 'returns a PreAssembly::Bundle' do
+      expect(bc.bundle).to be_a(PreAssembly::Bundle)
+    end
+    it 'caches the Bundle' do
+      expect(bc.bundle).to be(bc.bundle) # same instance
+    end
+  end
 
   describe "#staging_dir" do
     it 'is hardcoded to the correct path' do

--- a/spec/models/bundle_context_spec.rb
+++ b/spec/models/bundle_context_spec.rb
@@ -17,65 +17,36 @@ RSpec.describe BundleContext, type: :model do
       expect(BundleContext.new).not_to be_valid
       expect(bc).to be_valid
     end
-
-    context "defines enum with expected values" do
-      it "content_structure enum" do
-        is_expected.to define_enum_for(:content_structure).with(
-          "simple_image" => 0,
-          "simple_book" => 1,
-          "book_as_image" => 2,
-          "file" => 3,
-          "smpl" => 4
-        )
-      end
-
-      it "content_metadata_creation enum" do
-        is_expected.to define_enum_for(:content_metadata_creation).with(
-          "default" => 0,
-          "filename" => 1,
-          "smpl_cm_style" => 2
-        )
-      end
-    end
-
-    describe "#content_structure=" do
-      it "validation rejects a value if it does not match the enum" do
-        expect { described_class.new(content_structure: 654) }
-          .to raise_error(ArgumentError, "'654' is not a valid content_structure")
-        expect { described_class.new(content_structure: 'book_as_pdf') }
-          .to raise_error(ArgumentError, "'book_as_pdf' is not a valid content_structure")
-      end
-
-      it "will accept a symbol, but will always return a string" do
-        expect(described_class.new(content_structure: :smpl).content_structure).to eq 'smpl'
-      end
-    end
-
-    describe "#content_metadata_creation=" do
-      it "validation rejects a value if it does not match the enum" do
-        expect { described_class.new(content_metadata_creation: 654) }
-          .to raise_error(ArgumentError, "'654' is not a valid content_metadata_creation")
-        expect { described_class.new(content_metadata_creation: 'dpg') }
-          .to raise_error(ArgumentError, "'dpg' is not a valid content_metadata_creation")
-      end
-
-      it "will accept a symbol, but will always return a string" do
-        expect(described_class.new(content_metadata_creation: :smpl_cm_style).content_metadata_creation).to eq 'smpl_cm_style'
-      end
-    end
-
-    context "bundle_dir path does not exist" do
-      it "object does not pass validation" do
-        expect { bc.bundle_dir = 'does/not/exist' }.to change { bc.valid? }.to(false)
-      end
-    end
-
-    it { is_expected.to validate_presence_of(:project_name) }
-    it { is_expected.to validate_presence_of(:content_structure) }
-    it { is_expected.to validate_presence_of(:bundle_dir) }
-    it { is_expected.to validate_presence_of(:content_metadata_creation) }
-    it { is_expected.to belong_to(:user) }
   end
+
+  it do
+    is_expected.to define_enum_for(:content_structure).with(
+      "simple_image" => 0,
+      "simple_book" => 1,
+      "book_as_image" => 2,
+      "file" => 3,
+      "smpl" => 4
+    )
+  end
+  it do
+    is_expected.to define_enum_for(:content_metadata_creation).with(
+      "default" => 0,
+      "filename" => 1,
+      "smpl_cm_style" => 2
+    )
+  end
+
+  context "bundle_dir path does not exist" do
+    it "object does not pass validation" do
+      expect { bc.bundle_dir = 'does/not/exist' }.to change(bc, :valid?).to(false)
+    end
+  end
+
+  it { is_expected.to validate_presence_of(:project_name) }
+  it { is_expected.to validate_presence_of(:content_structure) }
+  it { is_expected.to validate_presence_of(:bundle_dir) }
+  it { is_expected.to validate_presence_of(:content_metadata_creation) }
+  it { is_expected.to belong_to(:user) }
 
   describe "#staging_dir" do
     it 'is hardcoded to the correct path' do

--- a/spec/models/job_run_spec.rb
+++ b/spec/models/job_run_spec.rb
@@ -8,11 +8,27 @@ RSpec.describe JobRun, type: :model do
                       content_metadata_creation: 1,
                       user: user)
   end
-  let(:discovery_report_run) do
+  let(:job_run) do
     described_class.new(output_location: '/path/to/report', bundle_context: bc, job_type: 'discovery_report')
   end
 
   it { is_expected.to belong_to(:bundle_context) }
+
+
+  describe 'enqueue!' do
+    it 'does nothing if unpersisted' do
+      expect(DiscoveryReportJob).not_to receive(:perform_later)
+      job_run.enqueue!
+    end
+    it 'calls the correct job for job_type' do
+      allow(job_run).to receive(:persisted?).and_return(true)
+      expect(DiscoveryReportJob).to receive(:perform_later).with(job_run)
+      job_run.enqueue!
+      job_run.job_type = 'preassembly'
+      expect(PreassemblyJob).to receive(:perform_later).with(job_run)
+      job_run.enqueue!
+    end
+  end
 
   describe '#job_type enum' do
     it 'defines expected values' do
@@ -25,8 +41,9 @@ RSpec.describe JobRun, type: :model do
 
   context 'validation' do
     it 'is not valid without all required fields' do
+      expect(described_class.new).not_to be_valid
       expect(described_class.new(bundle_context: bc)).not_to be_valid
-      expect(discovery_report_run).to be_valid
+      expect(job_run).to be_valid
     end
   end
 end

--- a/spec/models/job_run_spec.rb
+++ b/spec/models/job_run_spec.rb
@@ -1,58 +1,32 @@
-require 'rails_helper'
-
 RSpec.describe JobRun, type: :model do
+  let(:user) { User.new(sunet_id: 'Jdoe') }
+  let(:bc) do
+    BundleContext.new(project_name: 'SmokeTest',
+                      content_structure: 1,
+                      bundle_dir: 'spec/test_data/bundle_input_g',
+                      staging_style_symlink: false,
+                      content_metadata_creation: 1,
+                      user: user)
+  end
+  let(:discovery_report_run) do
+    described_class.new(output_location: '/path/to/report', bundle_context: bc, job_type: 'discovery_report')
+  end
 
-  context "validation" do
-    let(:user) do
-      User.new(sunet_id: "Jdoe")
-    end
+  it { is_expected.to belong_to(:bundle_context) }
 
-    let(:bc) do
-      BundleContext.new(project_name: "SmokeTest",
-                        content_structure: 1,
-                        bundle_dir: "spec/test_data/images_jp2_tif",
-                        staging_style_symlink: false,
-                        content_metadata_creation: 1,
-                        user: user)
-    end
-
-    let(:discovery_report_run) do
-      JobRun.new(output_location: "/path/to/report",
-                 bundle_context: bc,
-                 job_type: "discovery_report")
-    end
-
-    it "is not valid if it doesn't have the required fields" do
-      expect(JobRun.new).not_to be_valid
-      expect(discovery_report_run).to be_valid
-    end
-
-    context "#job_type enum" do
-      it "defines expected values" do
-        is_expected.to define_enum_for(:job_type).with(
-          "discovery_report" => 0,
-          "preassembly" => 1
-        )
-      end
-    end
-
-    it { is_expected.to belong_to(:bundle_context) }
-
-    context 'job_type' do
-      it 'valid values' do
-        expect(JobRun.new(job_type: 0, bundle_context: bc)).to be_valid
-        expect(JobRun.new(job_type: 1, bundle_context: bc)).to be_valid
-        expect(JobRun.new(job_type: 'discovery_report', bundle_context: bc)).to be_valid
-        expect(JobRun.new(job_type: 'preassembly', bundle_context: bc)).to be_valid
-      end
-      it 'throws ArgumentError if value missing from enum' do
-        expect { JobRun.new(job_type: 3, bundle_context: bc) }.to raise_error(ArgumentError, /'3' is not a valid job_type/)
-        expect { JobRun.new(job_type: 'foo', bundle_context: bc) }.to raise_error(ArgumentError, /'foo' is not a valid job_type/)
-      end
-      it 'is required' do
-        expect(JobRun.new(bundle_context: bc)).not_to be_valid
-      end
+  describe '#job_type enum' do
+    it 'defines expected values' do
+      is_expected.to define_enum_for(:job_type).with(
+        'discovery_report' => 0,
+        'preassembly' => 1
+      )
     end
   end
 
+  context 'validation' do
+    it 'is not valid without all required fields' do
+      expect(described_class.new(bundle_context: bc)).not_to be_valid
+      expect(discovery_report_run).to be_valid
+    end
+  end
 end


### PR DESCRIPTION
Wires in `JobRun` as param to both jobs and auto-`enqueue!`s objects via `after_create` hook.

Cleanups:
- Not everything is about validation, so don't nest under it in spec
- Don't need to confirm how enums work after identifying the values: that's rails internals
- `require 'rails_helper'` is handled by `.rspec`
- consolidate the presence validations in BC.

Part of #85 
closes #267