### PR TITLE
JobRun#job_type is required and it's preassembly without a hyphen

### DIFF
--- a/app/models/job_run.rb
+++ b/app/models/job_run.rb
@@ -1,8 +1,10 @@
 class JobRun < ApplicationRecord
   belongs_to :bundle_context
 
+  validates :job_type, presence: true
+
   enum job_type: {
     "discovery_report" => 0,
-    "pre_assembly" => 1
+    "preassembly" => 1
   }
 end

--- a/db/migrate/20180914014133_job_run_job_type_not_null.rb
+++ b/db/migrate/20180914014133_job_run_job_type_not_null.rb
@@ -1,0 +1,5 @@
+class JobRunJobTypeNotNull < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :job_runs, :job_type, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_10_225753) do
+ActiveRecord::Schema.define(version: 2018_09_14_014133) do
 
   create_table "bundle_contexts", force: :cascade do |t|
     t.string "project_name", null: false
@@ -26,7 +26,7 @@ ActiveRecord::Schema.define(version: 2018_09_10_225753) do
 
   create_table "job_runs", force: :cascade do |t|
     t.string "output_location"
-    t.integer "job_type"
+    t.integer "job_type", null: false
     t.integer "bundle_context_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/models/job_run_spec.rb
+++ b/spec/models/job_run_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe JobRun, type: :model do
+
   context "validation" do
     let(:user) do
       User.new(sunet_id: "Jdoe")
@@ -25,15 +26,33 @@ RSpec.describe JobRun, type: :model do
       expect(JobRun.new).not_to be_valid
       expect(discovery_report_run).to be_valid
     end
+
     context "#job_type enum" do
       it "defines expected values" do
         is_expected.to define_enum_for(:job_type).with(
           "discovery_report" => 0,
-          "pre_assembly" => 1
+          "preassembly" => 1
         )
       end
     end
 
     it { is_expected.to belong_to(:bundle_context) }
+
+    context 'job_type' do
+      it 'valid values' do
+        expect(JobRun.new(job_type: 0, bundle_context: bc)).to be_valid
+        expect(JobRun.new(job_type: 1, bundle_context: bc)).to be_valid
+        expect(JobRun.new(job_type: 'discovery_report', bundle_context: bc)).to be_valid
+        expect(JobRun.new(job_type: 'preassembly', bundle_context: bc)).to be_valid
+      end
+      it 'throws ArgumentError if value missing from enum' do
+        expect { JobRun.new(job_type: 3, bundle_context: bc) }.to raise_error(ArgumentError, /'3' is not a valid job_type/)
+        expect { JobRun.new(job_type: 'foo', bundle_context: bc) }.to raise_error(ArgumentError, /'foo' is not a valid job_type/)
+      end
+      it 'is required' do
+        expect(JobRun.new(bundle_context: bc)).not_to be_valid
+      end
+    end
   end
+
 end


### PR DESCRIPTION
Closes #252:

> -  add a migration that puts a NOT NULL constraint on the job_runs.job_type column.
> -  add a validation to the JobRun class that always expects the presence of job_type.
