### PR TITLE
Tweak BundleContextController and rework tests

### DIFF
--- a/app/controllers/bundle_context_controller.rb
+++ b/app/controllers/bundle_context_controller.rb
@@ -4,15 +4,10 @@ class BundleContextController < ApplicationController
   end
 
   def create
-    @bundle_context = BundleContext.new(bundle_context_params)
-
-    # TODO: ticket #270 user should be authenticated as saved in AR
-    user = User.create(sunet_id: 'temp')
-
-    @bundle_context.user = user
-    if @bundle_context.save
-      # TODO: ticket #267 Choose type of job (DiscoveryReport or Pre-Assembly) using params[:job_selection]
-      PreassemblyJob.perform_later
+    @bundle_context = BundleContext.create(bundle_context_params)
+    if @bundle_context.persisted?
+      # TODO: toggle job_type by extra param
+      @job_run = JobRun.create(bundle_context: @bundle_context, job_type: 'discovery_report')
     else
       render :index
     end
@@ -22,5 +17,6 @@ class BundleContextController < ApplicationController
 
   def bundle_context_params
     params.permit(:project_name, :content_structure, :content_metadata_creation, :bundle_dir)
+          .merge(user: current_user)
   end
 end

--- a/spec/controllers/bundle_context_controller_spec.rb
+++ b/spec/controllers/bundle_context_controller_spec.rb
@@ -1,71 +1,44 @@
 RSpec.describe BundleContextController, type: :controller do
-  context 'GET index' do
-    let(:bc) do
-      BundleContext.new(
-        project_name: "Smoke Test",
-        content_structure: "simple_image",
-        content_metadata_creation: "default",
-        bundle_dir: "spec/test_data/bundle_input_b",
-        user: user
-      )
-    end
+  let(:params) do
+    {
+      project_name: 'Smoke Test',
+      content_structure: 'simple_image',
+      content_metadata_creation: 'default',
+      bundle_dir: 'spec/test_data/smpl_multimedia'
+    }
+  end
 
+  before { sign_in(User.create(sunet_id: 'foo')) }
+
+  describe 'GET index' do
     it "renders the index template" do
       get :index
       expect(response).to render_template("index")
-    end
-    it "is successful" do
-      get :index
-      expect(response.status).to eq(200)
+      expect(response).to have_http_status(200)
     end
   end
 
   context "POST create" do
     context "Valid Parameters" do
-      let(:bc) { BundleContext.find_by(project_name: 'Smoke Test') }
+      before { post :create, params: params }
 
-      before do
-        post :create, params: { project_name: "Smoke Test",
-                                content_structure: "simple_image",
-                                content_metadata_creation: "default",
-                                bundle_dir: "spec/test_data/bundle_input_b" }
-      end
-
-      it "passes valid params" do
-        expect(response.status).to eq(200)
-      end
-      it 'saves BundleContext in db' do
-        expect(bc).to be_an_instance_of BundleContext
+      it 'passes newly created object' do
+        expect(assigns(:bundle_context)).to be_a(BundleContext).and be_persisted
+        expect(response).to have_http_status(200)
       end
       it 'has the correct attributes' do
+        bc = assigns(:bundle_context)
         expect(bc.project_name).to eq 'Smoke Test'
         expect(bc.content_structure).to eq "simple_image"
         expect(bc.content_metadata_creation).to eq "default"
-        expect(bc.bundle_dir).to eq "spec/test_data/bundle_input_b"
-      end
-      it 'calls preassembly job when job_selection is Pre-Assembly Job' do
-        # TODO: test PreassemblyJob.perform_later when job_selection is "Pre-Assembly Job"
-      end
-      it 'calls discovery report job when job_selection is Discovery Report' do
-        # TODO: test DiscoveryReportJob.performat_later when job_select is "Discovery Report"
+        expect(bc.bundle_dir).to eq "spec/test_data/smpl_multimedia"
       end
     end
 
     context "Invalid Parameters" do
-      let(:post_create) { post :create }
-
-      let(:bc) { BundleContext.find_by(bundle_dir: "spec/test_data/bundle_input_b") }
-
-      before do
-        post :create, params: { project_name: nil,
-                                content_structure: "simple_image",
-                                content_metadata_creation: "default",
-                                bundle_dir: "spec/test_data/bundle_input_b" }
-      end
-
-      it 'passes invalid params' do
-        expect(bc).to be_nil
-        expect(post_create).to render_template(:index)
+      it 'do not create objects' do
+        expect { post :create, params: params.merge(project_name: nil) }.not_to change(BundleContext, :count)
+        expect { post :create }.not_to change(BundleContext, :count)
       end
     end
   end


### PR DESCRIPTION
No need to separately `find_by` when rspec gives us the `assigns` method.  It gives the tests access to the **same** object the template would receive (even better than a different object -- or `nil` -- returned by `find_by`).

Uses devise helper `sign_in` method and removes hardcoded `User.create` in controller (meaning only one object could ever be created, since the subsequent `User.create` would certainly fail).

Controller is not concerned with Job directly, only with creating a `JobRun` object.

`current_user` is one of the `bundle_context_params`, logically.  Pass it to `.create`.

`bundle_input_b` doesn't exist anymore, and the model still requires the `bundle_dir` to exist to be valid (and saved). Changed it to `smpl_multimedia`.

This fixes the build.