### PR TITLE
bundle_context: project_name alphanum-ish only; output_dir uses project_name instead of bundle_dir

### DIFF
--- a/app/models/bundle_context.rb
+++ b/app/models/bundle_context.rb
@@ -5,7 +5,9 @@ class BundleContext < ApplicationRecord
   has_many :job_runs
   before_save :verify_output_dir
 
-  validates :bundle_dir, :content_metadata_creation, :content_structure, :project_name, presence: true
+  validates :bundle_dir, :content_metadata_creation, :content_structure, presence: true
+  validates :project_name, presence: true, format: { with: /\A[\w-]+\z/,
+    message: "only allows A-Z, a-z, 0-9, hyphen and underscore" }
   validates :staging_style_symlink, inclusion: { in: [true, false] }
 
   validate :verify_bundle_directory

--- a/spec/controllers/bundle_contexts_controller_spec.rb
+++ b/spec/controllers/bundle_contexts_controller_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe BundleContextsController, type: :controller do
     {
       bundle_context:
         {
-          project_name: 'Smoke Test',
+          project_name: 'SMPL-multimedia',
           content_structure: 'simple_image',
           content_metadata_creation: 'default',
           bundle_dir: 'spec/test_data/smpl_multimedia',
@@ -51,7 +51,7 @@ RSpec.describe BundleContextsController, type: :controller do
         end
         it 'has the correct attributes' do
           bc = assigns(:bundle_context)
-          expect(bc.project_name).to eq 'Smoke Test'
+          expect(bc.project_name).to eq 'SMPL-multimedia'
           expect(bc.content_structure).to eq "simple_image"
           expect(bc.content_metadata_creation).to eq "default"
           expect(bc.bundle_dir).to eq "spec/test_data/smpl_multimedia"
@@ -74,6 +74,12 @@ RSpec.describe BundleContextsController, type: :controller do
           expect { post :create, params: params }.not_to change(BundleContext, :count)
           expect { post :create, params: { bundle_context: {
             project_name: '',
+            content_structure: '',
+            content_metadata_creation: '',
+            bundle_dir: ''
+          }}}.not_to change(BundleContext, :count)
+          expect { post :create, params: { bundle_context: {
+            project_name: "SMPL's folly",
             content_structure: '',
             content_metadata_creation: '',
             bundle_dir: ''

--- a/spec/models/bundle_context_spec.rb
+++ b/spec/models/bundle_context_spec.rb
@@ -1,16 +1,16 @@
 RSpec.describe BundleContext, type: :model do
-  subject(:bc) do
-    BundleContext.new(
-      project_name: "Images jp2 tif",
+  let(:user) { User.new(sunet_id: "Jdoe@stanford.edu") }
+  let (:attr_hash) {
+    {
+      project_name: "Images_jp2_tif",
       content_structure: 1,
       bundle_dir: "spec/test_data/images_jp2_tif/",
       staging_style_symlink: false,
       content_metadata_creation: 1,
       user: user
-    )
-  end
-
-  let(:user) { User.new(sunet_id: "Jdoe@stanford.edu") }
+    }
+  }
+  subject(:bc) { BundleContext.new(attr_hash) }
 
   context "validation" do
     it "is not valid unless it has all required attributes" do
@@ -22,6 +22,25 @@ RSpec.describe BundleContext, type: :model do
     end
     it 'is not valid unless bundle_dir exists on filesystem' do
       expect { bc.bundle_dir = 'does/not/exist' }.to change(bc, :valid?).to(false)
+    end
+    it { is_expected.to validate_presence_of(:content_structure) }
+    it { is_expected.to validate_presence_of(:bundle_dir) }
+    it { is_expected.to validate_presence_of(:content_metadata_creation) }
+    describe 'project_name' do
+      it { is_expected.to validate_presence_of(:project_name) }
+      it 'is not valid with chars other than alphanum, hyphen and underscore' do
+        attr_hash[:project_name] = 's p a c e s'
+        expect(bc).not_to be_valid
+        attr_hash[:project_name] = "apostrophe's"
+        expect(bc).not_to be_valid
+        attr_hash[:project_name] = 'quotes"'
+        expect(bc).not_to be_valid
+      end
+      it 'is valid with alphanum, hyphen and underscore chars' do
+        valid_chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-'
+        attr_hash[:project_name] = valid_chars
+        expect(bc).to be_valid
+      end
     end
   end
 
@@ -42,10 +61,6 @@ RSpec.describe BundleContext, type: :model do
     )
   end
 
-  it { is_expected.to validate_presence_of(:project_name) }
-  it { is_expected.to validate_presence_of(:content_structure) }
-  it { is_expected.to validate_presence_of(:bundle_dir) }
-  it { is_expected.to validate_presence_of(:content_metadata_creation) }
   it { is_expected.to belong_to(:user) }
 
   it 'bundle_dir has trailing slash removed' do
@@ -96,7 +111,7 @@ RSpec.describe BundleContext, type: :model do
       # Settings.job_output_parent_dir for test from config/settings/test.yml as 'log/test_jobs'
       # bc.user.user_id above as 'Jdoe'
       # bc.bundle_dir above as 'spec/test_data/images_jp2_tif'
-      expect(bc.output_dir).to eq 'log/test_jobs/Jdoe/spec/test_data/images_jp2_tif'
+      expect(bc.output_dir).to eq 'log/test_jobs/Jdoe@stanford.edu/spec/test_data/images_jp2_tif'
     end
   end
 

--- a/spec/models/bundle_context_spec.rb
+++ b/spec/models/bundle_context_spec.rb
@@ -29,17 +29,15 @@ RSpec.describe BundleContext, type: :model do
     describe 'project_name' do
       it { is_expected.to validate_presence_of(:project_name) }
       it 'is not valid with chars other than alphanum, hyphen and underscore' do
-        attr_hash[:project_name] = 's p a c e s'
-        expect(bc).not_to be_valid
-        attr_hash[:project_name] = "apostrophe's"
-        expect(bc).not_to be_valid
-        attr_hash[:project_name] = 'quotes"'
-        expect(bc).not_to be_valid
+        expect { bc.project_name = 's p a c e s' }.to change(bc, :valid?).to(false)
+        bc.project_name = "apostrophe's"
+        expect(bc.valid?).to eq false
+        bc.project_name = 'quotes"'
+        expect(bc.valid?).to eq false
       end
       it 'is valid with alphanum, hyphen and underscore chars' do
         valid_chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-'
-        attr_hash[:project_name] = valid_chars
-        expect(bc).to be_valid
+        expect { bc.project_name = valid_chars }.not_to change(bc, :valid?).from(true)
       end
     end
   end

--- a/spec/models/job_run_spec.rb
+++ b/spec/models/job_run_spec.rb
@@ -1,13 +1,15 @@
 RSpec.describe JobRun, type: :model do
   let(:user) { User.new(sunet_id: 'Jdoe@stanford.edu') }
   let(:bc) do
-    BundleContext.new(id: 1,
-                      project_name: 'SmokeTest',
-                      content_structure: 1,
-                      bundle_dir: 'spec/test_data/bundle_input_g',
-                      staging_style_symlink: false,
-                      content_metadata_creation: 1,
-                      user: user)
+    bc = BundleContext.new(project_name: 'ImagesJp2Tif',
+                           content_structure: 1,
+                           bundle_dir: 'spec/test_data/images_jp2_tif',
+                           staging_style_symlink: false,
+                           content_metadata_creation: 1,
+                           user: user)
+    Dir.delete(bc.output_dir) if Dir.exist?(bc.output_dir)
+    bc.save
+    bc
   end
   let(:job_run) do
     described_class.new(output_location: '/path/to/report', bundle_context: bc, job_type: 'discovery_report')


### PR DESCRIPTION
Per instructions from Ben on Slack, captured in #78 comments, use the project name rather than the bundle dir in the output directory for a bundle context.

Also, per separate slack conversation, also captured in #78 comments, restrict the characters allowed for the project name.

Lastly, fixes broken travis build.

Connects to #78