### PR TITLE
JobRunsController

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,9 +32,8 @@ gem 'modsulator'
 group :test do
   gem 'coveralls', require: false
   gem 'equivalent-xml'
+  gem 'factory_bot_rails'
   gem 'shoulda-matchers', git: 'https://github.com/thoughtbot/shoulda-matchers.git', branch: 'rails-5'
-  # gem 'solr_wrapper' # for running integration structure locally
-  # gem 'jettywrapper' # for running integration structure locally
 end
 
 group :deployment do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,6 +212,11 @@ GEM
     erubi (1.7.1)
     erubis (2.7.0)
     execjs (2.7.0)
+    factory_bot (4.11.1)
+      activesupport (>= 3.0.0)
+    factory_bot_rails (4.11.1)
+      factory_bot (~> 4.11.1)
+      railties (>= 3.0.0)
     faraday (0.15.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
@@ -527,6 +532,7 @@ DEPENDENCIES
   dor-services (~> 5.29)
   equivalent-xml
   erubis
+  factory_bot_rails
   honeybadger (~> 3.1)
   jbuilder
   jquery-rails

--- a/app/assets/javascripts/job_runs.js
+++ b/app/assets/javascripts/job_runs.js
@@ -1,0 +1,2 @@
+// Place all the behaviors and hooks related to the matching controller here.
+// All this logic will automatically be available in application.js.

--- a/app/assets/stylesheets/job_runs.css
+++ b/app/assets/stylesheets/job_runs.css
@@ -1,0 +1,4 @@
+/*
+  Place all the styles related to the matching controller here.
+  They will automatically be included in application.css.
+*/

--- a/app/controllers/job_runs_controller.rb
+++ b/app/controllers/job_runs_controller.rb
@@ -1,0 +1,5 @@
+class JobRunsController < ApplicationController
+  def show
+    @job_run = JobRun.find(params[:id])
+  end
+end

--- a/app/models/bundle_context.rb
+++ b/app/models/bundle_context.rb
@@ -50,7 +50,7 @@ class BundleContext < ApplicationRecord
   end
 
   def output_dir
-    @output_dir ||= "#{normalize_dir(Settings.job_output_parent_dir)}/#{user.sunet_id}/#{bundle_dir}"
+    @output_dir ||= File.join(normalize_dir(Settings.job_output_parent_dir), user.email, bundle_dir)
   end
 
   def progress_log_file

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,9 @@
 class User < ApplicationRecord
   devise :remote_user_authenticatable # We don't want other (default) Devise modules
   has_many :bundle_contexts
-  validates :sunet_id, presence: true, uniqueness: true, null: false
+  validates :sunet_id, presence: true, uniqueness: true
 
   def email
     sunet_id.include?('@') ? sunet_id : "#{sunet_id}@stanford.edu"
   end
-
 end

--- a/app/views/job_runs/show.html.erb
+++ b/app/views/job_runs/show.html.erb
@@ -1,0 +1,5 @@
+<h2><%= job_run.job_type %> #<%= job_run.id %></h2>
+  <% for attribute in job_run.attributes.keys.sort %>
+    <p><%= attribute.humanize %> <%= job_run.attributes[attribute].to_s %></p>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,5 @@ Rails.application.routes.draw do
   devise_for :users, skip: :all
   root to: "bundle_contexts#index"
   resources :bundle_contexts
+  resources :job_runs, only: [:show]
 end

--- a/spec/controllers/bundle_contexts_controller_spec.rb
+++ b/spec/controllers/bundle_contexts_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe BundleContextsController, type: :controller do
           content_structure: 'simple_image',
           content_metadata_creation: 'default',
           bundle_dir: 'spec/test_data/smpl_multimedia',
-          job_runs_attributes: { "0" =>{ job_type: "preassembly" }}
+          job_runs_attributes: { "0" => { job_type: "preassembly" } }
         }
     }
   end
@@ -21,11 +21,10 @@ RSpec.describe BundleContextsController, type: :controller do
 
 
   context 'users persisted in db' do
-
-    before { sign_in(User.create(sunet_id: 'foo@stanford.edu')) }
+    before { sign_in(create :user) }
 
     it "should have current_user" do
-      expect(subject.current_user).to_not eq(nil)
+      expect(subject.current_user).not_to be_nil
     end
 
     context 'GET index' do

--- a/spec/controllers/job_runs_controller_spec.rb
+++ b/spec/controllers/job_runs_controller_spec.rb
@@ -1,7 +1,5 @@
 RSpec.describe JobRunsController, type: :controller do
-  let(:user) { User.create!(sunet_id: 'foo') }
-
-  before { sign_in(user) }
+  before { sign_in(create(:user)) }
 
   describe 'GET #show' do
     it 'returns http success' do

--- a/spec/controllers/job_runs_controller_spec.rb
+++ b/spec/controllers/job_runs_controller_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe JobRunsController, type: :controller do
+  let(:user) { User.create!(sunet_id: 'foo') }
+
+  before { sign_in(user) }
+
+  describe 'GET #show' do
+    it 'returns http success' do
+      allow(JobRun).to receive(:find).with('123').and_return(instance_double(JobRun))
+      get :show, params: { id: 123 }
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'requires ID param' do
+      expect { get :show }.to raise_error(ActionController::UrlGenerationError)
+    end
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :user do
+    sequence(:sunet_id) { |n| "fake_#{n}@stanford.edu" } # TODO: migrate this to an `email` field
+  end
+end

--- a/spec/mailers/job_mailer_spec.rb
+++ b/spec/mailers/job_mailer_spec.rb
@@ -1,10 +1,5 @@
-require "rails_helper"
-
 RSpec.describe JobMailer, type: :mailer do
-  let(:user) do
-    User.new(sunet_id: "Jdoe@stanford.edu")
-  end
-
+  let(:user) { build(:user, sunet_id: "Jdoe@stanford.edu") }
   let(:bc) do
     BundleContext.new(id: 1,
                       project_name: "SmokeTest",
@@ -14,15 +9,13 @@ RSpec.describe JobMailer, type: :mailer do
                       content_metadata_creation: 1,
                       user: user)
   end
-
   let(:discovery_report_run) do
     JobRun.new(id: 1,
                output_location: "/path/to/report",
                bundle_context: bc,
                job_type: "discovery_report")
   end
-
-  let(:job_notification) { JobMailer.with(job_run: discovery_report_run).completion_email }
+  let(:job_notification) { described_class.with(job_run: discovery_report_run).completion_email }
 
   it 'renders the headers' do
     expect(job_notification.subject).to eq("Your pre-assembly job has completed")
@@ -33,5 +26,4 @@ RSpec.describe JobMailer, type: :mailer do
   it 'renders the body' do
     expect(job_notification.body.encoded).to include("Your discovery_report job #1 completed")
   end
-
 end

--- a/spec/models/bundle_context_spec.rb
+++ b/spec/models/bundle_context_spec.rb
@@ -1,5 +1,4 @@
 RSpec.describe BundleContext, type: :model do
-  let(:user) { User.new(sunet_id: "Jdoe@stanford.edu") }
   let (:attr_hash) {
     {
       project_name: "Images_jp2_tif",
@@ -7,7 +6,7 @@ RSpec.describe BundleContext, type: :model do
       bundle_dir: "spec/test_data/images_jp2_tif/",
       staging_style_symlink: false,
       content_metadata_creation: 1,
-      user: user
+      user: build(:user, sunet_id: 'Jdoe@stanford.edu')
     }
   }
   subject(:bc) { BundleContext.new(attr_hash) }

--- a/spec/models/job_run_spec.rb
+++ b/spec/models/job_run_spec.rb
@@ -1,15 +1,16 @@
 RSpec.describe JobRun, type: :model do
-  let(:user) { User.new(sunet_id: 'Jdoe@stanford.edu') }
   let(:bc) do
-    bc = BundleContext.new(project_name: 'ImagesJp2Tif',
-                           content_structure: 1,
-                           bundle_dir: 'spec/test_data/images_jp2_tif',
-                           staging_style_symlink: false,
-                           content_metadata_creation: 1,
-                           user: user)
-    Dir.delete(bc.output_dir) if Dir.exist?(bc.output_dir)
-    bc.save
-    bc
+    BundleContext.new(
+      project_name: 'ImagesJp2Tif',
+      content_structure: 1,
+      bundle_dir: 'spec/test_data/images_jp2_tif',
+      staging_style_symlink: false,
+      content_metadata_creation: 1,
+      user: build(:user)
+    ).tap do |bc|
+      Dir.delete(bc.output_dir) if Dir.exist?(bc.output_dir)
+      bc.save!
+    end
   end
   let(:job_run) do
     described_class.new(output_location: '/path/to/report', bundle_context: bc, job_type: 'discovery_report')

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,8 +1,7 @@
 RSpec.describe User, type: :model do
+  subject(:user) { build(:user, sunet_id: 'jdoe@stanford.edu') }
 
   context "validation" do
-    subject(:user) { User.new(sunet_id: "jdoe@stanford.edu") }
-
     it "is not valid unless it has all required attributes" do
       expect(User.new).not_to be_valid
       expect(user).to be_valid
@@ -13,31 +12,24 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_many(:bundle_contexts) }
 
     describe 'enforces unique constraint on sunet_id' do
-      let(:required_attributes) do
-        { sunet_id: "tempdoe@stanford.edu" }
-      end
-
-      before { described_class.create!(required_attributes) }
+      before { user.save! }
 
       it 'at model level' do
-        expect { described_class.create!(required_attributes) }.to raise_error(ActiveRecord::RecordInvalid)
+        expect { described_class.create!(sunet_id: user.sunet_id) }.to raise_error(ActiveRecord::RecordInvalid)
       end
       it 'at db level' do
-        dup_user = described_class.new(sunet_id: "tempdoe@stanford.edu")
-        expect { dup_user.save!(validate: false) }.to raise_error(ActiveRecord::RecordNotUnique)
+        expect { user.dup.save!(validate: false) }.to raise_error(ActiveRecord::RecordNotUnique)
       end
     end
   end
-  context "email address" do
 
+  context "email address" do
     it "returns the user's email address if the sunet_id is already an address" do
-      user = User.new(sunet_id: 'jdoe@stanford.edu')
       expect(user.email).to eq('jdoe@stanford.edu')
     end
 
-    it "returns the user's email address if the sunet_id is not an email address" do
-      user = User.new(sunet_id: 'jdoe')
-      expect(user.email).to eq('jdoe@stanford.edu')
+    it 'returns a stanford.edu email address if the sunet_id is not an email address' do
+      expect { user.sunet_id = 'jdoe' }.not_to change(user, :email).from('jdoe@stanford.edu')
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,6 +17,8 @@ Dir[Rails.root.join('spec', 'support', '*.rb')].each { |f| require f }
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   # config.fixture_path = "#{::Rails.root}/spec/fixtures"
 

--- a/spec/support/bundle_setup.rb
+++ b/spec/support/bundle_setup.rb
@@ -13,11 +13,9 @@ def noko_doc(x)
 end
 
 def bundle_context_from_hash(proj)
-  user = User.create(sunet_id: "Jdoe@stanford.edu")
-
+  user = build(:user, sunet_id: 'Jdoe@stanford.edu')
   cmc = hash_from_proj(proj)["content_md_creation"]["style"]
   cmc = cmc + "_cm_style" if cmc == "smpl"
-
   bc = BundleContext.new(
     project_name: hash_from_proj(proj)["project_name"],
     content_structure: hash_from_proj(proj)["project_style"]["content_structure"],

--- a/spec/views/job_runs/show.html.erb_spec.rb
+++ b/spec/views/job_runs/show.html.erb_spec.rb
@@ -1,0 +1,5 @@
+RSpec.describe 'job_runs/show.html.erb', type: :view do
+  it 'displays a job_run' do
+    skip 'gimme factories'
+  end
+end


### PR DESCRIPTION
Started with `rails generate controller JobRuns show`.

With modifications for `JobRun.find` and devise integration in spec.

Introduced FactoryBot and added a factory for users, converting specs over to use the factory where applicable.  I propose merging this as is to enable @jermnelson to work more on the `JobRunsController` UI.  Meanwhile, I will work on adding the other factories (ultimately to include one for `JobRun`).  

One TODO that would make sense (and we currently don't have) is a `:show` template partial for a `BundleContext`.  If we had one, I would probably try to reuse it in the `JobRun` show template (at least, when the job has not yet completed).  Most of the "input" the user cares about is in the BC object, so it makes sense to display that alongside (or immediately before downloading) the output.

Closes #300.