### PR TITLE
bundle_context: output_dir REALLY uses project_name

### DIFF
--- a/app/models/bundle_context.rb
+++ b/app/models/bundle_context.rb
@@ -1,5 +1,3 @@
-require 'fileutils'
-
 class BundleContext < ApplicationRecord
   belongs_to :user
   has_many :job_runs

--- a/app/models/bundle_context.rb
+++ b/app/models/bundle_context.rb
@@ -48,7 +48,7 @@ class BundleContext < ApplicationRecord
   end
 
   def output_dir
-    @output_dir ||= File.join(normalize_dir(Settings.job_output_parent_dir), user.email, bundle_dir)
+    @output_dir ||= File.join(normalize_dir(Settings.job_output_parent_dir), user.email, project_name)
   end
 
   def progress_log_file

--- a/spec/controllers/bundle_contexts_controller_spec.rb
+++ b/spec/controllers/bundle_contexts_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe BundleContextsController, type: :controller do
 
     context "POST create" do
       context "Valid Parameters" do
-        let(:output_dir) { "#{Settings.job_output_parent_dir}/#{subject.current_user.sunet_id}/spec/test_data/smpl_multimedia" }
+        let(:output_dir) { "#{Settings.job_output_parent_dir}/#{subject.current_user.sunet_id}/SMPL-multimedia" }
         before do
           Dir.delete(output_dir) if Dir.exist?(output_dir)
           post :create, params: params

--- a/spec/lib/pre_assembly/bundle_spec.rb
+++ b/spec/lib/pre_assembly/bundle_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe PreAssembly::Bundle do
     it 'runs images_jp2_tif cleanly using images_jp2_tif.yaml for options' do
       bc = bundle_context_from_hash('images_jp2_tif')
       # need to delete progress log to ensure this test doesn't skip objects already run
-      File.delete(bc.progress_log_file) if File.exist?(bc.progress_log_file)
+      FileUtils.rm_rf(bc.output_dir) if Dir.exist?(bc.output_dir)
+      bc.save
 
       b = PreAssembly::Bundle.new bc
       b.manifest_rows.each {|row| row.merge!("object" => row["folder"]) }

--- a/spec/models/bundle_context_spec.rb
+++ b/spec/models/bundle_context_spec.rb
@@ -104,11 +104,8 @@ RSpec.describe BundleContext, type: :model do
   end
 
   describe 'output_dir' do
-    it 'returns "Settings.job_output_parent_dir/user_id/bundle_dir"' do
-      # Settings.job_output_parent_dir for test from config/settings/test.yml as 'log/test_jobs'
-      # bc.user.user_id above as 'Jdoe'
-      # bc.bundle_dir above as 'spec/test_data/images_jp2_tif'
-      expect(bc.output_dir).to eq 'log/test_jobs/Jdoe@stanford.edu/spec/test_data/images_jp2_tif'
+    it 'returns "Settings.job_output_parent_dir/user_id/project_name"' do
+      expect(bc.output_dir).to eq "#{Settings.job_output_parent_dir}/#{bc.user.sunet_id}/#{bc.project_name}"
     end
   end
 
@@ -158,7 +155,7 @@ RSpec.describe BundleContext, type: :model do
     context 'bundle_context is new' do
       it 'creates directory' do
         bc.bundle_dir = 'i_do_not_exist'
-        Dir.delete(bc.output_dir) if Dir.exist?(bc.output_dir)
+        FileUtils.rm_rf(bc.output_dir) if Dir.exist?(bc.output_dir)
         expect(Dir.exist?(bc.output_dir)).to eq false
         bc.send(:verify_output_dir)
         expect(Dir.exist?(bc.output_dir)).to eq true

--- a/spec/support/bundle_setup.rb
+++ b/spec/support/bundle_setup.rb
@@ -16,7 +16,8 @@ def bundle_context_from_hash(proj)
   user = build(:user, sunet_id: 'Jdoe@stanford.edu')
   cmc = hash_from_proj(proj)["content_md_creation"]["style"]
   cmc = cmc + "_cm_style" if cmc == "smpl"
-  bc = BundleContext.new(
+
+  BundleContext.new(
     project_name: hash_from_proj(proj)["project_name"],
     content_structure: hash_from_proj(proj)["project_style"]["content_structure"],
     bundle_dir: hash_from_proj(proj)["bundle_dir"],
@@ -24,6 +25,4 @@ def bundle_context_from_hash(proj)
     content_metadata_creation: cmc ,
     user: user
   )
-  allow(bc).to receive(:progress_log_file).and_return(hash_from_proj(proj)["progress_log_file"])
-  bc
 end

--- a/spec/test_data/project_config_files/flat_dir_images.yaml
+++ b/spec/test_data/project_config_files/flat_dir_images.yaml
@@ -11,7 +11,7 @@ checksums_file:       'checksums.txt'
 desc_md_template:     'mods_template.xml'
 
 progress_log_file:    'log/progress_flat_dir_images.yaml'
-project_name:         'Flat Dir Images'
+project_name:         'Flat_Dir_Images'
 
 validate_files:       false
 

--- a/spec/test_data/project_config_files/images_jp2_tif.yaml
+++ b/spec/test_data/project_config_files/images_jp2_tif.yaml
@@ -16,7 +16,7 @@ checksums_file:        ~
 desc_md_template:     'mods_template.xml'
 
 progress_log_file:    'log/progress_log_images_jp2_tiff.yaml'
-project_name:         'Images jp2 tif'
+project_name:         'Images_jp2_tif'
 
 publish_attr:
   'image/jp2':

--- a/spec/test_data/project_config_files/obj_dirs_images.yaml
+++ b/spec/test_data/project_config_files/obj_dirs_images.yaml
@@ -11,7 +11,7 @@ checksums_file:       ~
 desc_md_template:     'mods_template.xml'
 
 progress_log_file:    'log/progress_obj_dirs_images.yaml'
-project_name:         'Object Directories with Images'
+project_name:         'Object_Directories_with_Images'
 
 validate_files:       false
 

--- a/spec/test_data/project_config_files/smpl_multimedia.yaml
+++ b/spec/test_data/project_config_files/smpl_multimedia.yaml
@@ -15,7 +15,7 @@ checksums_file:       ~
 desc_md_template:     'mods_template.xml'
 
 progress_log_file:    'log/progress_log_smpl_multimedia.yaml'
-project_name:         'SMPL Multimedia'
+project_name:         'SMPL_Multimedia'
 
 publish_attr:
   publish:            'no'


### PR DESCRIPTION
in addition to fixing my goof with output_dir:

- removes unnec require in bundle_context
- spec/support/bundle_setup can now rely on bc.progress_log_file

connects to #78 

Closes #317 