### PR TITLE
empty_object logic fix and Dor::Item find druid fix

### DIFF
--- a/app/services/discovery_report.rb
+++ b/app/services/discovery_report.rb
@@ -59,7 +59,7 @@ class DiscoveryReport
     { druid: dobj.druid.druid, errors: errors.compact, counts: counts }
   end
 
-  # @param [String] druid
+  # @param [DruidTools]
   # @return [Hash<Symbol => Boolean>] errors
   def registration_check(druid)
     begin

--- a/app/services/discovery_report.rb
+++ b/app/services/discovery_report.rb
@@ -52,7 +52,7 @@ class DiscoveryReport
       errors[:files_found_mismatch] = true unless counts[:files_in_manifest] == counts[:files_found]
     end
 
-    errors[:empty_object] = true if counts[:total_size] > 0
+    errors[:empty_object] = true unless counts[:total_size] > 0
     errors[:missing_files] = true unless dobj.object_files_exist?
     errors[:dupes] = true unless object_filenames_unique?(dobj)
     errors.merge!(registration_check(dobj.druid))
@@ -63,7 +63,7 @@ class DiscoveryReport
   # @return [Hash<Symbol => Boolean>] errors
   def registration_check(druid)
     begin
-      obj = Dor::Item.find(druid)
+      obj = Dor::Item.find(druid.druid)
     rescue ActiveFedora::ObjectNotFoundError
       return { item_not_registered: true }
     end

--- a/spec/services/discovery_report_spec.rb
+++ b/spec/services/discovery_report_spec.rb
@@ -72,4 +72,37 @@ RSpec.describe DiscoveryReport do
       end
     end
   end
+
+  context "integration test" do
+    let(:bc_params) do
+      {
+        project_name: "SmokeTest",
+        content_structure: 0,
+        bundle_dir: 'spec/test_data/images_jp2_tif',
+        staging_style_symlink: false,
+        content_metadata_creation: 0,
+        user: build(:user, sunet_id: 'jdoe@stanford.edu')
+      }
+    end
+    let(:bundle_context) {BundleContext.new(bc_params) }
+    let(:bundle) { PreAssembly::Bundle.new(bundle_context) }
+    let(:dobj) { report.bundle.objects_to_process.first }
+
+    before do
+      allow(dobj).to receive(:pid).and_return("kk203bw3276")
+      allow(report).to receive(:registration_check).and_return({}) # pretend everything is in Dor
+    end
+
+    it "matches the expected output " do
+      expect(report.process_dobj(dobj)).to eq ({
+        druid: "druid:kk203bw3276",
+        errors: {dupes: true},
+        counts: {total_size: 254802, mimetypes: {"image/tiff"=>4, "image/jp2"=>2},
+        filename_no_extension: 0}
+      })
+      expect(report.summary).to include({
+        :objects_with_error=>0, :mimetypes=>{}, :total_size=>0
+      })      
+    end
+  end
 end

--- a/spec/services/discovery_report_spec.rb
+++ b/spec/services/discovery_report_spec.rb
@@ -51,5 +51,25 @@ RSpec.describe DiscoveryReport do
         druid: 'druid:kk203bw3276'
       )
     end
+
+    context "folders are empty" do
+      it "adds empty_object error" do
+        expect(report.process_dobj(dobj)).to match a_hash_including(errors: a_hash_including(empty_object: true))
+      end
+    end
+
+    context "folders are not empty" do
+      let(:obj_file) { instance_double(PreAssembly::ObjectFile, path: "random/path", filesize: 324, mimetype: "")}
+
+      before do
+        allow(dobj).to receive(:object_files).and_return([obj_file, obj_file])
+        allow(report).to receive(:using_smpl_manifest?).and_return(false)
+        allow(report).to receive(:registration_check).and_return({}) # pretend everything is in Dor
+      end
+
+      it "does not add empty_object error" do
+        expect(report.process_dobj(dobj)).not_to include(a_hash_including(empty_object: true))
+      end
+    end
   end
 end


### PR DESCRIPTION
- Dor::Item find takes in a druid not druid tool object
- empty_object logic was backwards
- 2 RSpec tests to test the fixed logic.

closes #306 
connects #237