### PR TITLE
Use sqlite adapter in test and dev.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,6 @@ env:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 
 cache: bundler
-services:
-- postgresql
-
-before_script:
-- bundle exec rake travis_setup_postgres db:reset
 
 rvm:
   - 2.4.4

--- a/README.md
+++ b/README.md
@@ -230,37 +230,6 @@ To make your life easier, it's easiest to put this in your bash profile so you d
 
 ### Prerequisites
 
-#### PostgreSQL
-
-##### Installing Postgres
-
-If you use homebrew you can install PostgreSQL with:
-```sh
-brew install postgresql
-```
-
-Make sure Postgres starts every time your computer starts up.
-```sh
-brew services start postgresql
-```
-
-Check to see if Postgres is installed with `postgres -V` and that it's accepting connections with `pg_isready`.
-
-##### Configuring Postgres
-
-Using the `psql` utility, run these two setup scripts from the command line, like so:
-```sh
-psql -f db/scripts/preassembly_setup.sql postgres
-psql -f db/scripts/preassembly_test_setup.sql postgres
-```
-
-These scripts do the following for you:
-* create the test and dev PostgreSQL users.
-* create the test and dev databases.
-* setup the needed ownership and permissions between the DBs and the users.
-
-For more info on postgres commands, see https://www.postgresql.org/docs/
-
 #### exiftool
 
 You need exiftool on your system in order to successfully run all of the tests.

--- a/Rakefile
+++ b/Rakefile
@@ -2,8 +2,5 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require_relative 'config/application'
-Rails.application.load_tasks
 
-task :travis_setup_postgres do
-  sh("psql -f db/scripts/preassembly_test_setup.sql postgres")
-end
+Rails.application.load_tasks

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,16 +1,30 @@
+# SQLite version 3.x
+#   gem install sqlite3
+#
+#   Ensure the SQLite 3 gem is defined in your Gemfile
+#   gem 'sqlite3'
+#
 default: &default
-  adapter: postgresql
-  encoding: unicode
-  # For details on connection pooling, see rails configuration guide
-  # http://guides.rubyonrails.org/configuring.html#database-pooling
+  adapter: sqlite3
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  timeout: 5000
 
 development:
   <<: *default
-  database: preassembly
-  username: preassembly
+  database: db/development.sqlite3
 
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: preassembly_test
-  username: preassembly_test
+  database: db/test.sqlite3
+
+# NOTE: this never gets used.
+# Actual production database.yml file (and setup) controlled by puppet, uses postgres.
+production:
+  <<: *default
+  adapter: postgresql
+  encoding: unicode
+  database: preassembly
+  username: preassembly

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,16 +12,13 @@
 
 ActiveRecord::Schema.define(version: 2018_09_14_014133) do
 
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
-
   create_table "bundle_contexts", force: :cascade do |t|
     t.string "project_name", null: false
     t.integer "content_structure", null: false
     t.string "bundle_dir", null: false
     t.boolean "staging_style_symlink", default: false, null: false
     t.integer "content_metadata_creation", null: false
-    t.bigint "user_id", null: false
+    t.integer "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_bundle_contexts_on_user_id"
@@ -30,7 +27,7 @@ ActiveRecord::Schema.define(version: 2018_09_14_014133) do
   create_table "job_runs", force: :cascade do |t|
     t.string "output_location"
     t.integer "job_type", null: false
-    t.bigint "bundle_context_id", null: false
+    t.integer "bundle_context_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["bundle_context_id"], name: "index_job_runs_on_bundle_context_id"
@@ -43,6 +40,4 @@ ActiveRecord::Schema.define(version: 2018_09_14_014133) do
     t.index ["sunet_id"], name: "index_users_on_sunet_id", unique: true
   end
 
-  add_foreign_key "bundle_contexts", "users"
-  add_foreign_key "job_runs", "bundle_contexts"
 end

--- a/db/scripts/preassembly_setup.sql
+++ b/db/scripts/preassembly_setup.sql
@@ -1,5 +1,0 @@
-CREATE USER preassembly;
-ALTER USER preassembly CREATEDB;
-CREATE DATABASE preassembly;
-ALTER DATABASE preassembly OWNER TO preassembly;
-GRANT ALL PRIVILEGES ON DATABASE preassembly TO preassembly;

--- a/db/scripts/preassembly_test_setup.sql
+++ b/db/scripts/preassembly_test_setup.sql
@@ -1,5 +1,0 @@
-CREATE USER preassembly_test;
-ALTER USER preassembly_test CREATEDB;
-CREATE DATABASE preassembly_test;
-ALTER DATABASE preassembly_test OWNER TO preassembly_test;
-GRANT ALL PRIVILEGES ON DATABASE preassembly_test TO preassembly_test;


### PR DESCRIPTION
Largely a reversion of "postgres initialization scripts for dev and test"

No initialization (or configuration) is required for prod, because the `database.yml` and database setup itself is performed by Puppet.

Fixes #288