### PR TITLE
File attr

### DIFF
--- a/app/lib/pre_assembly/bundle.rb
+++ b/app/lib/pre_assembly/bundle.rb
@@ -17,7 +17,6 @@ module PreAssembly
              :content_exclusion,
              :content_md_creation,
              :content_structure,
-             :file_attr,
              :manifest_cols,
              :manifest_rows,
              :path_in_bundle,
@@ -107,7 +106,6 @@ module PreAssembly
       {
         :bundle_dir           => bundle_dir,
         :content_md_creation  => content_md_creation,
-        :file_attr            => file_attr,
         :project_name         => project_name,
         :project_style        => content_structure,
         :smpl_manifest        => smpl_manifest,

--- a/app/lib/pre_assembly/digital_object.rb
+++ b/app/lib/pre_assembly/digital_object.rb
@@ -5,51 +5,42 @@ module PreAssembly
     include PreAssembly::Logging
 
     INIT_PARAMS = [
-      :container,
-      :unadjusted_container,
-      :stageable_items,
-      :object_files,
-      :project_style,
-      :project_name,
-      :file_attr,
-      :bundle_dir,
       :assembly_staging_dir,
+      :bundle_dir,
+      :container,
       :content_md_creation,
+      :object_files,
+      :project_name,
+      :project_style,
+      :smpl_manifest,
+      :stageable_items,
       :staging_style,
-      :smpl_manifest
+      :unadjusted_container
     ]
 
-    attr_accessor :label,
-                  :content_md_file,
-                  :technical_md_file,
+    attr_accessor :content_md_file,
                   :content_md_xml,
-                  :technical_md_xml,
-                  :pre_assem_finished,
                   :content_structure,
+                  :label,
+                  :manifest_row,
+                  :pre_assem_finished,
                   :source_id,
-                  :manifest_row
+                  :technical_md_file,
+                  :technical_md_xml
 
     attr_writer :dor_object, :druid_tree_dir
 
     INIT_PARAMS.each { |p| attr_accessor p }
 
-    ####
-    # Initialization.
-    ####
-
+    # @param [Hash] params
     def initialize(params = {})
       INIT_PARAMS.each { |p| instance_variable_set "@#{p}", params[p] }
-      self.file_attr ||= params[:publish_attr]
-      setup
-    end
-
-    def setup
-      self.label              = 'Unknown' # used for registration when no label is provided in the manifest
-      self.content_md_file    = 'contentMetadata.xml'
-      self.technical_md_file  = 'technicalMetadata.xml'
-      self.content_md_xml     = ''
-      self.technical_md_xml   = ''
-      self.content_structure  = (project_style ? project_style : 'file')
+      self.label             = 'Unknown' # used for registration when no label is provided in the manifest
+      self.content_md_file   = 'contentMetadata.xml'
+      self.technical_md_file = 'technicalMetadata.xml'
+      self.content_md_xml    = ''
+      self.technical_md_xml  = ''
+      self.content_structure = (project_style ? project_style : 'file')
     end
 
     def stager(source, destination)
@@ -223,9 +214,6 @@ module PreAssembly
       else
         # otherwise use the content metadata generation gem
         params = { :druid => druid.id, :objects => content_object_files, :add_exif => false, :bundle => content_md_creation.to_sym, :style => content_md_creation_style }
-
-        params.merge!(:add_file_attributes => true, :file_attributes => file_attr.stringify_keys) unless file_attr.nil?
-
         self.content_md_xml = Assembly::ContentMetadata.create_content_metadata(params)
       end
     end

--- a/spec/lib/pre_assembly/smpl_spec.rb
+++ b/spec/lib/pre_assembly/smpl_spec.rb
@@ -63,12 +63,10 @@ RSpec.describe PreAssembly::Smpl do
 
   def setup_dobj(druid, smpl_manifest)
     ps = {
-      # :apo_druid_id  => 'qq333xx4444',
-      # :set_druid_id  => 'mm111nn2222',
       :source_id     => 'SourceIDFoo',
       :project_name  => 'ProjectBar',
       :label         => 'LabelQuux',
-      :publish_attr  => { :publish => 'no', :shelve => 'no', :preserve => 'yes' },
+      # :publish_attr  => { :publish => 'no', :shelve => 'no', :preserve => 'yes' },
       :project_style => {},
       :bundle_dir    => bundle_dir,
       :smpl_manifest => smpl_manifest,
@@ -82,7 +80,7 @@ RSpec.describe PreAssembly::Smpl do
   end
 
   def exp_xml_object_aa111aa1111
-    <<-END.gsub(/^ {8}/, '')
+    <<-END
     <?xml version="1.0"?>
          <contentMetadata type="media" objectId="aa111aa1111">
            <resource type="media" sequence="1" id="aa111aa1111_1">
@@ -122,7 +120,7 @@ RSpec.describe PreAssembly::Smpl do
   end
 
   def exp_xml_object_aa111aa1111_with_thumb
-    <<-END.gsub(/^ {8}/, '')
+    <<-END
     <?xml version="1.0"?>
          <contentMetadata type="media" objectId="aa111aa1111">
            <resource type="media" sequence="1" id="aa111aa1111_1" thumb="yes">
@@ -162,7 +160,7 @@ RSpec.describe PreAssembly::Smpl do
   end
 
   def exp_xml_object_bb222bb2222
-    <<-END.gsub(/^ {8}/, '')
+    <<-END
             <?xml version="1.0"?>
             <contentMetadata objectId="bb222bb2222" type="media">
               <resource sequence="1" id="bb222bb2222_1" type="media">


### PR DESCRIPTION
Broken off from #337 
Fixes #228

This functionality relates to content metadata generation and was well tested, so it is probably wise to have Ben sign off that some other part of the ecosystem is responsible for this or that indeed it is
unneeded for the app MVP.