### PR TITLE
Smpl console work

### DIFF
--- a/app/services/discovery_report.rb
+++ b/app/services/discovery_report.rb
@@ -86,11 +86,11 @@ class DiscoveryReport
 
   # @return [Boolean]
   def using_smpl_manifest?
-    content_md_creation == :smpl && File.exist?(File.join(bundle_dir, bundle.bundle_context.smpl_manifest))
+    content_md_creation == "smpl_cm_style" && File.exist?(File.join(bundle_dir, bundle.bundle_context.smpl_manifest))
   end
 
   # @return [PreAssembly::Smpl]
   def smpl
-    @smpl ||= PreAssembly::Smpl.new(csv_filename: content_md_creation[:smpl_manifest], bundle_dir: bundle_dir)
+    @smpl ||= PreAssembly::Smpl.new(csv_filename: bundle.bundle_context.smpl_manifest, bundle_dir: bundle_dir)
   end
 end

--- a/app/services/discovery_report.rb
+++ b/app/services/discovery_report.rb
@@ -47,7 +47,7 @@ class DiscoveryReport
       cm_files = smpl.manifest[bundle_id].fetch(:files, [])
       counts[:files_in_manifest] = cm_files.count
       relative_paths = dobj.object_files.map(&:relative_path)
-      counts[:files_found] = (cm_files.map(&:filename) & relative_paths).count
+      counts[:files_found] = (cm_files.pluck(:filename) & relative_paths).count
       errors[:empty_manifest] = true unless counts[:files_in_manifest] > 0
       errors[:files_found_mismatch] = true unless counts[:files_in_manifest] == counts[:files_found]
     end


### PR DESCRIPTION
- made a few changes so when i run discovery_report w/ a SMPL manifest / SMPL project it works.
this is the output i get when running: 
```
irb(main):022:0> discovery_report.process_dobj(first_digital_object)
=> {:druid=>"druid:aa111aa1111", :errors=>{:dupes=>true, :item_not_registered=>true}, :counts=>{:total_size=>31552, :mimetypes=>{"image/jpeg"=>4, ""=>16, "application/xml"=>6, "audio/x-wav"=>8, "audio/mpeg"=>4, "application/pdf"=>2}, :filename_no_extension=>0, :files_in_manifest=>9, :files_found=>9}}



```