### PR TITLE
DigitalObjects.new takes a Bundle, instead of a big hash proxy for a bundle

### DIFF
--- a/app/models/bundle_context.rb
+++ b/app/models/bundle_context.rb
@@ -11,7 +11,7 @@ class BundleContext < ApplicationRecord
   validate :verify_bundle_directory
   validate :verify_content_metadata_creation
 
-  after_initialize :normalize_bundle_dir
+  after_initialize :normalize_bundle_dir, :default_enums
 
   enum content_structure: {
     "simple_image" => 0,
@@ -99,6 +99,11 @@ class BundleContext < ApplicationRecord
   end
 
   private
+
+  def default_enums
+    self[:content_structure] ||= 0
+    self[:content_metadata_creation] ||= 0
+  end
 
   def normalize_dir(dir)
     dir.chomp('/') if dir

--- a/app/services/discovery_report.rb
+++ b/app/services/discovery_report.rb
@@ -48,7 +48,7 @@ class DiscoveryReport
     errors[:empty_files] = empty_files if empty_files > 0
 
     if using_smpl_manifest? # if we are using a SMPL manifest, let's add how many files were found
-      bundle_id = File.basename(dobj.unadjusted_container)
+      bundle_id = File.basename(dobj.container)
       cm_files = smpl.manifest[bundle_id].fetch(:files, [])
       counts[:files_in_manifest] = cm_files.count
       relative_paths = dobj.object_files.map(&:relative_path)

--- a/spec/lib/pre_assembly/bundle_spec.rb
+++ b/spec/lib/pre_assembly/bundle_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe PreAssembly::Bundle do
 
     it "returns a filtered list of digital objects" do
       flat_dir_images.skippables = {}
-      flat_dir_images.skippables[flat_dir_images.digital_objects[-1].unadjusted_container] = true
+      flat_dir_images.skippables[flat_dir_images.digital_objects.last.container] = true
       o2p = flat_dir_images.objects_to_process
       expect(o2p.size).to eq(flat_dir_images.digital_objects.size - 1)
       expect(o2p).to eq(flat_dir_images.digital_objects[0..-2])
@@ -199,7 +199,7 @@ RSpec.describe PreAssembly::Bundle do
     it "returns expected info about a digital object" do
       dobj = flat_dir_images.digital_objects[0]
       exp = {
-        :unadjusted_container => dobj.unadjusted_container,
+        :container => dobj.container,
         :pid                  => dobj.pid,
         :pre_assem_finished   => dobj.pre_assem_finished,
         :timestamp            => Time.now.strftime('%Y-%m-%d %H:%I:%S')

--- a/spec/models/bundle_context_spec.rb
+++ b/spec/models/bundle_context_spec.rb
@@ -21,8 +21,9 @@ RSpec.describe BundleContext, type: :model do
     it { is_expected.to validate_presence_of(:content_structure) }
     it { is_expected.to validate_presence_of(:bundle_dir) }
     it { is_expected.to validate_presence_of(:content_metadata_creation) }
+    it { is_expected.to validate_presence_of(:project_name) }
+
     describe 'project_name' do
-      it { is_expected.to validate_presence_of(:project_name) }
       it 'is not valid with chars other than alphanum, hyphen and underscore' do
         expect { bc.project_name = 's p a c e s' }.to change(bc, :valid?).to(false)
         bc.project_name = "apostrophe's"
@@ -55,6 +56,12 @@ RSpec.describe BundleContext, type: :model do
   end
 
   it { is_expected.to belong_to(:user) }
+
+  it 'enums default to their default values' do
+    bc = described_class.new
+    expect(bc.content_structure).to eq 'simple_image'
+    expect(bc.content_metadata_creation).to eq 'default'
+  end
 
   it 'bundle_dir has trailing slash removed' do
     expect(bc.bundle_dir).to eq "spec/test_data/images_jp2_tif"

--- a/spec/test_data/input/mock_progress_log.yaml
+++ b/spec/test_data/input/mock_progress_log.yaml
@@ -1,12 +1,12 @@
 --- 
 :pre_assem_finished: true
-:unadjusted_container: aa
+:container: aa
 :pid: druid:cb837cp4412
---- 
+---
 :pre_assem_finished: true
-:unadjusted_container: bb
+:container: bb
 :pid: druid:cm057cr1745
---- 
+---
 :pre_assem_finished: false
-:unadjusted_container: cc
+:container: cc
 :pid: druid:cp898cs9946


### PR DESCRIPTION
Extends #338 

`DigitalObject` initialization previously required ugly, error-prone massive Hashes that were almost entirely derived from the `Bundle` initializing it.  Solution: pass the bundle object instead of a proxy. This reduces memory footprint and logical divergence, since the operative data element stays w/ the instance where it lives, instead of having been copied into a hash with *slightly* different naming conventions.

Also:
- removes `unadjusted_container`, which is never any different than `container`
- only 3 `INIT_PARAMS` now
  - anything beyond those 3 raises!  No more silent garbage initialization (which was happening in specs!)
- `BundleContext` enums now assume default values upon initialization
- test cleanup with factories and structure

Fixes #271 