### PR TITLE
Remove "Return to Argo" button

### DIFF
--- a/app/views/bundle_contexts/create.html.erb
+++ b/app/views/bundle_contexts/create.html.erb
@@ -1,19 +1,16 @@
 
 <div class="container mx-auto mt-5" style="width: 50em">
   <div class="card">
-  <div class="card-body">
-    <h5 class="card-title">
-      <i class="far fa-check-circle text-success"></i>
-      Success! Your job is queued.</h5>
-    <p class="card-text">A link to your validation report will be emailed to you when it is ready.</p>
-    <p class="card-text">
-      If your file has any errors, an email notification will be sent to you, and
-      you can restart the job where it left off.</p>
-
+    <div class="card-body">
+      <h5 class="card-title">
+        <i class="far fa-check-circle text-success"></i>
+        Success! Your job is queued.
+      </h5>
+      <p class="card-text">A link to your validation report will be emailed to you when it is ready.</p>
+      <p class="card-text">
+        If your file has any errors, an email notification will be sent to you, and
+        you can restart the job where it left off.
+      </p>
     </div>
-    <div class="mx-auto mb-2">
-      <a href="https://argo.stanford.edu/"
-         class="btn btn-sul-dlss">Return to Argo</a>
-    </div>
-</div>
+  </div>
 </div>


### PR DESCRIPTION
We can add this or an alternative link back later, but right now the flow is not necessarily going to involve Argo anyway.  If any link "from" Argo opens in a new tab (probably should), then linking back is
less useful than closing the current tab.

Fixes #313