### PR TITLE
Call super in ObjectFile subclass initializer

### DIFF
--- a/app/lib/pre_assembly/bundle.rb
+++ b/app/lib/pre_assembly/bundle.rb
@@ -144,9 +144,10 @@ module PreAssembly
       digital_objects.map(&:object_files).flatten
     end
 
+    # @return [PreAssembly::ObjectFile]
     def new_object_file(stageable, file_path)
       ObjectFile.new(
-        path: file_path,
+        file_path,
         relative_path: relative_path(get_base_dir(stageable), file_path),
         exclude_from_content: exclude_from_content(file_path)
       )
@@ -163,7 +164,7 @@ module PreAssembly
     # sets the checksum attribute.
     def load_checksums(dobj)
       log '  - load_checksums()'
-      dobj.object_files.each { |file| file.checksum = file.md5 }
+      dobj.object_files.each { |file| file.provider_md5 = file.md5 }
     end
 
     # confirm that the all of the source IDs supplied within a manifest are locally unique

--- a/app/lib/pre_assembly/object_file.rb
+++ b/app/lib/pre_assembly/object_file.rb
@@ -1,22 +1,22 @@
 module PreAssembly
   class ObjectFile < Assembly::ObjectFile
-    attr_accessor :relative_path, :exclude_from_content
-    attr_reader :checksum
+    include ActiveModel::AttributeMethods
+    attr_accessor :exclude_from_content
+    alias_attribute :checksum, :provider_md5
 
-    def initialize(params = {})
-      @path                 = params[:path]
-      @relative_path        = params[:relative_path]
-      self.checksum         = params[:checksum]
-      @exclude_from_content = params[:exclude_from_content]
+    # @param [String] path full path
+    # @param [Hash<Symbol => Object>] params
+    # @see Assembly::ObjectFile, Assembly::ObjectFileable
+    def initialize(path, params = {})
+      super
+      @provider_md5 ||= params[:checksum]
+      @exclude_from_content = params[:exclude_from_content] || false
     end
 
-    def checksum=(value)
-      @checksum = value
-      self.provider_md5 = value # this is an attribute of the Assembly::ObjectFile class
-    end
-
+    # This is a bit of a lie.  ObjectFiles with the same relative_path but different checksums
+    # are clearly not representing the same thing.
     def <=>(other)
-      @relative_path <=> other.relative_path
+      relative_path <=> other.relative_path
     end
   end
 end

--- a/spec/lib/pre_assembly/digital_object_spec.rb
+++ b/spec/lib/pre_assembly/digital_object_spec.rb
@@ -17,9 +17,8 @@ RSpec.describe PreAssembly::DigitalObject do
     (1..2).each do |i|
       f = "image#{i}.#{extension}"
       dobj.object_files.push PreAssembly::ObjectFile.new(
-        path: "#{dobj.bundle_dir}/#{dru}/#{f}",
+        "#{dobj.bundle_dir}/#{dru}/#{f}",
         relative_path: f,
-        exclude_from_content: false,
         checksum: i.to_s * 4
       )
     end
@@ -123,7 +122,7 @@ RSpec.describe PreAssembly::DigitalObject do
       n = files.size
       m = n / 2
       dobj.object_files = files.map do |f|
-        PreAssembly::ObjectFile.new(exclude_from_content: false, relative_path: f)
+        PreAssembly::ObjectFile.new("/path/to/#{f}", relative_path: f)
       end
       # All of them are included in content.
       expect(dobj.content_object_files.size).to eq(n)
@@ -247,7 +246,7 @@ RSpec.describe PreAssembly::DigitalObject do
       n = files.size
       m = n / 2
       dobj.object_files = files.map do |f|
-        PreAssembly::ObjectFile.new(exclude_from_content: false, relative_path: f)
+        PreAssembly::ObjectFile.new("/path/to/#{f}", relative_path: f)
       end
       # All of them are included in content.
       expect(dobj.content_object_files.size).to eq(n)
@@ -310,7 +309,7 @@ RSpec.describe PreAssembly::DigitalObject do
       # Generate some object_files.
       files = %w[file5.tif file4.tif file3.tif file2.tif file1.tif file0.tif]
       dobj.object_files = files.map do |f|
-        PreAssembly::ObjectFile.new(exclude_from_content: false, relative_path: f)
+        PreAssembly::ObjectFile.new("/path/to/#{f}", relative_path: f)
       end
       # All of them are included in content.
       expect(dobj.content_object_files.size).to eq(files.size)

--- a/spec/lib/pre_assembly/object_file_spec.rb
+++ b/spec/lib/pre_assembly/object_file_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe PreAssembly::ObjectFile do
-  let(:object_file) { described_class.new(path: 'spec/test_data/flat_dir_images/image1.tif') }
+  let(:object_file) { described_class.new('spec/test_data/flat_dir_images/image1.tif') }
 
   describe 'initialization' do
     it 'can initialize an ObjectFile' do


### PR DESCRIPTION
- make `initialize` signatures compatible and call super, because that's what good subclasses do.
- `exclude_from_content` has a default: `false`
- Use `alias_attribute` instead of custom double-setter method
- only initialize locally the stuff we define locally, the rest is the superclass' domain