### PR TITLE
BundleContext show page

### DIFF
--- a/app/controllers/bundle_contexts_controller.rb
+++ b/app/controllers/bundle_contexts_controller.rb
@@ -10,7 +10,8 @@ class BundleContextsController < ApplicationController
   def create
     @bundle_context = BundleContext.new(bundle_contexts_params)
     if @bundle_context.save
-      redirect_to controller: 'job_runs', created: 1
+      flash[:success] = 'Success! Your job is queued. A link to your validation report will be emailed to you when it is ready.'
+      redirect_to controller: 'job_runs'
     else
       render :new
     end

--- a/app/controllers/bundle_contexts_controller.rb
+++ b/app/controllers/bundle_contexts_controller.rb
@@ -16,6 +16,10 @@ class BundleContextsController < ApplicationController
     end
   end
 
+  def show
+    @bundle_context = BundleContext.find(params[:id])
+  end
+
   private
 
   def bundle_contexts_params

--- a/app/controllers/job_runs_controller.rb
+++ b/app/controllers/job_runs_controller.rb
@@ -1,6 +1,5 @@
 class JobRunsController < ApplicationController
   def index
-    flash[:notice] = 'Success! Your job is queued. A link to your validation report will be emailed to you when it is ready.' if params[:created]
     @job_runs = JobRun.order('created_at desc').page params[:page]
   end
 
@@ -13,7 +12,7 @@ class JobRunsController < ApplicationController
     if @job_run.output_location
       send_file @job_run.output_location
     else
-      flash[:notice] = 'Job is not complete. Please check back later.'
+      flash[:warning] = 'Job is not complete. Please check back later.'
       render 'show'
     end
   end

--- a/app/models/bundle_context.rb
+++ b/app/models/bundle_context.rb
@@ -114,7 +114,7 @@ class BundleContext < ApplicationRecord
 
   def verify_bundle_directory
     return if errors.key?(:bundle_dir)
-    errors.add(:bundle_dir, "Bundle directory: #{bundle_dir} not found.") unless File.directory?(bundle_dir)
+    errors.add(:bundle_dir, "'#{bundle_dir}' not found.") unless File.directory?(bundle_dir)
   end
 
   def verify_content_metadata_creation

--- a/app/views/bundle_contexts/show.html.erb
+++ b/app/views/bundle_contexts/show.html.erb
@@ -1,0 +1,24 @@
+<div class="container mt-5">
+  <dl class="dl row">
+    <dt class="col-sm-3">Project Name</dt>
+    <dd class="col-sm-9"><%= @bundle_context.project_name %></dd>
+    <dt class="col-sm-3">User</dt>
+    <dd class="col-sm-9"><%= @bundle_context.user.email %></dd>
+    <dt class="col-sm-3">Content Structure</dt>
+    <dd class="col-sm-9"><%= @bundle_context.content_structure %></dd>
+    <dt class="col-sm-3">Bundle Directory</dt>
+    <dd class="col-sm-9"><%= @bundle_context.bundle_dir %></dd>
+    <dt class="col-sm-3">Staging Style Symlink?</dt>
+    <dd class="col-sm-9">
+      <% if @bundle_context.staging_style_symlink %>
+        <i class="fas fa-check"></i>
+      <% else %>
+        <i class="far fa-times-circle"></i>
+      <% end %>
+    </dd>
+    <dt class="col-sm-3">Content Metadata Creation</dt>
+    <dd class="col-sm-9"><%= @bundle_context.content_metadata_creation %></dd>
+    <dt class="col-sm-3">Created At</dt>
+    <dd class="col-sm-9"><%= @bundle_context.created_at %></dd>
+  </dl>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,17 +4,13 @@
     <title>Pre-Assembly</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.2.0/css/all.css" integrity="sha384-hWVjflwFxL6sNzntih27bfxkr27PmbbK/iSvJ+a4+0owXq79v+lsFkW54bOGbiDQ" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.2.0/css/all.css" integrity="sha384-hWVjflwFxL6sNzntih27bfxkr27PmbbK/iSvJ+a4+0owXq79v+lsFkW54bOGbiDQ" crossorigin="anonymous">
     <%= stylesheet_link_tag  'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
 
   <body>
     <%= render "shared/header" %>
-    <div class="container mx-auto mt-5" style="width: 50em">
-      <p class="notice alert-info" role="alert"><%= notice %></p>
-      <p class="alert" role="alert"><%= alert %></p>
-    </div>
     <%= yield %>
   </body>
 </html>

--- a/app/views/shared/_header.erb
+++ b/app/views/shared/_header.erb
@@ -1,7 +1,15 @@
 <nav class="navbar">
-     <a class="navbar-brand" href="#"><%= image_tag('sul-logo.png', height: '30') %></a>
+  <a class="navbar-brand" href="#"><%= image_tag('sul-logo.png', height: '30') %></a>
 </nav>
 <div style="background-color: #8c1515; color: white; font-family: serif">
   <h1 class="p-4">Accessioning</h1>
   <%= image_tag("bookheader.png", width: "100%", height: "75") %>
 </div>
+<% flash.each do |key, value| %>
+  <div class="container">
+    <div class="alert alert-<%= key %> alert-dismissible" role="alert">
+      <button type="button" class="close" data-dismiss="alert" aria-label="Close"><i class="fas fa-times"></i></button>
+      <%= value %>
+    </div>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   devise_for :users, skip: :all
   root to: 'bundle_contexts#new'
-  resources :bundle_contexts, only: [:new, :create]
+  resources :bundle_contexts, only: [:create, :new, :show]
   resources :job_runs, only: [:show, :index]
   get 'job_runs/:id/download', to: 'job_runs#download', as: 'download'
   mount Resque::Server.new, at: '/resque'

--- a/spec/controllers/bundle_contexts_controller_spec.rb
+++ b/spec/controllers/bundle_contexts_controller_spec.rb
@@ -44,7 +44,8 @@ RSpec.describe BundleContextsController, type: :controller do
           post :create, params: params
           expect(assigns(:bundle_context)).to be_a(BundleContext).and be_persisted
           expect(response).to have_http_status(302) # HTTP code for found
-          expect(response).to redirect_to(job_runs_path(created: 1))
+          expect(response).to redirect_to(job_runs_path)
+          expect(flash[:success]).to start_with('Success! Your job is queued.')
         end
         it 'has the correct attributes' do
           post :create, params: params
@@ -68,11 +69,12 @@ RSpec.describe BundleContextsController, type: :controller do
 
       context 'Invalid Parameters' do
         let(:bc_params) { { project_name: '', content_structure: '', content_metadata_creation: '', bundle_dir: '' } }
+
         it 'do not create objects' do
           params[:bundle_context][:project_name] = nil
           expect { post :create, params: params }.not_to change(BundleContext, :count)
           expect { post :create, params: { bundle_context: bc_params } }.not_to change(BundleContext, :count)
-          bc_params.merge!(project_name: "SMPL's folly")
+          bc_params[:project_name] = "SMPL's folly"
           expect { post :create, params: { bundle_context: bc_params } }.not_to change(BundleContext, :count)
         end
       end

--- a/spec/controllers/bundle_contexts_controller_spec.rb
+++ b/spec/controllers/bundle_contexts_controller_spec.rb
@@ -67,25 +67,13 @@ RSpec.describe BundleContextsController, type: :controller do
       end
 
       context 'Invalid Parameters' do
+        let(:bc_params) { { project_name: '', content_structure: '', content_metadata_creation: '', bundle_dir: '' } }
         it 'do not create objects' do
           params[:bundle_context][:project_name] = nil
           expect { post :create, params: params }.not_to change(BundleContext, :count)
-          expect do
-            post :create, params: { bundle_context: {
-              project_name: '',
-              content_structure: '',
-              content_metadata_creation: '',
-              bundle_dir: ''
-            } }
-          end .not_to change(BundleContext, :count)
-          expect do
-            post :create, params: { bundle_context: {
-              project_name: "SMPL's folly",
-              content_structure: '',
-              content_metadata_creation: '',
-              bundle_dir: ''
-            } }
-          end .not_to change(BundleContext, :count)
+          expect { post :create, params: { bundle_context: bc_params } }.not_to change(BundleContext, :count)
+          bc_params.merge!(project_name: "SMPL's folly")
+          expect { post :create, params: { bundle_context: bc_params } }.not_to change(BundleContext, :count)
         end
       end
     end

--- a/spec/controllers/job_runs_controller_spec.rb
+++ b/spec/controllers/job_runs_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe JobRunsController, type: :controller do
     it 'before job is complete, renders page with flash' do
       allow(JobRun).to receive(:find).with('123').and_return(instance_double(JobRun, output_location: nil))
       get :download, params: { id: 123 }
-      expect(flash[:notice]).to eq('Job is not complete. Please check back later.')
+      expect(flash[:warning]).to eq('Job is not complete. Please check back later.')
     end
     it 'when job is complete, returns file attachment' do
       job_run_double = instance_double(JobRun, output_location: 'spec/test_data/input/mock_progress_log.yaml')
@@ -42,7 +42,7 @@ RSpec.describe JobRunsController, type: :controller do
         'Content-Type' => 'application/x-yaml',
         'Content-Disposition' => 'attachment; filename="mock_progress_log.yaml"'
       )
-      expect(flash[:notice]).to be_nil
+      expect(flash[:warning]).to be_nil
     end
     it 'requires ID param' do
       expect { get :download }.to raise_error(ActionController::UrlGenerationError)

--- a/spec/views/bundle_context_spec.rb
+++ b/spec/views/bundle_context_spec.rb
@@ -25,6 +25,6 @@ RSpec.describe 'bundle_contexts/new' do
     bc = build(:bundle_context, bundle_dir: 'bad path').tap(&:valid?)
     assign(:bundle_context, bc)
     render
-    expect(render).to match(/Bundle dir Bundle directory: bad path not found./)
+    expect(render).to match(/Bundle dir &#39;bad path&#39; not found./)
   end
 end

--- a/spec/views/bundle_contexts/show.html.erb_spec.rb
+++ b/spec/views/bundle_contexts/show.html.erb_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe 'bundle_contexts/show.html.erb', type: :view do
+  let(:bc) { create(:bundle_context) }
+
+  it 'diplays BundleContext info' do
+    assign(:bundle_context, bc)
+    render
+    expect(rendered).to include("<dd class=\"col-sm-9\">#{bc.project_name}</dd>")
+    expect(rendered).to include('<i class="far fa-times-circle"></i>') # icon for symlink="false"
+  end
+end


### PR DESCRIPTION
This is a coherent enough chunk of progress to warrant a PR now.  

- reworks flash notices, for bootstrap styling and better specificity, with close-capability
- add BundleContext show template with tests 
- cleans up some specs

New flash `success` message looks like:
![screen shot 2018-10-01 at 5 58 44 pm](https://user-images.githubusercontent.com/109954/46323578-d8a78b00-c5a3-11e8-9032-f3af55c0f9a2.png)

Up next:
- action buttons for "new discovery report" and "new preassembly"
- possible refactor of the BundleContext `<dl>` into a partial, to be used by show page, put also included in `JobRun` show page.

Part of #374 
