### PR TITLE
discovery_report default

### DIFF
--- a/app/controllers/bundle_contexts_controller.rb
+++ b/app/controllers/bundle_contexts_controller.rb
@@ -1,7 +1,7 @@
 class BundleContextsController < ApplicationController
   def new
     @bundle_context = BundleContext.new(
-      job_runs: [JobRun.new(job_type: 'preassembly')],
+      job_runs: [JobRun.new],
       content_structure: 'simple_image',
       content_metadata_creation: 'default'
     )

--- a/app/models/job_run.rb
+++ b/app/models/job_run.rb
@@ -3,6 +3,7 @@ class JobRun < ApplicationRecord
   validates :job_type, presence: true
   after_create :enqueue!
   after_update :send_notification, if: -> { saved_change_to_output_location? }
+  after_initialize :default_enums
 
   enum job_type: {
     'discovery_report' => 0,
@@ -29,5 +30,11 @@ class JobRun < ApplicationRecord
   # @return [DiscoveryReport]
   def to_discovery_report
     @to_discovery_report ||= DiscoveryReport.new(bundle_context.bundle)
+  end
+
+  private
+
+  def default_enums
+    self[:job_type] ||= 0
   end
 end

--- a/spec/controllers/bundle_contexts_controller_spec.rb
+++ b/spec/controllers/bundle_contexts_controller_spec.rb
@@ -60,10 +60,6 @@ RSpec.describe BundleContextsController, type: :controller do
           Dir.delete(output_dir) if Dir.exist?(output_dir) # even if the directory is missing, cannot reuse user & project_name
           expect { post :create, params: params }.to raise_error(ActiveRecord::RecordNotUnique)
         end
-        it 'fails if job_type is nil' do
-          params[:bundle_context][:job_runs_attributes] = { '0' => { job_type: '' } }
-          expect { post :create, params: params }.not_to change(JobRun, :count)
-        end
       end
 
       context 'Invalid Parameters' do

--- a/spec/models/job_run_spec.rb
+++ b/spec/models/job_run_spec.rb
@@ -51,13 +51,17 @@ RSpec.describe JobRun, type: :model do
         'preassembly' => 1
       )
     end
+    it 'defaults to correct value' do
+      expect(described_class.new.job_type).to eq('discovery_report')
+    end
   end
 
   context 'validation' do
     it 'is not valid without all required fields' do
       expect(described_class.new).not_to be_valid
-      expect(described_class.new(bundle_context: build(:bundle_context))).not_to be_valid
-      expect(job_run).to be_valid
+    end
+    it 'is valid with just bundle_context' do
+      expect(described_class.new(bundle_context: build(:bundle_context))).to be_valid
     end
   end
 end


### PR DESCRIPTION
Default the enum value in the model via `after_initialize`, like our other models.   Then just let the BC controller pass a new object directly (it no longer has to know anything about `JobRun` values).

Fixes #382