### PR TITLE
these fixme and todo's are not needed anymore

### DIFF
--- a/app/jobs/preassembly_job.rb
+++ b/app/jobs/preassembly_job.rb
@@ -5,7 +5,6 @@ class PreassemblyJob < ApplicationJob
   def perform(job_run)
     bc = job_run.bundle_context
     bc.bundle.run_pre_assembly
-    # TODO: produce and save a run-specific log file, similar to discovery_report?
     job_run.output_location = bc.progress_log_file
     job_run.save!
   end

--- a/app/models/bundle_context.rb
+++ b/app/models/bundle_context.rb
@@ -104,7 +104,6 @@ class BundleContext < ApplicationRecord
 
   def verify_output_dir
     if persisted?
-      # FIXME: or should we just try to create it?
       raise "Output directory (#{output_dir}) should already exist, but doesn't" unless Dir.exist?(output_dir)
     else
       raise "Output directory (#{output_dir}) should not already exist" if Dir.exist?(output_dir)


### PR DESCRIPTION
There are 0 FIXME’s left in the code, and about 9 TODO’s left in the code. THe last 9 have to do with using `dor-workflow-service` gem (which i dont think we will get to this cycle) and removing code that is not being used (which we may or may not get to )


closes #355 