### PR TITLE
default user, and a couple touchups

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,26 @@ brew install exiftool
 bundle exec rspec
 ```
 
+## Running the application for local development
+
+Just the usual:
+
+```bash
+bundle exec rails server
+```
+
+When running the application in development mode, it will use a default sunet_id (`'tmctesterson'`) for
+its sessions. To override that behavior and specify an alternate user, you can manually specify the `REMOTE_USER`
+environment variable at startup, like so:
+
+```bash
+REMOTE_USER="ima_user" bundle exec rails server
+```
+
+Because the application looks for user info in an environment variable, and because local dev environments don't have
+an Apache module setting that environment variable per request based on headers from Webauth/Shibboleth, dev just always
+sets a single value in that env var at start time.  So laptop dev instances basically only allow one fake login at a time.
+
 ## Troubleshooting
 
 ### Seeing an error like this when you try to run pre-assembly or a discovery report?

--- a/app/lib/pre_assembly/bundle.rb
+++ b/app/lib/pre_assembly/bundle.rb
@@ -47,8 +47,9 @@ module PreAssembly
 
     # Runs the pre-assembly process and returns an array of PIDs of the digital objects processed.
     def run_pre_assembly
-      log "\nrun_pre_assembly(#{run_log_msg})"
+      log "\nstarting run_pre_assembly(#{run_log_msg})"
       process_digital_objects
+      log "\nfinishing run_pre_assembly(#{run_log_msg})"
       processed_pids
     end
 

--- a/app/lib/pre_assembly/digital_object.rb
+++ b/app/lib/pre_assembly/digital_object.rb
@@ -202,7 +202,6 @@ module PreAssembly
     end
 
     # Invoke the contentMetadata creation method used by the project
-    # if we are not using a standard known style of content metadata generation, pass the task off to a custom method
     def create_content_metadata
       if content_md_creation == 'smpl_cm_style'
         self.content_md_xml = smpl_manifest.generate_cm(druid.id)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,4 +58,7 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  require 'dev_shibboleth_headers'
+  config.middleware.use DevShibbolethHeaders
 end

--- a/lib/dev_shibboleth_headers.rb
+++ b/lib/dev_shibboleth_headers.rb
@@ -1,0 +1,20 @@
+# This is a Rack middleware that we use in development. It sets an env var in such a way as to
+# simulate the way mod_shib injects request headers that then result in an env var being set
+# for the request.
+#
+# This is certainly not thread safe as it uses class level variables
+class DevShibbolethHeaders
+  class_attribute :user
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    # in development mode, devise will look for the user name to be provided by
+    # ENV['REMOTE_USER'].  in other environments, it will check env['REMOTE_USER'].
+    # we only want to set this default in dev anyway.
+    ENV['REMOTE_USER'] ||= 'tmctesterson'
+    @app.call(env)
+  end
+end

--- a/spec/lib/pre_assembly/bundle_spec.rb
+++ b/spec/lib/pre_assembly/bundle_spec.rb
@@ -6,13 +6,7 @@ RSpec.describe PreAssembly::Bundle do
 
   describe '#run_pre_assembly' do
     let(:exp_workflow_svc_url) { Regexp.new("^#{Dor::Config.dor_services.url}/objects/.*/apo_workflows/assemblyWF$") }
-    let(:b) do
-      bc = bundle_context_from_hash('images_jp2_tif')
-      # need to delete progress log to ensure this test doesn't skip objects already run
-      FileUtils.rm_rf(bc.output_dir) if Dir.exist?(bc.output_dir)
-      bc.save
-      described_class.new bc
-    end
+    let(:b) { described_class.new(create(:bundle_context_with_deleted_output_dir)) }
 
     before do
       allow(RestClient).to receive(:post)
@@ -21,10 +15,10 @@ RSpec.describe PreAssembly::Bundle do
       allow(Dor::Item).to receive(:find).with(any_args)
     end
 
-    it 'runs images_jp2_tif cleanly using images_jp2_tif.yaml for options' do
+    it 'runs cleanly and returns the list of druids that were processed' do
       pids = []
       expect { pids = b.run_pre_assembly }.not_to raise_error
-      expect(pids).to eq ['druid:jy812bp9403', 'druid:tz250tk7584', 'druid:gn330dv6119']
+      expect(pids).to eq ['druid:aa111aa1111', 'druid:bb222bb2222']
     end
 
     it 'logs the start and finish of the run' do

--- a/spec/lib/pre_assembly/bundle_spec.rb
+++ b/spec/lib/pre_assembly/bundle_spec.rb
@@ -6,6 +6,13 @@ RSpec.describe PreAssembly::Bundle do
 
   describe '#run_pre_assembly' do
     let(:exp_workflow_svc_url) { Regexp.new("^#{Dor::Config.dor_services.url}/objects/.*/apo_workflows/assemblyWF$") }
+    let(:b) do
+      bc = bundle_context_from_hash('images_jp2_tif')
+      # need to delete progress log to ensure this test doesn't skip objects already run
+      FileUtils.rm_rf(bc.output_dir) if Dir.exist?(bc.output_dir)
+      bc.save
+      described_class.new bc
+    end
 
     before do
       allow(RestClient).to receive(:post)
@@ -15,22 +22,12 @@ RSpec.describe PreAssembly::Bundle do
     end
 
     it 'runs images_jp2_tif cleanly using images_jp2_tif.yaml for options' do
-      bc = bundle_context_from_hash('images_jp2_tif')
-      # need to delete progress log to ensure this test doesn't skip objects already run
-      FileUtils.rm_rf(bc.output_dir) if Dir.exist?(bc.output_dir)
-      bc.save
-      b = described_class.new bc
       pids = []
       expect { pids = b.run_pre_assembly }.not_to raise_error
       expect(pids).to eq ['druid:jy812bp9403', 'druid:tz250tk7584', 'druid:gn330dv6119']
     end
 
     it 'logs the start and finish of the run' do
-      bc = bundle_context_from_hash('images_jp2_tif')
-      # need to delete progress log to ensure this test doesn't skip objects already run
-      FileUtils.rm_rf(bc.output_dir) if Dir.exist?(bc.output_dir)
-      bc.save
-      b = described_class.new bc
       allow(b).to receive(:log) # there will be other log statements we don't care about here
       expect(b).to receive(:log).with("\nstarting run_pre_assembly(#{b.run_log_msg})")
       expect(b).to receive(:log).with("\nfinishing run_pre_assembly(#{b.run_log_msg})")

--- a/spec/lib/pre_assembly/bundle_spec.rb
+++ b/spec/lib/pre_assembly/bundle_spec.rb
@@ -24,6 +24,18 @@ RSpec.describe PreAssembly::Bundle do
       expect { pids = b.run_pre_assembly }.not_to raise_error
       expect(pids).to eq ['druid:jy812bp9403', 'druid:tz250tk7584', 'druid:gn330dv6119']
     end
+
+    it 'logs the start and finish of the run' do
+      bc = bundle_context_from_hash('images_jp2_tif')
+      # need to delete progress log to ensure this test doesn't skip objects already run
+      FileUtils.rm_rf(bc.output_dir) if Dir.exist?(bc.output_dir)
+      bc.save
+      b = described_class.new bc
+      allow(b).to receive(:log) # there will be other log statements we don't care about here
+      expect(b).to receive(:log).with("\nstarting run_pre_assembly(#{b.run_log_msg})")
+      expect(b).to receive(:log).with("\nfinishing run_pre_assembly(#{b.run_log_msg})")
+      b.run_pre_assembly
+    end
   end
 
   describe '#load_skippables' do
@@ -38,6 +50,14 @@ RSpec.describe PreAssembly::Bundle do
   describe '#run_log_msg' do
     it 'returns a string' do
       expect(flat_dir_images.run_log_msg).to be_a(String)
+    end
+
+    it 'returns a string with the expected values' do
+      expect(flat_dir_images.run_log_msg).to match(/content_structure="#{flat_dir_images.content_structure}"/)
+      expect(flat_dir_images.run_log_msg).to match(/project_name="#{flat_dir_images.project_name}"/)
+      expect(flat_dir_images.run_log_msg).to match(/bundle_dir="#{flat_dir_images.bundle_dir}"/)
+      expect(flat_dir_images.run_log_msg).to match(/assembly_staging_dir="#{flat_dir_images.assembly_staging_dir}"/)
+      expect(flat_dir_images.run_log_msg).to match(/environment="test"/)
     end
   end
 


### PR DESCRIPTION
mainly:
* a bit of rack middleware to set a default sunet_id in dev, and instructions on how to override the default (#323).  ripped off and tweaked from the argo code pointed to by #323.

but also some stuff from my notes (nitpicks to other PRs that i didn't ticket):
* log message for Bundle#run_pre_assembly end, differentiate start/end log messages in that method. tests. (https://github.com/sul-dlss/pre-assembly/pull/346#discussion_r220278499)
* remove defunct comment (https://github.com/sul-dlss/pre-assembly/pull/256/files#r217549930)

fixes #323