### PR TITLE
JobRunsController gets its own create method/route, BC show gets buttons

### DIFF
--- a/app/controllers/bundle_contexts_controller.rb
+++ b/app/controllers/bundle_contexts_controller.rb
@@ -10,7 +10,7 @@ class BundleContextsController < ApplicationController
   def create
     @bundle_context = BundleContext.new(bundle_contexts_params)
     if @bundle_context.save
-      flash[:success] = 'Success! Your job is queued. A link to your validation report will be emailed to you when it is ready.'
+      flash[:success] = 'Success! Your job is queued. A link to job output will be emailed to you upon completion.'
       redirect_to controller: 'job_runs'
     else
       render :new

--- a/app/controllers/job_runs_controller.rb
+++ b/app/controllers/job_runs_controller.rb
@@ -1,4 +1,15 @@
 class JobRunsController < ApplicationController
+  def create
+    raise ActionController::ParameterMissing, :bundle_context_id unless job_run_params[:bundle_context_id]
+    @job_run = JobRun.new(job_run_params)
+    if @job_run.save
+      flash[:success] = 'Success! Your job is queued. A link to job output will be emailed to you upon completion.'
+    else
+      flash[:error] = "Error(s) saving JobRun: #{@job_run.errors}"
+    end
+    redirect_to(action: 'index')
+  end
+
   def index
     @job_runs = JobRun.order('created_at desc').page params[:page]
   end
@@ -15,5 +26,11 @@ class JobRunsController < ApplicationController
       flash[:warning] = 'Job is not complete. Please check back later.'
       render 'show'
     end
+  end
+
+  private
+
+  def job_run_params
+    params.require(:job_run).permit(:bundle_context_id, :job_type)
   end
 end

--- a/app/views/bundle_contexts/show.html.erb
+++ b/app/views/bundle_contexts/show.html.erb
@@ -21,4 +21,17 @@
     <dt class="col-sm-3">Created At</dt>
     <dd class="col-sm-9"><%= @bundle_context.created_at %></dd>
   </dl>
+  <div class="row mx-auto mt-5">
+    <h3 class="col-sm-12">Actions</h3>
+    <%= form_for(@bundle_context.job_runs.new) do |form| %>
+      <%= form.hidden_field :bundle_context_id, value: @bundle_context.id %>
+      <%= form.hidden_field :job_type, value: 'discovery_report' %>
+      <%= form.submit 'New Discovery Report', class: 'btn btn-success' %>
+    <% end %>
+    <%= form_for(@bundle_context.job_runs.new) do |form| %>
+      <%= form.hidden_field :bundle_context_id, value: @bundle_context.id %>
+      <%= form.hidden_field :job_type, value: 'preassembly' %>
+      <%= form.submit 'Run Preassembly', class: 'btn btn-sul-dlss' %>
+    <% end %>
+  </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   devise_for :users, skip: :all
   root to: 'bundle_contexts#new'
   resources :bundle_contexts, only: [:create, :new, :show]
-  resources :job_runs, only: [:show, :index]
+  resources :job_runs, only: [:create, :index, :show]
   get 'job_runs/:id/download', to: 'job_runs#download', as: 'download'
   mount Resque::Server.new, at: '/resque'
 end

--- a/spec/views/bundle_contexts/show.html.erb_spec.rb
+++ b/spec/views/bundle_contexts/show.html.erb_spec.rb
@@ -1,10 +1,17 @@
 RSpec.describe 'bundle_contexts/show.html.erb', type: :view do
   let(:bc) { create(:bundle_context) }
 
+  before { assign(:bundle_context, bc) }
+
   it 'diplays BundleContext info' do
-    assign(:bundle_context, bc)
     render
     expect(rendered).to include("<dd class=\"col-sm-9\">#{bc.project_name}</dd>")
     expect(rendered).to include('<i class="far fa-times-circle"></i>') # icon for symlink="false"
+  end
+
+  it 'has buttons for new Jobs' do
+    render
+    expect(rendered).to include('<input type="submit" name="commit" value="Run Preassembly"')
+    expect(rendered).to include('<input type="submit" name="commit" value="New Discovery Report"')
   end
 end


### PR DESCRIPTION
Complete with route, actions and specs.

Show page for a `BundleContext` with buttons looks like:

![screen shot 2018-10-02 at 4 58 51 pm](https://user-images.githubusercontent.com/109954/46385143-52f11180-c66f-11e8-8e44-3a85ac6e18c3.png)

Does #374, or as much of it as I think is relevant (that ticket is too expansive).  
