### PR TITLE
restrict allowable paths for bundle dir input

### DIFF
--- a/config/initializers/load_config.rb
+++ b/config/initializers/load_config.rb
@@ -1,0 +1,1 @@
+ALLOWABLE_BUNDLE_DIRS = YAML.safe_load(ERB.new(File.read("#{Rails.root}/config/settings/bundle_dir_roots.yml.erb")).result)[Rails.env]

--- a/config/settings/bundle_dir_roots.yml.erb
+++ b/config/settings/bundle_dir_roots.yml.erb
@@ -1,0 +1,43 @@
+development:
+  - <%= Rails.root.join("spec", "test_data").to_s %>
+  - <%= Rails.root.join("tmp").to_s %>
+test:
+  - <%= Rails.root.join("spec", "test_data").to_s %>
+  - <%= Rails.root.join("tmp").to_s %>
+production:
+  - '/thumpers/dpgthumper-se1/'
+  - '/thumpers/dpgthumper-se2/'
+  - '/thumpers/se9/'
+  - '/thumpers/dpgthumper-staging/'
+  - '/thumpers/dpgthumper-imageserver/'
+  - '/thumpers/dpgthumper2-se1/'
+  - '/thumpers/sdr'
+  - '/arts/'
+  - '/smpl/'
+  - '/smpl2/'
+  - '/smpl3/'
+  - '/smpl4/'
+  - '/smpl5/'
+  - '/smpl6/'
+  - '/smpl7/'
+  - '/smpl8/'
+  - '/smpl9/'
+  - '/smpl10/'
+  - '/smpl11/'
+  - '/smpl12/'
+  - '/smpl13/'
+  - '/smpl14/'
+  - '/smpl15/'
+  - '/smpl16/'
+  - '/smpl17/'
+  - '/maps/'
+  - '/data/'
+  - '/datasets/'
+  - '/gov-data/'
+  - '/spec1/'
+  - '/spec2/'
+  - '/third_party/'
+  - '/dpgthumper/'
+  - '/dpgthumper2/'
+  - '/sdrthumpers/'
+

--- a/spec/models/bundle_context_spec.rb
+++ b/spec/models/bundle_context_spec.rb
@@ -37,6 +37,16 @@ RSpec.describe BundleContext, type: :model do
         expect { bc.project_name = valid_chars }.not_to change(bc, :valid?).from(true)
       end
     end
+
+    context 'bundle_dir must be a sub dir of allowed parent directories' do
+      it 'cannot jailbreak' do
+        expect { bc.bundle_dir = 'tmp/../../foo/' }.to change(bc, :valid?).to(false)
+      end
+
+      it 'cannot use the root directly' do
+        expect { bc.bundle_dir = 'tmp/' }.to change(bc, :valid?).to(false)
+      end
+    end
   end
 
   it do


### PR DESCRIPTION
Hopefully i spelled all of the mounts [here](https://consul.stanford.edu/pages/viewpage.action?title=Content+Mount+Paths&spaceKey=CollAcc) correctly


closes #387 