### PR TITLE
Taking Bundle private

### DIFF
--- a/spec/lib/pre_assembly/bundle_spec.rb
+++ b/spec/lib/pre_assembly/bundle_spec.rb
@@ -3,10 +3,33 @@ RSpec.describe PreAssembly::Bundle do
   let(:flat_dir_images) { bundle_setup(:flat_dir_images) }
   let(:images_jp2_tif) { bundle_setup(:images_jp2_tif) }
   let(:smpl_multimedia) { bundle_setup(:smpl_multimedia) }
+  let(:b) { create(:bundle_context_with_deleted_output_dir).bundle }
+
+  after { FileUtils.rm_rf(b.bundle_context.output_dir) if Dir.exist?(b.bundle_context.output_dir) } # cleanup
 
   describe '#run_pre_assembly' do
+    before do
+      allow(b).to receive(:process_digital_objects) # stub expensive call
+      allow(b).to receive(:log) # log statements we don't care about here
+    end
+
+    it 'returns processed_pids' do
+      allow(b).to receive(:processed_pids).and_return ['druid:aa111aa1111', 'druid:bb222bb2222']
+      expect(b.run_pre_assembly).to eq ['druid:aa111aa1111', 'druid:bb222bb2222']
+    end
+    it 'logs the start and finish of the run' do
+      expect(b).to receive(:log).with("\nstarting run_pre_assembly(#{b.run_log_msg})")
+      expect(b).to receive(:log).with("\nfinishing run_pre_assembly(#{b.run_log_msg})")
+      b.run_pre_assembly
+    end
+    it 'calls process_digital_objects' do
+      expect(b).to receive(:process_digital_objects)
+      b.run_pre_assembly
+    end
+  end
+
+  describe '#process_digital_objects' do
     let(:exp_workflow_svc_url) { Regexp.new("^#{Dor::Config.dor_services.url}/objects/.*/apo_workflows/assemblyWF$") }
-    let(:b) { described_class.new(create(:bundle_context_with_deleted_output_dir)) }
 
     before do
       allow(RestClient).to receive(:post)
@@ -15,17 +38,8 @@ RSpec.describe PreAssembly::Bundle do
       allow(Dor::Item).to receive(:find).with(any_args)
     end
 
-    it 'runs cleanly and returns the list of druids that were processed' do
-      pids = []
-      expect { pids = b.run_pre_assembly }.not_to raise_error
-      expect(pids).to eq ['druid:aa111aa1111', 'druid:bb222bb2222']
-    end
-
-    it 'logs the start and finish of the run' do
-      allow(b).to receive(:log) # there will be other log statements we don't care about here
-      expect(b).to receive(:log).with("\nstarting run_pre_assembly(#{b.run_log_msg})")
-      expect(b).to receive(:log).with("\nfinishing run_pre_assembly(#{b.run_log_msg})")
-      b.run_pre_assembly
+    it 'runs cleanly' do
+      expect { b.process_digital_objects }.not_to raise_error
     end
   end
 
@@ -71,112 +85,11 @@ RSpec.describe PreAssembly::Bundle do
     end
   end
 
-  describe '#object_discovery: discovery via manifest and crawl' do
-    it 'discover_containers_via_manifest() should return expected information' do
-      vals = %w[123.tif 456.tif 789.tif]
-      allow(flat_dir_images).to receive(:manifest_rows).and_return(vals.map { |v| { object: v } })
-      expect(flat_dir_images.discover_containers_via_manifest).to eq(vals.map { |v| flat_dir_images.path_in_bundle v })
-    end
-
-    it '#discover_items_via_crawl should return expected information' do
-      items = %w[abc.txt def.txt ghi.txt 123.tif 456.tif 456.TIF].map { |i| flat_dir_images.path_in_bundle i }
-      allow(flat_dir_images).to receive(:dir_glob).and_return(items)
-      expect(flat_dir_images.discover_items_via_crawl(flat_dir_images.bundle_dir)).to eq(items.sort)
-    end
-  end
-
-  describe 'object discovery: #discover_object_files' do
-    let(:fs) do
-      %w[
-        gn330dv6119/image1.jp2
-        gn330dv6119/image1.tif
-        gn330dv6119/image2.jp2
-        gn330dv6119/image2.tif
-        jy812bp9403/00/image1.tif
-        jy812bp9403/00/image2.tif
-        jy812bp9403/05/image1.jp2
-        tz250tk7584/00/image1.tif
-        tz250tk7584/00/image2.tif
-      ]
-    end
-    let(:files) { fs.map { |f| images_jp2_tif.path_in_bundle f } }
-    let(:dirs) { %w[gn330dv6119 jy812bp9403 tz250tk7584].map { |d| images_jp2_tif.path_in_bundle d } }
-
-    it 'finds expected files with correct relative paths' do
-      tests = [
-        # Stageables.    Expected relative paths.                 Type of item as stageables.
-        [files,         fs.map { |f| File.basename f }], # Files.
-        [dirs,          fs], # Directories.
-        # note: the following line fails because we now require manifest file to be in the directory
-        # [images_jp2_tif.bundle_dir, fs.map { |f| File.join(File.basename(images_jp2_tif.bundle_dir), f) }], # Even higher directory.
-      ]
-      tests.each do |stageables, exp_relative_paths|
-        # Full paths of object files should never change, but the relative paths varies, depending on the stageables.
-        ofiles = images_jp2_tif.discover_object_files(stageables)
-        expect(ofiles.map(&:path)).to eq(files)
-        expect(ofiles.map(&:relative_path)).to eq(exp_relative_paths)
-      end
-    end
-  end
-
-  describe 'object discovery: other' do
-    it 'is able to exercise all_object_files()' do
-      fake_files = [[1, 2], [3, 4], [5, 6]]
-      fake_dobjs = fake_files.map { |fs| instance_double(PreAssembly::DigitalObject, object_files: fs) }
-      flat_dir_images.digital_objects = fake_dobjs
-      expect(flat_dir_images.all_object_files).to eq(fake_files.flatten)
-    end
-
-    it 'new_object_file() should return an ObjectFile with expected path values' do
-      allow(flat_dir_images).to receive(:exclude_from_content).and_return(false)
-      tests = [
-        # Stageable is a file:
-        # - immediately in bundle dir.
-        { stageable: 'BUNDLE/x.tif',
-          file_path: 'BUNDLE/x.tif',
-          exp_rel_path: 'x.tif' },
-        # - within subdir of bundle dir.
-        { stageable: 'BUNDLE/a/b/x.tif',
-          file_path: 'BUNDLE/a/b/x.tif',
-          exp_rel_path: 'x.tif' },
-        # Stageable is a directory:
-        # - immediately in bundle dir
-        { stageable: 'BUNDLE/a',
-          file_path: 'BUNDLE/a/x.tif',
-          exp_rel_path: 'a/x.tif' },
-        # - immediately in bundle dir, with file deeper
-        { stageable: 'BUNDLE/a',
-          file_path: 'BUNDLE/a/b/x.tif',
-          exp_rel_path: 'a/b/x.tif' },
-        # - within a subdir of bundle dir
-        { stageable: 'BUNDLE/a/b',
-          file_path: 'BUNDLE/a/b/x.tif',
-          exp_rel_path: 'b/x.tif' },
-        # - within a subdir of bundle dir, with file deeper
-        { stageable: 'BUNDLE/a/b',
-          file_path: 'BUNDLE/a/b/c/d/x.tif',
-          exp_rel_path: 'b/c/d/x.tif' }
-      ]
-      tests.each do |t|
-        ofile = flat_dir_images.new_object_file t[:stageable], t[:file_path]
-        expect(ofile).to be_a(PreAssembly::ObjectFile)
-        expect(ofile.path).to          eq(t[:file_path])
-        expect(ofile.relative_path).to eq(t[:exp_rel_path])
-      end
-    end
-
-    it 'exclude_from_content() should behave correctly' do
-      skip 'web app does not need to support exclude_from_content'
-      expect(smpl_multimedia.exclude_from_content(smpl_multimedia.path_in_bundle('image1.tif'))).to be_falsey
-      expect(smpl_multimedia.exclude_from_content(smpl_multimedia.path_in_bundle('descMetadata.xml'))).to be_truthy
-    end
-  end
-
   describe '#load_checksums' do
     it 'loads checksums and attach them to the ObjectFiles' do
-      smpl_multimedia.all_object_files.each { |f| expect(f.checksum).to be_nil }
+      smpl_multimedia.send(:all_object_files).each { |f| expect(f.checksum).to be_nil }
       smpl_multimedia.digital_objects.each { |dobj| smpl_multimedia.load_checksums(dobj) }
-      smpl_multimedia.all_object_files.each { |f| expect(f.checksum).to match(md5_regex) }
+      smpl_multimedia.send(:all_object_files).each { |f| expect(f.checksum).to match(md5_regex) }
     end
   end
 
@@ -220,6 +133,129 @@ RSpec.describe PreAssembly::Bundle do
     end
   end
 
+  ### Private methods
+
+  describe '#discover_containers_via_manifest' do
+    it 'returns expected information' do
+      vals = %w[123.tif 456.tif 789.tif]
+      allow(flat_dir_images).to receive(:manifest_rows).and_return(vals.map { |v| { object: v } })
+      expect(flat_dir_images.send(:discover_containers_via_manifest)).to eq(vals.map { |v| flat_dir_images.path_in_bundle v })
+    end
+  end
+
+  describe '#discover_items_via_crawl' do
+    it 'returns expected information' do
+      items = %w[abc.txt def.txt ghi.txt 123.tif 456.tif 456.TIF].map { |i| flat_dir_images.path_in_bundle i }
+      allow(flat_dir_images).to receive(:dir_glob).and_return(items)
+      expect(flat_dir_images.send(:discover_items_via_crawl, flat_dir_images.bundle_dir)).to eq(items.sort)
+    end
+  end
+
+  describe '#discover_object_files' do
+    let(:fs) do
+      %w[
+        gn330dv6119/image1.jp2
+        gn330dv6119/image1.tif
+        gn330dv6119/image2.jp2
+        gn330dv6119/image2.tif
+        jy812bp9403/00/image1.tif
+        jy812bp9403/00/image2.tif
+        jy812bp9403/05/image1.jp2
+        tz250tk7584/00/image1.tif
+        tz250tk7584/00/image2.tif
+      ]
+    end
+    let(:files) { fs.map { |f| images_jp2_tif.path_in_bundle f } }
+    let(:dirs) { %w[gn330dv6119 jy812bp9403 tz250tk7584].map { |d| images_jp2_tif.path_in_bundle d } }
+
+    it 'finds expected files with correct relative paths from files' do
+      ofiles = images_jp2_tif.send(:discover_object_files, files)
+      expect(ofiles.map(&:path)).to eq(files)
+      expect(ofiles.map(&:relative_path)).to eq(fs.map { |f| File.basename f })
+    end
+    it 'finds expected files with correct relative paths from dirs' do
+      ofiles = images_jp2_tif.send(:discover_object_files, dirs)
+      expect(ofiles.map(&:path)).to eq(files)
+      expect(ofiles.map(&:relative_path)).to eq(fs)
+    end
+  end
+
+  describe '#new_object_file' do
+    it 'returns an ObjectFile with expected path values' do
+      allow(flat_dir_images).to receive(:exclude_from_content).and_return(false)
+      tests = [
+        # Stageable is a file:
+        # - immediately in bundle dir.
+        { stageable: 'BUNDLE/x.tif',
+          file_path: 'BUNDLE/x.tif',
+          exp_rel_path: 'x.tif' },
+        # - within subdir of bundle dir.
+        { stageable: 'BUNDLE/a/b/x.tif',
+          file_path: 'BUNDLE/a/b/x.tif',
+          exp_rel_path: 'x.tif' },
+        # Stageable is a directory:
+        # - immediately in bundle dir
+        { stageable: 'BUNDLE/a',
+          file_path: 'BUNDLE/a/x.tif',
+          exp_rel_path: 'a/x.tif' },
+        # - immediately in bundle dir, with file deeper
+        { stageable: 'BUNDLE/a',
+          file_path: 'BUNDLE/a/b/x.tif',
+          exp_rel_path: 'a/b/x.tif' },
+        # - within a subdir of bundle dir
+        { stageable: 'BUNDLE/a/b',
+          file_path: 'BUNDLE/a/b/x.tif',
+          exp_rel_path: 'b/x.tif' },
+        # - within a subdir of bundle dir, with file deeper
+        { stageable: 'BUNDLE/a/b',
+          file_path: 'BUNDLE/a/b/c/d/x.tif',
+          exp_rel_path: 'b/c/d/x.tif' }
+      ]
+      tests.each do |t|
+        ofile = flat_dir_images.send(:new_object_file, t[:stageable], t[:file_path])
+        expect(ofile).to be_a(PreAssembly::ObjectFile)
+        expect(ofile.path).to          eq(t[:file_path])
+        expect(ofile.relative_path).to eq(t[:exp_rel_path])
+      end
+    end
+  end
+
+  describe '#exclude_from_content' do
+    it 'behaves correctly' do
+      skip 'web app does not need to support exclude_from_content'
+      expect(smpl_multimedia.send(:exclude_from_content, smpl_multimedia.path_in_bundle('image1.tif'))).to be_falsey
+      expect(smpl_multimedia.send(:exclude_from_content, smpl_multimedia.path_in_bundle('descMetadata.xml'))).to be_truthy
+    end
+  end
+
+  describe '#all_object_files' do
+    it 'returns Array of object_files from all DigitalObjects' do
+      fake_files = [[1, 2], [3, 4], [5, 6]]
+      fake_dobjs = fake_files.map { |fs| instance_double(PreAssembly::DigitalObject, object_files: fs) }
+      flat_dir_images.digital_objects = fake_dobjs
+      expect(flat_dir_images.send(:all_object_files)).to eq(fake_files.flatten)
+    end
+  end
+
+  describe '#get_base_dir' do
+    it 'returns expected value' do
+      expect(flat_dir_images.send(:get_base_dir, 'foo/bar/fubb.txt')).to eq('foo/bar')
+    end
+    it 'raises error if given bogus arguments' do
+      exp_msg = /^Bad arg to get_base_dir/
+      expect { flat_dir_images.send(:get_base_dir, 'foo.txt')     }.to raise_error(ArgumentError, exp_msg)
+      expect { flat_dir_images.send(:get_base_dir, '')            }.to raise_error(ArgumentError, exp_msg)
+      expect { flat_dir_images.send(:get_base_dir, 'x\y\foo.txt') }.to raise_error(ArgumentError, exp_msg)
+    end
+  end
+
+  describe '#dir_glob' do
+    it ' returns expected information' do
+      exp = [1, 2, 3].map { |n| flat_dir_images.path_in_bundle "image#{n}.tif" }
+      expect(flat_dir_images.send(:dir_glob, flat_dir_images.path_in_bundle('*.tif'))).to eq(exp)
+    end
+  end
+
   describe 'file and directory utilities' do
     let(:relative) { 'abc/def.jpg' }
     let(:full) { flat_dir_images.path_in_bundle(relative) }
@@ -228,23 +264,7 @@ RSpec.describe PreAssembly::Bundle do
       expect(flat_dir_images.path_in_bundle(relative)).to eq('spec/test_data/flat_dir_images/abc/def.jpg')
     end
     it '#relative_path returns expected value' do
-      expect(flat_dir_images.relative_path(flat_dir_images.bundle_dir, full)).to eq(relative)
-    end
-    it '#get_base_dir returns expected value' do
-      expect(flat_dir_images.get_base_dir('foo/bar/fubb.txt')).to eq('foo/bar')
-    end
-
-    it '#get_base_dir raises error if given bogus arguments' do
-      exp_msg  = /^Bad arg to get_base_dir/
-      bad_args = ['foo.txt', '', 'x\y\foo.txt']
-      bad_args.each do |arg|
-        expect { flat_dir_images.get_base_dir(arg) }.to raise_error(ArgumentError, exp_msg)
-      end
-    end
-
-    it '#dir_glob returns expected information' do
-      exp = [1, 2, 3].map { |n| flat_dir_images.path_in_bundle "image#{n}.tif" }
-      expect(flat_dir_images.dir_glob(flat_dir_images.path_in_bundle('*.tif'))).to eq(exp)
+      expect(flat_dir_images.send(:relative_path, flat_dir_images.bundle_dir, full)).to eq(relative)
     end
 
     it '#find_files_recursively returns expected information' do
@@ -272,7 +292,7 @@ RSpec.describe PreAssembly::Bundle do
       }.each do |proj, files|
         b = described_class.new(bundle_context_from_hash(proj))
         exp_files = files.map { |f| b.path_in_bundle f }
-        expect(b.find_files_recursively(b.bundle_dir).sort).to eq(exp_files)
+        expect(b.send(:find_files_recursively, b.bundle_dir).sort).to eq(exp_files)
       end
     end
   end


### PR DESCRIPTION
- Use private methods if they aren't called elsewhere in the app (tests don't count, use `.send` to test private methods)
- add YARD
- remove lines in `process_digital_objects` that don't do anything (related to previous faulty terminal output)
- restructure specs to actually `describe '#method'`
- remove `manifest_sourceids_unique?` (unused)
- make the costly (preassembly) test run only once, as part of the method that contains the most responsibility, `process_digital_objects`, not `run_pre_assembly`