### PR TITLE
Bundle dir staging - chomp trailing slash

### DIFF
--- a/config/initializers/bundle_dir_roots.yml.erb
+++ b/config/initializers/bundle_dir_roots.yml.erb
@@ -40,4 +40,5 @@ production:
   - '/dpgthumper/'
   - '/dpgthumper2/'
   - '/sdrthumpers/'
+  - '/dor/staging/'
 

--- a/config/initializers/load_config.rb
+++ b/config/initializers/load_config.rb
@@ -1,1 +1,2 @@
 ALLOWABLE_BUNDLE_DIRS = YAML.safe_load(ERB.new(File.read("#{Rails.root}/config/initializers/bundle_dir_roots.yml.erb")).result)[Rails.env]
+ALLOWABLE_BUNDLE_DIRS = ALLOWABLE_BUNDLE_DIRS.map { |path| path.chomp('/') }


### PR DESCRIPTION
bug fix - chomp trailing slash in ALLOWABLE_BUNDLED_DIRS
add dor/staging to production mounts, (union of stage and prod mounts)