### PR TITLE
BC index, kaminari templates and a bugfix

### DIFF
--- a/app/controllers/bundle_contexts_controller.rb
+++ b/app/controllers/bundle_contexts_controller.rb
@@ -17,6 +17,10 @@ class BundleContextsController < ApplicationController
     end
   end
 
+  def index
+    @bundle_contexts = BundleContext.order(:created_at).page(params[:page])
+  end
+
   def show
     @bundle_context = BundleContext.find(params[:id])
   end

--- a/app/views/bundle_contexts/_bundle_context.html.erb
+++ b/app/views/bundle_contexts/_bundle_context.html.erb
@@ -1,8 +1,25 @@
+<div class="row">
+  <h3 class="col bg-light">
+    <%= link_to bundle_context.project_name, bundle_context %> by <%= bundle_context.user.email %>
+  </h3>
+</div>
+<div class="row p-1 pl-5">
+  <div>
+    <%= form_for(bundle_context.job_runs.new) do |form| %>
+    <%= form.hidden_field :bundle_context_id, value: bundle_context.id %>
+    <%= form.hidden_field :job_type, value: 'discovery_report' %>
+    <%= form.submit 'New Discovery Report', class: 'btn btn-sm btn-success' %>
+    <% end %>
+  </div>
+  <div>
+    <%= form_for(bundle_context.job_runs.new) do |form| %>
+    <%= form.hidden_field :bundle_context_id, value: bundle_context.id %>
+    <%= form.hidden_field :job_type, value: 'preassembly' %>
+    <%= form.submit 'Run Preassembly', class: 'btn btn-sm btn-sul-dlss' %>
+    <% end %>
+  </div>
+</div>
 <dl class="dl row">
-  <dt class="col-sm-3">Project Name</dt>
-  <dd class="col-sm-9"><%= bundle_context.project_name %></dd>
-  <dt class="col-sm-3">User</dt>
-  <dd class="col-sm-9"><%= bundle_context.user.email %></dd>
   <dt class="col-sm-3">Content Structure</dt>
   <dd class="col-sm-9"><%= bundle_context.content_structure %></dd>
   <dt class="col-sm-3">Bundle Directory</dt>

--- a/app/views/bundle_contexts/index.html.erb
+++ b/app/views/bundle_contexts/index.html.erb
@@ -1,0 +1,7 @@
+<div class="container">
+  <h2>Projects</h2>
+
+  <%= paginate @bundle_contexts %>
+    <%= render @bundle_contexts %>
+  <%= paginate @bundle_contexts %>
+</div>

--- a/app/views/bundle_contexts/new.html.erb
+++ b/app/views/bundle_contexts/new.html.erb
@@ -9,7 +9,6 @@
       }
     });
   });
-
 </script>
 <div class="container mt-3">
   <div class="row">

--- a/app/views/bundle_contexts/show.html.erb
+++ b/app/views/bundle_contexts/show.html.erb
@@ -1,16 +1,3 @@
 <div class="container mt-5">
   <%= render @bundle_context %>
-  <div class="row mx-auto mt-5">
-    <h3 class="col-sm-12">Actions</h3>
-    <%= form_for(@bundle_context.job_runs.new) do |form| %>
-      <%= form.hidden_field :bundle_context_id, value: @bundle_context.id %>
-      <%= form.hidden_field :job_type, value: 'discovery_report' %>
-      <%= form.submit 'New Discovery Report', class: 'btn btn-success' %>
-    <% end %>
-    <%= form_for(@bundle_context.job_runs.new) do |form| %>
-      <%= form.hidden_field :bundle_context_id, value: @bundle_context.id %>
-      <%= form.hidden_field :job_type, value: 'preassembly' %>
-      <%= form.submit 'Run Preassembly', class: 'btn btn-sul-dlss' %>
-    <% end %>
-  </div>
 </div>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+Kaminari.configure do |config|
+  # config.default_per_page = 25
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.params_on_first_page = false
+end

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Kaminari.configure do |config|
   # config.default_per_page = 25
   # config.max_per_page = nil

--- a/config/initializers/load_config.rb
+++ b/config/initializers/load_config.rb
@@ -1,2 +1,2 @@
-ALLOWABLE_BUNDLE_DIRS = YAML.safe_load(ERB.new(File.read("#{Rails.root}/config/initializers/bundle_dir_roots.yml.erb")).result)[Rails.env]
-ALLOWABLE_BUNDLE_DIRS = ALLOWABLE_BUNDLE_DIRS.map { |path| path.chomp('/') }
+bundle_dir_roots = YAML.safe_load(ERB.new(File.read("#{Rails.root}/config/initializers/bundle_dir_roots.yml.erb")).result)[Rails.env]
+ALLOWABLE_BUNDLE_DIRS = bundle_dir_roots.map { |path| path.chomp('/') }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   devise_for :users, skip: :all
   root to: 'bundle_contexts#new'
-  resources :bundle_contexts, only: [:create, :new, :show]
+  resources :bundle_contexts, only: %i[create index new show]
   resources :job_runs, only: [:create, :index, :show]
   get 'job_runs/:id/download', to: 'job_runs#download', as: 'download'
   mount Resque::Server.new, at: '/resque'

--- a/spec/controllers/bundle_contexts_controller_spec.rb
+++ b/spec/controllers/bundle_contexts_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe BundleContextsController, type: :controller do
       expect(controller.current_user).not_to be_nil
     end
 
-    context 'GET new' do
+    context '#new' do
       it 'renders the new template' do
         get :new
         expect(response).to render_template('new')
@@ -34,7 +34,15 @@ RSpec.describe BundleContextsController, type: :controller do
       end
     end
 
-    context 'POST create' do
+    describe '#index' do
+      it 'renders index' do
+        get :index
+        expect(response).to render_template('index')
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context '#create' do
       context 'Valid Parameters' do
         let(:output_dir) { "#{Settings.job_output_parent_dir}/#{subject.current_user.email}/SMPL-multimedia" }
 

--- a/spec/views/bundle_contexts/show.html.erb_spec.rb
+++ b/spec/views/bundle_contexts/show.html.erb_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'bundle_contexts/show.html.erb', type: :view do
 
   it 'diplays BundleContext info' do
     render
-    expect(rendered).to include("<dd class=\"col-sm-9\">#{bc.project_name}</dd>")
+    expect(rendered).to include("<a href=\"/bundle_contexts/1\">#{bc.project_name}</a> by #{bc.user.email}")
     expect(rendered).to include('<i class="far fa-times-circle"></i>') # icon for symlink="false"
   end
 


### PR DESCRIPTION
- buttons are now part of the partial for a BC, meaning they are included via reuse by `JobRunsController#show` and `BundleContextsController#index` here.
- route added
- minimal test
- BC index does pagination when needed
- Kaminari templates and config generated
- Removed double-assignment of a constant.

Looks like:
![screen shot 2018-10-04 at 5 28 20 pm](https://user-images.githubusercontent.com/109954/46511154-c32f9c80-c801-11e8-96d7-5ec6f4be465f.png)

_________________________________________________________________
Overall, in the future seems like we could use a NavBar with links for:
- "Jobs"
- "Projects"
- "New Project"