### PR TITLE
Updates Header w/ useful links and Adds RSpec tests

### DIFF
--- a/app/views/job_runs/_recent_history.erb
+++ b/app/views/job_runs/_recent_history.erb
@@ -12,9 +12,6 @@
 
 <h4>Recent jobs</h4>
 <div class="container">
-  <%= link_to '[view full history]', job_runs_path %>
-</div>
-<div class="container">
   <table class="table">
       <thead>
         <tr>

--- a/app/views/job_runs/index.html.erb
+++ b/app/views/job_runs/index.html.erb
@@ -1,7 +1,4 @@
 <div class="container">
-  <%= link_to '[start new job]', root_path %>
-</div>
-<div class="container">
   <h2>Job Run History</h2>
 
   <%= paginate @job_runs %>

--- a/app/views/job_runs/show.html.erb
+++ b/app/views/job_runs/show.html.erb
@@ -1,8 +1,4 @@
 <div class="container">
-  <%= link_to '[all jobs]', job_runs_path %>
-</div>
-
-<div class="container">
   <h2><%= @job_run.job_type.humanize %> #<%= @job_run.id %></h2>
 </div>
 

--- a/app/views/shared/_header.erb
+++ b/app/views/shared/_header.erb
@@ -13,7 +13,7 @@
         <%= link_to 'Start New Project', root_path, class: "nav-link" %>
       </li>
       <li class = "nav-item">
-        <a class="nav-link" href="https://github.com/sul-dlss/pre-assembly/wiki">Usage Instructions</a>
+        <%= link_to 'All Projects', bundle_contexts_path, class: "nav-link" %>
       </li>
     </ul>
     <div>

--- a/app/views/shared/_header.erb
+++ b/app/views/shared/_header.erb
@@ -3,14 +3,13 @@
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>
-
   <div class="collapse navbar-collapse">
     <ul class="navbar-nav mx-auto">
       <li class="nav-item">
-        <%= link_to 'All Jobs', job_runs_path, class: "nav-link"%>
+        <%= link_to 'Start New Project', root_path, class: "nav-link" %>
       </li>
       <li class="nav-item">
-        <%= link_to 'Start New Project', root_path, class: "nav-link" %>
+        <%= link_to 'All Jobs', job_runs_path, class: "nav-link"%>
       </li>
       <li class = "nav-item">
         <%= link_to 'All Projects', bundle_contexts_path, class: "nav-link" %>

--- a/app/views/shared/_header.erb
+++ b/app/views/shared/_header.erb
@@ -1,9 +1,24 @@
-<nav class="navbar">
-  <div>
-    <a class="navbar-brand" href="#"><%= link_to image_tag('sul-logo.png', height: '30'), :root %></a>
-  </div>
-  <div>
-    <a class="nav-link user-instruct" href="https://github.com/sul-dlss/pre-assembly/wiki">Usage Instructions</a>
+<nav class="navbar navbar-expand-sm">
+  <a class="navbar-brand" href="#"><%= link_to image_tag('sul-logo.png', height: '30'), :root %></a>
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+
+  <div class="collapse navbar-collapse">
+    <ul class="navbar-nav mx-auto">
+      <li class="nav-item">
+        <%= link_to 'All Jobs', job_runs_path, class: "nav-link"%>
+      </li>
+      <li class="nav-item">
+        <%= link_to 'Start New Project', root_path, class: "nav-link" %>
+      </li>
+      <li class = "nav-item">
+        <a class="nav-link" href="https://github.com/sul-dlss/pre-assembly/wiki">Usage Instructions</a>
+      </li>
+    </ul>
+    <div>
+      <a class="nav-link" href="https://github.com/sul-dlss/pre-assembly/wiki">Usage Instructions</a>
+    </div>
   </div>
 </nav>
 <div style="background-color: #8c1515; color: white; font-family: serif">

--- a/app/views/shared/_header.erb
+++ b/app/views/shared/_header.erb
@@ -1,5 +1,10 @@
 <nav class="navbar">
-  <a class="navbar-brand" href="#"><%= image_tag('sul-logo.png', height: '30') %></a>
+  <div>
+    <a class="navbar-brand" href="#"><%= link_to image_tag('sul-logo.png', height: '30'), :root %></a>
+  </div>
+  <div>
+    <a class="nav-link user-instruct" href="https://github.com/sul-dlss/pre-assembly/wiki">Usage Instructions</a>
+  </div>
 </nav>
 <div style="background-color: #8c1515; color: white; font-family: serif">
   <h1 class="p-4">Accessioning</h1>

--- a/spec/views/shared/_header_spec.rb
+++ b/spec/views/shared/_header_spec.rb
@@ -10,6 +10,9 @@ RSpec.describe 'shared/_header.erb' do
     it 'Start New Projects' do
       expect(rendered).to include("<a class=\"nav-link\" href=\"/\">Start New Project</a>\n")
     end
+    it 'All Projects' do
+      expect(rendered).to include("<a class=\"nav-link\" href=\"/bundle_contexts\">All Projects</a>\n")
+    end
     it 'Accessioning' do
       expect(rendered).to include("<h1 class=\"p-4\">Accessioning</h1>\n")
     end

--- a/spec/views/shared/_header_spec.rb
+++ b/spec/views/shared/_header_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe 'shared/_header.erb' do
-  context "should have the right links on the header" do
+  context 'should have the right links on the header' do
     before { render }
+
     it 'Usage Instructions' do
       expect(rendered).to include("<a class=\"nav-link\" href=\"https://github.com/sul-dlss/pre-assembly/wiki\">Usage Instructions</a>\n")
     end

--- a/spec/views/shared/_header_spec.rb
+++ b/spec/views/shared/_header_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe 'shared/_header.erb' do
+  context "should have the right links on the header" do
+    before { render }
+    it 'Usage Instructions' do
+      expect(rendered).to include("<a class=\"nav-link\" href=\"https://github.com/sul-dlss/pre-assembly/wiki\">Usage Instructions</a>\n")
+    end
+    it 'All Jobs' do
+      expect(rendered).to include("<a class=\"nav-link\" href=\"/job_runs\">All Jobs</a>\n")
+    end
+    it 'Start New Projects' do
+      expect(rendered).to include("<a class=\"nav-link\" href=\"/\">Start New Project</a>\n")
+    end
+    it 'Accessioning' do
+      expect(rendered).to include("<h1 class=\"p-4\">Accessioning</h1>\n")
+    end
+  end
+end


### PR DESCRIPTION
 -  removes unnecessary links that are now located on the header
- adds Projects, Jobs, and Start a new job to header
- Logo now links to Root and Adds usage info too.
- adds Rspec tests
rebased off master


Looks like this full size:

<img width="1676" alt="screen shot 2018-10-05 at 2 04 52 pm" src="https://user-images.githubusercontent.com/7877303/46560264-e0b74180-c8a7-11e8-9d19-79dee41ee0b0.png">

As we shrink the web page it looks like this:

<img width="588" alt="screen shot 2018-10-05 at 2 06 50 pm" src="https://user-images.githubusercontent.com/7877303/46560285-faf11f80-c8a7-11e8-8173-a1354604e190.png">


And then like this:

<img width="550" alt="screen shot 2018-10-05 at 2 07 34 pm" src="https://user-images.githubusercontent.com/7877303/46560317-15c39400-c8a8-11e8-9237-4b9602018afb.png">



closes #314 
closes #410 