### PR TITLE
Better bundle_dir validation, and a couple outstanding cleanups

### DIFF
--- a/app/lib/pre_assembly/bundle.rb
+++ b/app/lib/pre_assembly/bundle.rb
@@ -12,7 +12,6 @@ module PreAssembly
              :apply_tag,
              :bundle_dir,
              :config_filename,
-             :content_exclusion,
              :content_md_creation,
              :content_structure,
              :manifest_rows,
@@ -202,16 +201,8 @@ module PreAssembly
     def new_object_file(stageable, file_path)
       ObjectFile.new(
         file_path,
-        relative_path: relative_path(get_base_dir(stageable), file_path),
-        exclude_from_content: exclude_from_content(file_path)
+        relative_path: relative_path(get_base_dir(stageable), file_path)
       )
-    end
-
-    # If user supplied a content exclusion regex pattern, see
-    # whether it matches the current file path.
-    def exclude_from_content(file_path)
-      return false unless content_exclusion
-      file_path&.match?(content_exclusion) ? true : false
     end
 
     ####

--- a/app/models/bundle_context.rb
+++ b/app/models/bundle_context.rb
@@ -67,11 +67,6 @@ class BundleContext < ApplicationRecord
     nil
   end
 
-  # TODO: Delete everywhere in code as single commit (#228)
-  def file_attr
-    nil
-  end
-
   def smpl_manifest
     'smpl_manifest.csv'
   end

--- a/app/models/bundle_context.rb
+++ b/app/models/bundle_context.rb
@@ -62,11 +62,6 @@ class BundleContext < ApplicationRecord
     {}
   end
 
-  # TODO: Delete everywhere in code as single commit (#227)
-  def content_exclusion
-    nil
-  end
-
   def smpl_manifest
     'smpl_manifest.csv'
   end

--- a/app/models/bundle_context.rb
+++ b/app/models/bundle_context.rb
@@ -10,7 +10,6 @@ class BundleContext < ApplicationRecord
   validates :staging_style_symlink, inclusion: { in: [true, false] }
 
   validate :verify_bundle_directory
-  validate :verify_content_metadata_creation
   validate :verify_bundle_dir_path
 
   after_initialize :normalize_bundle_dir, :default_enums
@@ -116,15 +115,14 @@ class BundleContext < ApplicationRecord
 
   def verify_bundle_directory
     return if errors.key?(:bundle_dir)
-    errors.add(:bundle_dir, "'#{bundle_dir}' not found.") unless File.directory?(bundle_dir)
-  end
-
-  def verify_content_metadata_creation
-    return unless smpl_cm_style?
-    errors.add(:content_metadata_creation, "The SMPL manifest #{smpl_manifest} was not found in #{bundle_dir}.") unless File.exist?(File.join(bundle_dir, smpl_manifest))
+    return errors.add(:bundle_dir, "'#{bundle_dir}' not found.") unless File.directory?(bundle_dir)
+    errors.add(:bundle_dir, "missing manifest: #{bundle_dir}/#{manifest}") unless File.exist?(File.join(bundle_dir, manifest))
+    return unless smpl_cm_style? # only smpl objects require smpl_manifest.csv
+    errors.add(:bundle_dir, "missing SMPL manifest: #{bundle_dir}/#{smpl_manifest}") unless File.exist?(File.join(bundle_dir, smpl_manifest))
   end
 
   def verify_bundle_dir_path
+    return if errors.key?(:bundle_dir)
     match_flag = nil
     bundle_dir_path&.ascend do |sub_path|
       next unless ::ALLOWABLE_BUNDLE_DIRS.include?(sub_path.to_s)

--- a/spec/lib/pre_assembly/bundle_spec.rb
+++ b/spec/lib/pre_assembly/bundle_spec.rb
@@ -182,7 +182,6 @@ RSpec.describe PreAssembly::Bundle do
 
   describe '#new_object_file' do
     it 'returns an ObjectFile with expected path values' do
-      allow(flat_dir_images).to receive(:exclude_from_content).and_return(false)
       tests = [
         # Stageable is a file:
         # - immediately in bundle dir.

--- a/spec/test_data/exemplar_templates/TEMPLATE.yaml
+++ b/spec/test_data/exemplar_templates/TEMPLATE.yaml
@@ -65,16 +65,6 @@ staging_style:    'copy'     # the staging style, can be "copy" or "symlink", de
                              #  if set to "symlink", then all discovered files will be symlinked into the staging directory from the bundle directory
 
 ####
-# Additional materials accompaning the bundle.
-#
-# These file names below should be expressed in relative terms -- relative to bundle_dir.
-####
-
-manifest:         'manifest.csv'       # The manifest file, if 'use_manifest' is true.  Path must be relative to the bundle path. Otherwise, set to ~
-checksums_file:   'checksums.txt'      # A provider checksum file (in default md5sum format).  Path must be relative to the bundle path. If none provided, set to ~
-desc_md_template: 'mods_template.xml'  # An optional descriptive metadata XML template to use in conjunction with the manifest.  Path can be absolute or relative to the bundle path.
-
-####
 # The CSV file is expected with columns (always lowercase):
 # - 'druid', required
 # - 'object', required
@@ -82,10 +72,6 @@ desc_md_template: 'mods_template.xml'  # An optional descriptive metadata XML te
 ####
 # Attributes related to content metadata generation.
 ####
-
-# A regex to exclude staged files from contentMetadata.xml (content will still be staged though).
-content_exclusion: ~             # Include all staged files in content metadata.
-                   '(?i)\.xml$'  # Exclude xml files from content metadata.
 
 # The method used to bundle resources together when generating content metadata.
 content_md_creation:
@@ -96,33 +82,3 @@ content_md_creation:
                                          # part of a single resource node.
                'smpl'                   # Only used by SMPL projects.  Will generate a content metadata file using the SMPL preContentMetadata.
                'none'                   # Do not generate any contentMetadata.xml file.  Select this option only if you have a previously created valid contentMetadata.xml in the root of your staged folder.
-  smpl_manifest:    'smpl_manifest.csv'  # The manifest file for use in SMPL projects.  Typically set to ~ unless style='smpl'
-
-
-####
-# Attributes related common-accessioning steps.
-####
-
-publish_attr:  ~  # Most projects should set this to nil.  If not specified or nil, they will be added by the assembly robots based on mimetype.
-
-  # If you want to specify them here, you can do it in two ways.  First off, don't set 'publish_attr' to nil.  Next
-  # set it globally for all files, like this:
-  shelve:   'no'
-  publish:  'no'
-  preserve: 'yes'
-
-  # The second is by mime-type, nesting under each mimetype (which must be quoted), like this.  The attributes will be set according to the
-  #  mime-type of the file.  You must also set a 'default', which will be applied if no mime-type matches.  If any of the default attributes are
-  # set to nil and no mime-type matches, the attributes will be left off and added during assembly according to the defaults.
-  'image/jp2':
-    publish:            'yes'
-    shelve:             'yes'
-    preserve:           'no'
-  'image/tiff':
-    publish:            'no'
-    shelve:             'no'
-    preserve:           'yes'
-  'default':
-    publish:             'no'
-    shelve:              'no'
-    preserve:            'yes'

--- a/spec/test_data/exemplar_templates/reg_example.yaml
+++ b/spec/test_data/exemplar_templates/reg_example.yaml
@@ -10,16 +10,10 @@ stageable_discovery:
   regex: ~
 
 manifest:   ~
-checksums_file:   ~
-desc_md_template: ~
 
 project_name:      'Gould'
 
 progress_log_file: '/dor/preassembly/gould_log.yaml'
 
-content_exclusion: ~
-
 content_md_creation:
   style:       'default'
-
-publish_attr: ~


### PR DESCRIPTION
- Check for `manifest.csv`
- Check for `smpl_manifest.csv` for SPML object type
- Combine with other bundle_dir validator method
- Error key is `:bundle_dir`, not `:content_metadata_creation`

Tests for each condition.

This would help avoid the "invisible" kind of failure Ben reported when DiscoveryReport fails during the job (for missing manifest file).  