### PR TITLE
Update dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
       mini_exiftool
       nokogiri
     ast (2.4.0)
-    autoprefixer-rails (9.1.4)
+    autoprefixer-rails (9.2.0)
       execjs
     bcrypt (3.1.12)
     bootstrap (4.1.3)
@@ -233,7 +233,7 @@ GEM
     htmlentities (4.3.4)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (1.1.0)
+    i18n (1.1.1)
       concurrent-ruby (~> 1.0)
     iso-639 (0.2.8)
     jaro_winkler (1.5.1)
@@ -265,7 +265,7 @@ GEM
     loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.0)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
@@ -289,11 +289,13 @@ GEM
       iso-639
       nokogiri
       nom-xml (~> 1.0)
-    modsulator (1.0.4)
+    modsulator (1.2.1)
       activesupport
+      deprecation (~> 0)
       equivalent-xml (>= 0.6.0)
       nokogiri
-      roo (>= 1.1)
+      roo (= 2.5.1)
+      stanford-mods-normalizer (~> 0.1)
     mono_logger (1.1.0)
     multi_json (1.13.1)
     multipart-post (2.0.0)
@@ -412,7 +414,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     retries (0.0.5)
-    roo (2.7.1)
+    roo (2.5.1)
       nokogiri (~> 1)
       rubyzip (~> 1.1, < 2.0.0)
     rsolr (2.2.1)
@@ -420,7 +422,7 @@ GEM
       faraday (>= 0.9.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.1)
+    rspec-expectations (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-mocks (3.8.0)
@@ -443,7 +445,7 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    rubocop-rspec (1.29.1)
+    rubocop-rspec (1.30.0)
       rubocop (>= 0.58.0)
     ruby-cache (0.3.0)
     ruby-graphviz (1.2.3)
@@ -507,7 +509,7 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.8)
-    tins (1.16.3)
+    tins (1.17.0)
     turbolinks (5.2.0)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)

--- a/spec/controllers/job_runs_controller_spec.rb
+++ b/spec/controllers/job_runs_controller_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe JobRunsController, type: :controller do
     it 'successfully returns json' do
       get :index, format: 'json'
       expect(response).to have_http_status(:success)
-      expect(response.header).to include('Content-Type' => 'application/json; charset=utf-8')
+      expect(response.header['Content-Type']).to eq 'application/json; charset=utf-8'
     end
   end
 
@@ -68,10 +68,8 @@ RSpec.describe JobRunsController, type: :controller do
       allow(JobRun).to receive(:find).with('123').and_return(job_run_double)
       get :download, params: { id: 123 }
       expect(response).to have_http_status(:success)
-      expect(response.header).to include(
-        'Content-Type' => 'application/x-yaml',
-        'Content-Disposition' => 'attachment; filename="mock_progress_log.yaml"'
-      )
+      expect(response.header['Content-Type']).to eq 'application/x-yaml'
+      expect(response.header['Content-Disposition']).to eq 'attachment; filename="mock_progress_log.yaml"'
       expect(flash[:warning]).to be_nil
     end
     it 'requires ID param' do


### PR DESCRIPTION
`rspec-expectations` updated from https://github.com/rspec/rspec-expectations/compare/v3.8.1...v3.8.2 and changed the function of `.include` - 

```
* Change `include` matcher to rely on a `respond_to?(:include?)` check rather than a direct
  Hash comparison before calling `to_hash` to convert to a hash. (Jordan Owens, #1073)
```

