### PR TITLE
update dor-services to v6; remove assembly-utils gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,10 +16,10 @@ gem 'honeybadger', '~> 3.1'
 # Stanford gems
 gem 'assembly-image'
 gem 'assembly-objectfile', '> 1.6.6'
-gem 'assembly-utils'
+# gem 'assembly-utils'  # only used by a devel/* scripts, which are not regularly used, but this locks dor-services to an old version
 gem 'dir_validator'
 # gem 'dor-fetcher'   # not supported anymore; only used by devel/get_dor_and_sdr_versions.rb script, which is not regularly used
-gem 'dor-services', '< 6'
+gem 'dor-services', '~> 6'
 gem 'dor-services-client', '~> 0.6'
 gem 'druid-tools'
 gem 'harvestdor'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,16 +48,12 @@ GEM
       tzinfo (~> 1.1)
     airbrussh (1.3.1)
       sshkit (>= 1.6.1, != 1.7.0)
-    assembly-image (1.7.3)
+    assembly-image (1.7.4)
       assembly-objectfile (>= 1.6.4)
       mini_exiftool (>= 1.6, < 3)
     assembly-objectfile (1.7.1)
       mime-types
       mini_exiftool
-      nokogiri
-    assembly-utils (1.5.0)
-      dor-services (~> 5.5)
-      druid-tools (>= 0.2.6)
       nokogiri
     awesome_print (1.8.0)
     builder (3.2.3)
@@ -115,11 +111,13 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dor-rights-auth (1.3.0)
       nokogiri
-    dor-services (5.32.1)
-      active-fedora (>= 7.0, < 9.a)
+    dor-services (6.1.11)
+      active-fedora (>= 8.7.0, < 9)
       activesupport (>= 4.2.10, < 6.0.0)
       confstruct (~> 0.2.7)
+      deprecation (~> 0)
       dor-rights-auth (~> 1.0, >= 1.2.0)
+      dor-services-client (~> 0.9)
       dor-workflow-service (~> 2.0, >= 2.0.1)
       druid-tools (>= 0.4.1)
       equivalent-xml (~> 0.5, >= 0.5.1)
@@ -133,7 +131,6 @@ GEM
       retries
       rsolr (>= 1.0.3, < 3)
       ruby-cache (~> 0.3.0)
-      ruby-graphviz
       rubydora (~> 2.1)
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
@@ -303,7 +300,6 @@ GEM
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
     ruby-cache (0.3.0)
-    ruby-graphviz (1.2.4)
     ruby-prof (0.17.0)
     ruby-progressbar (1.10.0)
     rubydora (2.1.0)
@@ -367,7 +363,6 @@ DEPENDENCIES
   actionpack (~> 4.2.10)
   assembly-image
   assembly-objectfile (> 1.6.6)
-  assembly-utils
   awesome_print
   byebug
   capistrano (~> 3)
@@ -377,7 +372,7 @@ DEPENDENCIES
   csv-mapper
   dir_validator
   dlss-capistrano (~> 3.1)
-  dor-services (< 6)
+  dor-services (~> 6)
   dor-services-client (~> 0.6)
   druid-tools
   equivalent-xml
@@ -399,4 +394,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.16.6
+   2.0.1

--- a/lib/pre_assembly.rb
+++ b/lib/pre_assembly.rb
@@ -15,7 +15,6 @@ require 'pre_assembly/object_file'
 require 'pre_assembly/remediation/remediate'
 require 'pre_assembly/smpl_precontent_metadata'
 
-require 'assembly-utils'
 require 'assembly-image'
 require 'rest_client'
 require 'honeybadger'


### PR DESCRIPTION
Has problems - on hold for now until necessary.

- [ ] update dor-services gem
- [ ] ~remove assembly-utils gem (locks dor-services to < 6 currently, and only used in a handful of one-off devel scripts, which are sparsely used)~  assembly-utils is used a bunch in this branch, oops...may need to go update assembly-utils to allow later dor-services
- [ ] investigate if dor-workflow-service needs to be configured differently?