### PR TITLE
unpin and update dor-services-client, update call

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'assembly-utils'
 gem 'dir_validator'
 # gem 'dor-fetcher'   # not supported anymore; only used by devel/get_dor_and_sdr_versions.rb script, which is not regularly used
 gem 'dor-services', '< 6'
-gem 'dor-services-client', '~> 0.6'
+gem 'dor-services-client'
 gem 'druid-tools'
 gem 'harvestdor'
 gem 'modsulator'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,10 +140,11 @@ GEM
       stanford-mods-normalizer (~> 0.1)
       systemu (~> 2.6)
       uuidtools (~> 2.1.4)
-    dor-services-client (0.10.0)
+    dor-services-client (1.7.0)
       activesupport (>= 4.2, < 6)
       deprecation
       faraday (~> 0.15)
+      moab-versioning (~> 4.0)
       nokogiri (~> 1.8)
     dor-workflow-service (2.12.0)
       activesupport (>= 3.2.1, < 6)
@@ -378,7 +379,7 @@ DEPENDENCIES
   dir_validator
   dlss-capistrano (~> 3.1)
   dor-services (< 6)
-  dor-services-client (~> 0.6)
+  dor-services-client
   druid-tools
   equivalent-xml
   harvestdor
@@ -399,4 +400,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.16.6
+   1.17.2

--- a/lib/pre_assembly/digital_object.rb
+++ b/lib/pre_assembly/digital_object.rb
@@ -496,19 +496,17 @@ module PreAssembly
       return unless @init_assembly_wf
       log "    - initialize_assembly_workflow()"
 
-      with_retries(max_tries: Dor::Config.dor.num_attempts, rescue: Exception, handler: PreAssembly.retry_handler('INITIALIZE_ASSEMBLY_WORKFLOW', method(:log))) do
-        begin
-          api_client.initialize_workflow(object: @druid.druid, wf_name: workflow_name)
-        rescue StandardError => error
-          raise PreAssembly::UnknownError, "POST to assemblyWF endpoint at #{Dor::Config.dor_services_url} returned #{error}"
-        end
-      end
+       with_retries(max_tries: Dor::Config.dor.num_attempts, rescue: Exception, handler: PreAssembly.retry_handler('INITIALIZE_ASSEMBLY_WORKFLOW', method(:log))) do
+          api_client.object(@druid.druid).workflow.create(wf_name: workflow_name)
+       end
     end
 
     private
 
     def api_client
-      @api_client ||= Dor::Services::Client.configure(url: Dor::Config.dor_services.url)
+      @api_client ||= Dor::Services::Client.configure(url: Dor::Config.dor_services.url,
+                                                      username: Dor::Config.dor_services.user,
+                                                      password: Dor::Config.dor_services.pass)
     end
 
     def workflow_name

--- a/spec/digital_object_spec.rb
+++ b/spec/digital_object_spec.rb
@@ -800,7 +800,7 @@ describe PreAssembly::DigitalObject do
   describe '#initialize_assembly_workflow' do
     before do
       allow(@dobj).to receive(:api_client).and_return(client)
-      allow(Dor::Config).to receive(:dor_services_url).and_return(service_url)
+      allow(@dobj).to receive(:druid).and_return(@dru)
       @dobj.init_assembly_wf = true
       @dobj.druid = @druid
     end
@@ -819,27 +819,26 @@ describe PreAssembly::DigitalObject do
       end
     end
 
-    context 'when api client is successful' do
+    context 'when @init_assembly_wf is true' do
       before do
-        allow(client).to receive(:initialize_workflow)
+        allow(client).to receive_message_chain(:object, :workflow, :create)
       end
 
       it 'starts the assembly workflow' do
-        expect { @dobj.initialize_assembly_workflow }.not_to raise_error
-        expect(client).to have_received(:initialize_workflow).once
+        expect(@dobj).to receive(:api_client)
+        @dobj.initialize_assembly_workflow
       end
     end
 
     context 'when the api client raises' do
       before do
-        allow(client).to receive(:initialize_workflow).and_raise(Dor::Services::Client::UnexpectedResponse)
+        allow(client).to receive_message_chain(:object, :workflow, :create).and_raise(Exception)
       end
 
       it 'raises an exception' do
-        expect { @dobj.initialize_assembly_workflow }.to raise_error(
-          /POST to assemblyWF endpoint at #{service_url} returned Dor::Services::Client::UnexpectedResponse/
-        )
+        expect { @dobj.initialize_assembly_workflow }.to raise_error(Exception)
       end
     end
+
   end
 end


### PR DESCRIPTION
fixes #473

- [x] update dor-services-client version
- [x] update method call to match latest version
- [x] update dor-services-client configuration
- [x] update specs
- [x] confirm shared configuration files on servers (-test and -prod) are correct
- [x] remove unneeded rescue block, which was previously refactored to be handled by the retries gem

smoke tested and validated on sul-lyberservices-test

