### PR TITLE
Changed SMPL option for content structure and content metadata creation

### DIFF
--- a/app/models/bundle_context.rb
+++ b/app/models/bundle_context.rb
@@ -118,7 +118,7 @@ class BundleContext < ApplicationRecord
     return errors.add(:bundle_dir, "'#{bundle_dir}' not found.") unless File.directory?(bundle_dir)
     errors.add(:bundle_dir, "missing manifest: #{bundle_dir}/#{manifest}") unless File.exist?(File.join(bundle_dir, manifest))
     return unless smpl_cm_style? # only smpl objects require smpl_manifest.csv
-    errors.add(:bundle_dir, "missing SMPL manifest: #{bundle_dir}/#{smpl_manifest}") unless File.exist?(File.join(bundle_dir, smpl_manifest))
+    errors.add(:bundle_dir, "missing Media (SMPL) manifest: #{bundle_dir}/#{smpl_manifest}") unless File.exist?(File.join(bundle_dir, smpl_manifest))
   end
 
   def verify_bundle_dir_path

--- a/app/views/bundle_contexts/_new_bc_form.erb
+++ b/app/views/bundle_contexts/_new_bc_form.erb
@@ -28,7 +28,7 @@
                 ['Simple Book', 'simple_book'],
                 ['Book as Image','book_as_image'],
                 ['File', 'file'],
-                ['SMPL', 'smpl']
+                ['Media', 'smpl']
             ]
             %>
         </div>
@@ -52,7 +52,7 @@
                 [
                     ["Default", "default"],
                     ["Filename", "filename"],
-                    ["SMPL", "smpl_cm_style"]
+                    ["Media", "smpl_cm_style"]
                 ]
             %>
         </div>

--- a/spec/models/bundle_context_spec.rb
+++ b/spec/models/bundle_context_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe BundleContext, type: :model do
     it 'adds error if spml object is missing smpl_manifest.csv' do
       allow(bc).to receive(:smpl_cm_style?).and_return(true)
       bc.send(:verify_bundle_directory)
-      expect(bc.errors.to_h).to include(bundle_dir: /missing SMPL manifest/)
+      expect(bc.errors.to_h).to include(bundle_dir: /missing Media \(SMPL\) manifest/)
     end
   end
 end


### PR DESCRIPTION
Changed option text from **SMPL** to **Media** in **Content Structure** and **Content metadata creation** select fields.

![Screen Shot 2019-08-12 at 10 16 44 AM](https://user-images.githubusercontent.com/71847/62880315-5a9b3100-bcea-11e9-86fb-0cea8b203e53.png)

For #490
