### PR TITLE
add 3d as a valid content type structure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'uglifier' # compressor for JavaScript assets
 
 # Stanford gems
 gem 'assembly-image', '~> 1.7'
-gem 'assembly-objectfile', '~> 1.7'
+gem 'assembly-objectfile', '~> 1.7', '>= 1.7.2' # 1.7.2 is the first version to support 3d content metadata generation
 gem 'dor-services', '~> 7.1'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,8 +63,8 @@ GEM
     assembly-image (1.7.5)
       assembly-objectfile (>= 1.6.4)
       mini_exiftool (>= 1.6, < 3)
-    assembly-objectfile (1.7.1)
-      mime-types
+    assembly-objectfile (1.7.2)
+      mime-types (> 3)
       mini_exiftool
       nokogiri
     ast (2.4.0)
@@ -528,7 +528,7 @@ PLATFORMS
 
 DEPENDENCIES
   assembly-image (~> 1.7)
-  assembly-objectfile (~> 1.7)
+  assembly-objectfile (~> 1.7, >= 1.7.2)
   bootstrap (~> 4.3, >= 4.3.1)
   capistrano-bundler
   capistrano-passenger

--- a/app/lib/pre_assembly/digital_object.rb
+++ b/app/lib/pre_assembly/digital_object.rb
@@ -64,7 +64,8 @@ module PreAssembly
         'Book (image-only)' => :book_as_image,
         'Manuscript (flipbook, ltr)' => :simple_book,
         'Manuscript (image-only)' => :book_as_image,
-        'Map' => :map
+        'Map' => :map,
+        '3D' => :'3d'
       }
       content_type_tag_mapping[content_type_tag] || content_structure.to_sym
     end

--- a/app/models/bundle_context.rb
+++ b/app/models/bundle_context.rb
@@ -19,7 +19,8 @@ class BundleContext < ApplicationRecord
     'simple_book' => 1,
     'book_as_image' => 2,
     'file' => 3,
-    'smpl' => 4
+    'smpl' => 4,
+    '3d' => 5
   }
 
   enum content_metadata_creation: {

--- a/app/views/bundle_contexts/_new_bc_form.erb
+++ b/app/views/bundle_contexts/_new_bc_form.erb
@@ -28,7 +28,8 @@
                 ['Simple Book', 'simple_book'],
                 ['Book as Image','book_as_image'],
                 ['File', 'file'],
-                ['Media', 'smpl']
+                ['Media', 'smpl'],
+                ['3D', '3d'],
             ]
             %>
         </div>

--- a/spec/models/bundle_context_spec.rb
+++ b/spec/models/bundle_context_spec.rb
@@ -55,7 +55,8 @@ RSpec.describe BundleContext, type: :model do
       'simple_book' => 1,
       'book_as_image' => 2,
       'file' => 3,
-      'smpl' => 4
+      'smpl' => 4,
+      '3d' => 5
     )
   end
   it do

--- a/spec/test_data/exemplar_templates/TEMPLATE.yaml
+++ b/spec/test_data/exemplar_templates/TEMPLATE.yaml
@@ -48,6 +48,8 @@ project_style:
 
                      'smpl'          # Used for SMPL projects
 
+                     '3d'            # Bundles 3d file types into <contentMetadata type="3d"> and 3d file extensions into <resource type="3d"> and others into <resource type="file">
+
   content_tag_override:   false      # DEFAULT if not supplied -- content_structure as defined above is always used even if the object is registered with a content type tag
                           true       # if set to true; then content_structure type is deteremined from registered object content type tag using mappings defined in pre-assembly if possible;
                                      # if no content tag is available or an unknown mapping occurs, the default content_structure defined in the YAML is used


### PR DESCRIPTION
~~pre-req: https://github.com/sul-dlss/assembly-objectfile/pull/7~~

addresses #427 and #428

Note that the `assembly-objectfile` gem is actually responsible for creating the contentMetadata, so this just needs to add the type as a selectable option.  Everything else happens in the gem.

