### PR TITLE
adds 3d support for v3-legacy accessioning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'honeybadger', '~> 3.1'
 
 # Stanford gems
 gem 'assembly-image'
-gem 'assembly-objectfile', '> 1.6.6'
+gem 'assembly-objectfile', '>= 1.7.2' # 1.7.2 is the first version to support 3d content metadata generation
 gem 'assembly-utils'
 gem 'dir_validator'
 # gem 'dor-fetcher'   # not supported anymore; only used by devel/get_dor_and_sdr_versions.rb script, which is not regularly used

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GEM
       tzinfo (~> 1.1)
     airbrussh (1.3.2)
       sshkit (>= 1.6.1, != 1.7.0)
-    assembly-image (1.7.5)
+    assembly-image (1.7.6)
       assembly-objectfile (>= 1.6.4)
       mini_exiftool (>= 1.6, < 3)
     assembly-objectfile (1.7.1)
@@ -402,4 +402,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.0.2
+   2.0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,8 +51,8 @@ GEM
     assembly-image (1.7.6)
       assembly-objectfile (>= 1.6.4)
       mini_exiftool (>= 1.6, < 3)
-    assembly-objectfile (1.7.1)
-      mime-types
+    assembly-objectfile (1.7.2)
+      mime-types (> 3)
       mini_exiftool
       nokogiri
     assembly-utils (1.5.0)
@@ -369,7 +369,7 @@ DEPENDENCIES
   actionmailer (~> 4.2.10)
   actionpack (~> 4.2.10)
   assembly-image
-  assembly-objectfile (> 1.6.6)
+  assembly-objectfile (>= 1.7.2)
   assembly-utils
   awesome_print
   byebug

--- a/config/projects/TEMPLATE.yaml
+++ b/config/projects/TEMPLATE.yaml
@@ -65,6 +65,8 @@ project_style:
                      'book_as_image' # Like simple_book, but with <contentMetadata type="book"> and <resource type="image"> instead of "page".
                                                 
                      'smpl'          # Used for SMPL projects
+
+                     '3d'            # Used for 3d objects
                      
   content_tag_override:   false      # DEFAULT if not supplied -- content_structure as defined above is always used even if the object is registered with a content type tag             
                           true       # if set to true; then content_structure type is deteremined from registered object content type tag using mappings defined in pre-assembly if possible;

--- a/lib/pre_assembly/bundle.rb
+++ b/lib/pre_assembly/bundle.rb
@@ -154,7 +154,7 @@ module PreAssembly
     def allowed_values
       {
         :project_style=>{
-          :content_structure=>[:simple_image,:simple_book,:book_as_image,:book_with_pdf,:file,:smpl],
+          :content_structure=>[:simple_image,:simple_book,:book_as_image,:book_with_pdf,:file,:smpl,:'3d'],
           :get_druid_from=>[:suri,:container,:container_barcode,:manifest,:druid_minter],
           },
         :content_md_creation=>{


### PR DESCRIPTION
(like #516 but for the v3-legacy branch)

~~pre-req: https://github.com/sul-dlss/assembly-objectfile/pull/7~~

addresses #427 and #428

Note that the assembly-objectfile gem is actually responsible for creating the contentMetadata, so this just needs to add the type as a selectable option. Everything else happens in the gem
