### PR TITLE
use sassc <2.1.0 to avoid GLIBC_2.14 not found error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'resque', '~> 2.0' # needs to match redis on VM
 gem 'resque-lock'
 gem 'resque-pool'
 gem 'roo' # for processing spreadsheets
+gem 'sassc', '~> 2.0.1' # Pinning to 2.0 because 2.1 requires GLIBC 2.14 on deploy
 gem 'simple_form' # rails form that handles errors internally and easily integrated w/ Bootstrap
 gem 'turbolinks' # improves speed of following links in web application
 gem 'uglifier' # compressor for JavaScript assets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -450,8 +450,9 @@ GEM
       nokogiri
       rest-client
     rubyzip (1.2.3)
-    sassc (2.1.0)
+    sassc (2.0.1)
       ffi (~> 1.9)
+      rake
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
       sassc (>= 2.0)
@@ -564,6 +565,7 @@ DEPENDENCIES
   rubocop (~> 0.60.0)
   rubocop-rspec
   ruby-prof
+  sassc (~> 2.0.1)
   shoulda-matchers (~> 4.0.0.rc1)
   simple_form
   sqlite3 (~> 1.3.13)


### PR DESCRIPTION
fixes deployment problem:  We can't deploy sassc 2.1.0 on our Centos 6 machines because it has glibc 2.12 and 2.14 is required for sassc 2.1.0;   sassc 2.0.1 fixes the problem.