### PR TITLE
Remove token_header keyword arg when configuring dor-services-client

### DIFF
--- a/config/initializers/dor_services_client.rb
+++ b/config/initializers/dor_services_client.rb
@@ -2,5 +2,4 @@
 
 # Configure dor-services-client to use the dor-services URL
 Dor::Services::Client.configure(url: Settings.DOR_SERVICES.URL,
-                                token: Settings.DOR_SERVICES.TOKEN,
-                                token_header: Settings.DOR_SERVICES.TOKEN_HEADER)
+                                token: Settings.DOR_SERVICES.TOKEN)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,4 +16,3 @@ job_output_parent_dir:  'log/jobs'
 DOR_SERVICES:
   URL: 'http://localhost:3003'
   TOKEN: 'secret-token'
-  TOKEN_HEADER: 'X-Auth' # This has to match dor-services-app ApplicationController::TOKEN_HEADER


### PR DESCRIPTION
This is no longer required, and in fact can break the client if the header value (from shared_configs) is unset. This is what broke the workflow service connection to dor-services-app.