### PR TITLE
Remove unused dependency 'roo'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem 'rake'
 gem 'resque', '~> 2.0' # needs to match redis on VM
 gem 'resque-lock'
 gem 'resque-pool'
-gem 'roo' # for processing spreadsheets
 gem 'sassc', '~> 2.0.1' # Pinning to 2.0 because 2.1 requires GLIBC 2.14 on deploy
 gem 'simple_form' # rails form that handles errors internally and easily integrated w/ Bootstrap
 gem 'turbolinks' # improves speed of following links in web application

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -414,9 +414,6 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     retries (0.0.5)
-    roo (2.8.2)
-      nokogiri (~> 1)
-      rubyzip (>= 1.2.1, < 2.0.0)
     rsolr (2.2.1)
       builder (>= 2.1.2)
       faraday (>= 0.9.0)
@@ -460,7 +457,6 @@ GEM
       mime-types
       nokogiri
       rest-client
-    rubyzip (1.3.0)
     sassc (2.0.1)
       ffi (~> 1.9)
       rake
@@ -572,7 +568,6 @@ DEPENDENCIES
   resque (~> 2.0)
   resque-lock
   resque-pool
-  roo
   rspec-rails (~> 3.7)
   rubocop (~> 0.60.0)
   rubocop-rspec


### PR DESCRIPTION
## Why was this change made?

One of roo's dependencies, rubyzip has a vulnerability. Since we don't need roo, the best thing to do is remove the dependency.


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

N/A