### PR TITLE
Extract AssemblyDirectory class from DigitalObject

### DIFF
--- a/app/lib/pre_assembly/assembly_directory.rb
+++ b/app/lib/pre_assembly/assembly_directory.rb
@@ -1,0 +1,55 @@
+module PreAssembly
+  # Represents the assembly structure on the filesystem
+  class AssemblyDirectory
+    def self.create(druid_id:)
+      new(druid_id: druid_id).tap(&:create_object_directories)
+    end
+
+    def initialize(druid_id:)
+      @druid_id = druid_id
+    end
+
+    def create_object_directories
+      FileUtils.mkdir_p druid_tree_dir unless File.directory?(druid_tree_dir)
+      FileUtils.mkdir_p metadata_dir unless File.directory?(metadata_dir)
+      FileUtils.mkdir_p content_dir unless File.directory?(content_dir)
+    end
+
+    def path_for(item_path)
+      # these are the names of special datastream files that will be staged in the 'metadata' folder instead of the 'content' folder
+      metadata_files = ['descMetadata.xml', 'contentMetadata.xml'].map(&:downcase)
+
+      metadata_files.include?(File.basename(item_path).downcase) ? metadata_dir : content_dir
+    end
+
+    # compute the base druid tree folder for this object
+    def druid_tree_dir
+      @druid_tree_dir ||= DruidTools::Druid.new(druid_id, assembly_staging_dir).path
+    end
+
+    def content_dir
+      @content_dir ||= File.join(druid_tree_dir, 'content')
+    end
+
+    # the metadata subfolder
+    def metadata_dir
+      @metadata_dir ||= File.join(druid_tree_dir, 'metadata')
+    end
+
+    def technical_metadata_file
+      File.join(metadata_dir, 'technicalMetadata.xml')
+    end
+
+    def content_metadata_file
+      File.join(metadata_dir, 'contentMetadata.xml')
+    end
+
+    private
+
+    attr_reader :druid_id
+
+    def assembly_staging_dir
+      Settings.assembly_staging_dir
+    end
+  end
+end

--- a/spec/lib/pre_assembly/assembly_directory_spec.rb
+++ b/spec/lib/pre_assembly/assembly_directory_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe PreAssembly::AssemblyDirectory do
+  subject(:object) { described_class.new(druid_id: 'gn330dv6119') }
+
+  describe 'druid tree' do
+    it 'has the correct folders (using the contemporary style)' do
+      expect(object.druid_tree_dir).to eq('tmp/assembly/gn/330/dv/6119/gn330dv6119')
+      expect(object.metadata_dir).to eq('tmp/assembly/gn/330/dv/6119/gn330dv6119/metadata')
+      expect(object.content_dir).to eq('tmp/assembly/gn/330/dv/6119/gn330dv6119/content')
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

DigitalObject has more than one responsibility so it would be easier to understand if some of them were extracted.

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?
n/a