### PR TITLE
Simplify how DigitalObject is initialized

### DIFF
--- a/app/lib/pre_assembly/bundle.rb
+++ b/app/lib/pre_assembly/bundle.rb
@@ -76,20 +76,17 @@ module PreAssembly
     # @return [Array<DigitalObject>]
     def digital_objects
       @digital_objects ||= discover_containers_via_manifest.each_with_index.map do |c, i|
-        params = {
-          container: c,
-          stageable_items: discover_items_via_crawl(c),
-          stager: stager
-        }
-        params[:object_files] = discover_object_files(params[:stageable_items])
-        DigitalObject.new(self, params).tap do |dobj|
-          r = manifest_rows[i]
-          # Get label and source_id from column names declared in YAML config.
-          dobj.label        = r['label'] || ''
-          dobj.source_id    = r['sourceid']
-          # Also store a hash of all values from the manifest row, using column names as keys.
-          dobj.manifest_row = r
-        end
+        stageable_items = discover_items_via_crawl(c)
+        row = manifest_rows[i]
+
+        DigitalObject.new(self,
+                          container: c,
+                          stageable_items: stageable_items,
+                          object_files: discover_object_files(stageable_items),
+                          label: row.fetch('label', ''),
+                          source_id: row['sourceid'],
+                          pid: row[:druid],
+                          stager: stager)
       end
     end
 

--- a/app/lib/pre_assembly/digital_object.rb
+++ b/app/lib/pre_assembly/digital_object.rb
@@ -2,7 +2,8 @@ module PreAssembly
   class DigitalObject
     include PreAssembly::Logging
 
-    attr_reader :bundle, :stageable_items, :object_files, :stager
+    attr_reader :bundle, :stageable_items, :object_files,
+                :stager, :label, :pid, :source_id
 
     delegate :bundle_dir,
              :content_md_creation,
@@ -12,28 +13,29 @@ module PreAssembly
              to: :bundle
 
     attr_accessor :container,
-                  :label,
-                  :manifest_row,
-                  :pre_assem_finished,
-                  :source_id
+                  :pre_assem_finished
 
     # @param [PreAssembly::Bundle] bundle
     # @param [String] container the identifier (non-namespaced)
     # @param [Array<String>] stageable_items items to stage
     # @param [Array<ObjectFile>] object_files path to files that are part of the object
+    # @param [String] label The label for this object
+    # @param [String] pid The identifier for the item
+    # @param [String] source_id The source identifier
     # @param [Object] stager the implementation of how to stage an object
-    def initialize(bundle, container: nil, stageable_items: nil, object_files: nil, stager:)
+    # rubocop:disable Metrics/ParameterLists
+    def initialize(bundle, container: nil, stageable_items: nil, object_files: nil,
+                   label: nil, pid: nil, source_id: nil, stager:)
       @bundle = bundle
       @container = container
       @stageable_items = stageable_items
       @object_files = object_files
+      @label = label
+      @pid = pid
+      @source_id = source_id
       @stager = stager
-      setup
     end
-
-    def setup
-      self.label = 'Unknown' # used for registration when no label is provided in the manifest
-    end
+    # rubocop:enable Metrics/ParameterLists
 
     # set this object's content_md_creation_style
     # @return [Symbol]
@@ -78,13 +80,6 @@ module PreAssembly
     # @return [DruidTools::Druid]
     def druid
       @druid ||= DruidTools::Druid.new(pid)
-    end
-
-    def pid
-      @pid ||= begin
-        raise 'manifest_row is required' unless manifest_row
-        manifest_row[:druid]
-      end
     end
 
     def dor_object

--- a/spec/lib/pre_assembly/bundle_spec.rb
+++ b/spec/lib/pre_assembly/bundle_spec.rb
@@ -115,7 +115,6 @@ RSpec.describe PreAssembly::Bundle do
         expect(dobj.label).to be_a(String)
         expect(dobj.label).not_to eq('Unknown') # hardcoded in class
         expect(dobj.source_id).to be_a(String)
-        expect(dobj.manifest_row).to be_a(Hash)
       end
     end
   end


### PR DESCRIPTION
## Why was this change made?

So we don't need so many setters and can just pass the values in when initializing the DigitalObject

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?
n/a