### PR TITLE
Do dependency injection of the stager

### DIFF
--- a/app/lib/pre_assembly/bundle.rb
+++ b/app/lib/pre_assembly/bundle.rb
@@ -78,7 +78,8 @@ module PreAssembly
       @digital_objects ||= discover_containers_via_manifest.each_with_index.map do |c, i|
         params = {
           container: c,
-          stageable_items: discover_items_via_crawl(c)
+          stageable_items: discover_items_via_crawl(c),
+          stager: stager
         }
         params[:object_files] = discover_object_files(params[:stageable_items])
         DigitalObject.new(self, params).tap do |dobj|
@@ -147,6 +148,10 @@ module PreAssembly
     end
 
     private
+
+    def stager
+      staging_style_symlink ? LinkStager : CopyStager
+    end
 
     # Discover object containers from a manifest.
     # The relative path to the container is supplied in one of the

--- a/app/lib/pre_assembly/copy_stager.rb
+++ b/app/lib/pre_assembly/copy_stager.rb
@@ -1,0 +1,7 @@
+module PreAssembly
+  class CopyStager
+    def self.stage(source, destination)
+      FileUtils.cp_r source, destination
+    end
+  end
+end

--- a/app/lib/pre_assembly/link_stager.rb
+++ b/app/lib/pre_assembly/link_stager.rb
@@ -1,0 +1,7 @@
+module PreAssembly
+  class LinkStager
+    def self.stage(source, destination)
+      FileUtils.ln_s source, destination, force: true
+    end
+  end
+end

--- a/spec/lib/pre_assembly/media_spec.rb
+++ b/spec/lib/pre_assembly/media_spec.rb
@@ -65,7 +65,8 @@ RSpec.describe PreAssembly::Media do
   # some helper methods for these tests
   def setup_dobj(druid, media_manifest)
     allow(bc.bundle).to receive(:media_manifest).and_return(media_manifest)
-    PreAssembly::DigitalObject.new(bc.bundle, container: druid).tap do |dobj|
+    PreAssembly::DigitalObject.new(bc.bundle, container: druid,
+                                              stager: PreAssembly::CopyStager).tap do |dobj|
       allow(dobj).to receive(:pid).and_return("druid:#{druid}")
       allow(dobj).to receive(:content_md_creation).and_return('media_cm_style')
     end


### PR DESCRIPTION
## Why was this change made?

In this way staging_style_symlink does not need to be delegated from BundleContext to Bundle to DigitalObject

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

n/a