### PR TITLE
Extract technical_metadata_creation

### DIFF
--- a/app/lib/pre_assembly/media_project_technical_metadata_creator.rb
+++ b/app/lib/pre_assembly/media_project_technical_metadata_creator.rb
@@ -1,0 +1,55 @@
+module PreAssembly
+  # Looks for *_techmd.xml files in the bundle_dir and concatenates them
+  class MediaProjectTechnicalMetadataCreator
+    def initialize(pid:, bundle_dir:, container:)
+      @pid = pid
+      @bundle_dir = bundle_dir
+      @container = container
+    end
+
+    # find all technical metadata files and append the xml to the combined technicalMetadata
+    def create
+      build_document do |combined|
+        in_bundle_directory do
+          tech_files_in_current_directory.each do |filename|
+            append_file(combined, filename)
+          end
+        end
+      end
+    end
+
+    private
+
+    attr_reader :bundle_dir, :container, :pid
+
+    def container_basename
+      File.basename(container)
+    end
+
+    def append_file(combined, filename)
+      tech_md_xml = Nokogiri::XML(File.open(File.join(bundle_dir, container_basename, filename)))
+      combined.root << tech_md_xml.root
+    end
+
+    def tech_files_in_current_directory
+      Dir.glob('**/*_techmd.xml').sort
+    end
+
+    def in_bundle_directory
+      current_directory = Dir.pwd
+      FileUtils.cd(File.join(bundle_dir, container_basename))
+      yield
+      FileUtils.cd(current_directory)
+    end
+
+    def build_document
+      tm = Nokogiri::XML::Document.new
+      tm_node = Nokogiri::XML::Node.new('technicalMetadata', tm)
+      tm_node['objectId'] = pid
+      tm_node['datetime'] = Time.now.utc.strftime('%Y-%m-%d-T%H:%M:%SZ')
+      tm << tm_node
+      yield tm
+      tm.to_xml
+    end
+  end
+end

--- a/spec/lib/pre_assembly/digital_object_spec.rb
+++ b/spec/lib/pre_assembly/digital_object_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe PreAssembly::DigitalObject do
       allow(object).to receive(:current_object_version).and_return(1)
       expect(object).to receive(:stage_files)
       expect(object).to receive(:generate_content_metadata)
-      expect(object).to receive(:generate_technical_metadata)
       expect(object).not_to receive(:create_new_version)
       expect(object).to receive(:initialize_assembly_workflow)
       object.pre_assemble
@@ -56,18 +55,9 @@ RSpec.describe PreAssembly::DigitalObject do
       allow(object).to receive(:current_object_version).and_return(2)
       expect(object).to receive(:stage_files)
       expect(object).to receive(:generate_content_metadata)
-      expect(object).to receive(:generate_technical_metadata)
       expect(object).to receive(:create_new_version)
       expect(object).to receive(:initialize_assembly_workflow)
       object.pre_assemble
-    end
-  end
-
-  describe '#container_basename' do
-    it 'returns expected value' do
-      d = 'xx111yy2222'
-      object.container = "foo/bar/#{d}"
-      expect(object.container_basename).to eq(d)
     end
   end
 

--- a/spec/lib/pre_assembly/media_project_technical_metadata_creator_spec.rb
+++ b/spec/lib/pre_assembly/media_project_technical_metadata_creator_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe PreAssembly::MediaProjectTechnicalMetadataCreator do
+  subject(:creator) do
+    described_class.new(pid: "druid:#{druid}",
+                        bundle_dir: bundle_dir,
+                        container: druid)
+  end
+
+  let(:bundle_dir) { Rails.root.join('spec/test_data/multimedia') }
+  let(:druid) { 'aa111aa1111' }
+
+  describe '#create_content_metadata - no thumb declaration' do
+    subject(:exp_xml) { noko_doc(creator.create) }
+
+    it 'generates technicalMetadata for Media by combining all existing _techmd.xml files' do
+      expect(exp_xml.css('technicalMetadata').size).to eq(1) # one top level node
+      expect(exp_xml.css('Mediainfo').size).to eq(2) # two Mediainfo nodes
+      counts = exp_xml.css('Count')
+      expect(counts.size).to eq(4) # four nodes that have file info
+      # look for some specific bits in the files that have been assembled
+      expect(counts.map(&:content)).to eq(%w[279 217 280 218])
+    end
+  end
+
+  describe '#container_basename' do
+    subject(:creator) do
+      described_class.new(pid: "druid:#{druid}",
+                          bundle_dir: bundle_dir,
+                          container: "foo/bar/#{druid}")
+    end
+
+    let(:druid) { 'xx111yy2222' }
+
+    it 'returns expected value' do
+      expect(creator.send(:container_basename)).to eq(druid)
+    end
+  end
+end

--- a/spec/lib/pre_assembly/media_spec.rb
+++ b/spec/lib/pre_assembly/media_spec.rb
@@ -17,16 +17,6 @@ RSpec.describe PreAssembly::Media do
       described_class.new(csv_filename: 'media_manifest.csv', bundle_dir: bundle_dir)
     end
 
-    it 'generates technicalMetadata for Media by combining all existing _techmd.xml files' do
-      exp_xml = noko_doc(dobj1.create_technical_metadata)
-      expect(exp_xml.css('technicalMetadata').size).to eq(1) # one top level node
-      expect(exp_xml.css('Mediainfo').size).to eq(2) # two Mediainfo nodes
-      counts = exp_xml.css('Count')
-      expect(counts.size).to eq(4) # four nodes that have file info
-      # look for some specific bits in the files that have been assembled
-      expect(counts.map(&:content)).to eq(%w[279 217 280 218])
-    end
-
     it 'generates content metadata from a Media manifest with no thumb columns' do
       expect(noko_doc(dobj1.create_content_metadata)).to be_equivalent_to noko_doc(exp_xml_object_aa111aa1111)
       expect(noko_doc(dobj2.create_content_metadata)).to be_equivalent_to noko_doc(exp_xml_object_bb222bb2222)


### PR DESCRIPTION
## Why was this change made?

Each class should only have one responsibility. This moves the responsibility for creating techMetadata.xml into it's own class.

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?
n/a