### PR TITLE
Keep progress separate from the model

### DIFF
--- a/app/lib/pre_assembly/bundle.rb
+++ b/app/lib/pre_assembly/bundle.rb
@@ -113,17 +113,17 @@ module PreAssembly
         log "  - Processing object: #{dobj.container}"
         log "  - N object files: #{dobj.object_files.size}"
         num_no_file_warnings += 1 if dobj.object_files.empty?
-
+        progress = { dobj: dobj }
         begin
           # Try to pre_assemble the digital object.
           load_checksums(dobj)
           dobj.pre_assemble
           # Indicate that we finished.
-          dobj.pre_assem_finished = true
+          progress[:pre_assem_finished] = true
           log "Completed #{dobj.druid}"
         ensure
           # Log the outcome no matter what.
-          File.open(progress_log_file, 'a') { |f| f.puts log_progress_info(dobj).to_yaml }
+          File.open(progress_log_file, 'a') { |f| f.puts log_progress_info(progress).to_yaml }
         end
       end
     ensure
@@ -135,11 +135,11 @@ module PreAssembly
       @o2p ||= digital_objects.reject { |dobj| skippables.key?(dobj.container) }
     end
 
-    def log_progress_info(dobj)
+    def log_progress_info(info)
       {
-        container: dobj.container,
-        pid: dobj.pid,
-        pre_assem_finished: dobj.pre_assem_finished,
+        container: info[:dobj].container,
+        pid: info[:dobj].pid,
+        pre_assem_finished: info[:pre_assem_finished],
         timestamp: Time.now.strftime('%Y-%m-%d %H:%I:%S')
       }
     end

--- a/app/lib/pre_assembly/digital_object.rb
+++ b/app/lib/pre_assembly/digital_object.rb
@@ -12,8 +12,6 @@ module PreAssembly
              :media_manifest,
              to: :bundle
 
-    attr_accessor :pre_assem_finished
-
     # @param [PreAssembly::Bundle] bundle
     # @param [String] container the identifier (non-namespaced)
     # @param [Array<String>] stageable_items items to stage

--- a/spec/lib/pre_assembly/bundle_spec.rb
+++ b/spec/lib/pre_assembly/bundle_spec.rb
@@ -137,13 +137,14 @@ RSpec.describe PreAssembly::Bundle do
   describe '#log_progress_info' do
     it 'returns expected info about a digital object' do
       dobj = flat_dir_images.digital_objects[0]
+      info = { dobj: dobj, pre_assem_finished: nil }
       exp = {
         container: dobj.container,
         pid: dobj.pid,
-        pre_assem_finished: dobj.pre_assem_finished,
+        pre_assem_finished: nil,
         timestamp: Time.now.strftime('%Y-%m-%d %H:%I:%S')
       }
-      expect(flat_dir_images.log_progress_info(dobj)).to eq(exp)
+      expect(flat_dir_images.log_progress_info(info)).to eq(exp)
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

Bundle is the only thing that needs to know about pre_assem_finished, so keep it there.

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?
n/a