### PR TITLE
Make methods that are not part of the interface private

### DIFF
--- a/app/lib/pre_assembly/digital_object.rb
+++ b/app/lib/pre_assembly/digital_object.rb
@@ -72,8 +72,6 @@ module PreAssembly
       log "    - pre_assemble(#{pid}) finished"
     end
 
-    attr_reader :assembly_directory
-
     ####
     # Determining the druid.
     ####
@@ -83,14 +81,15 @@ module PreAssembly
       @druid ||= DruidTools::Druid.new(pid)
     end
 
-    def dor_object
-      @dor_object ||= Dor::Item.find(pid)
-    rescue ActiveFedora::ObjectNotFoundError
-      @dor_object = nil
-    end
+    private
+
+    attr_reader :assembly_directory
 
     def content_type_tag
-      dor_object.nil? ? '' : dor_object.content_type_tag
+      dor_object = Dor::Item.find(pid)
+      dor_object.content_type_tag
+    rescue ActiveFedora::ObjectNotFoundError
+      ''
     end
 
     ####

--- a/spec/lib/pre_assembly/bundle_spec.rb
+++ b/spec/lib/pre_assembly/bundle_spec.rb
@@ -5,58 +5,59 @@ RSpec.describe PreAssembly::Bundle do
   let(:flat_dir_images) { bundle_setup(:flat_dir_images) }
   let(:images_jp2_tif) { bundle_setup(:images_jp2_tif) }
   let(:multimedia) { bundle_setup(:multimedia) }
-  let(:b) { create(:bundle_context_with_deleted_output_dir).bundle }
+  let(:bundle) { create(:bundle_context_with_deleted_output_dir).bundle }
 
-  after { FileUtils.rm_rf(b.bundle_context.output_dir) if Dir.exist?(b.bundle_context.output_dir) } # cleanup
+  after { FileUtils.rm_rf(bundle.bundle_context.output_dir) if Dir.exist?(bundle.bundle_context.output_dir) } # cleanup
 
   describe '#run_pre_assembly' do
     before do
-      allow(b).to receive(:process_digital_objects) # stub expensive call
-      allow(b).to receive(:log) # log statements we don't care about here
+      allow(bundle).to receive(:process_digital_objects) # stub expensive call
+      allow(bundle).to receive(:log) # log statements we don't care about here
     end
 
     it 'returns processed_pids' do
-      allow(b).to receive(:processed_pids).and_return ['druid:aa111aa1111', 'druid:bb222bb2222']
-      expect(b.run_pre_assembly).to eq ['druid:aa111aa1111', 'druid:bb222bb2222']
+      allow(bundle).to receive(:processed_pids).and_return ['druid:aa111aa1111', 'druid:bb222bb2222']
+      expect(bundle.run_pre_assembly).to eq ['druid:aa111aa1111', 'druid:bb222bb2222']
     end
     it 'logs the start and finish of the run' do
-      expect(b).to receive(:log).with("\nstarting run_pre_assembly(#{b.run_log_msg})")
-      expect(b).to receive(:log).with("\nfinishing run_pre_assembly(#{b.run_log_msg})")
-      b.run_pre_assembly
+      expect(bundle).to receive(:log).with("\nstarting run_pre_assembly(#{bundle.run_log_msg})")
+      expect(bundle).to receive(:log).with("\nfinishing run_pre_assembly(#{bundle.run_log_msg})")
+      bundle.run_pre_assembly
     end
     it 'calls process_digital_objects' do
-      expect(b).to receive(:process_digital_objects)
-      b.run_pre_assembly
+      expect(bundle).to receive(:process_digital_objects)
+      bundle.run_pre_assembly
     end
   end
 
   describe '#process_digital_objects' do
     let(:dor_services_client_object_version) { instance_double(Dor::Services::Client::ObjectVersion, open: true, close: true) }
     let(:dor_services_client_object) { instance_double(Dor::Services::Client::Object, version: dor_services_client_object_version) }
+    let(:item) { instance_double(Dor::Item, content_type_tag: 'image') }
 
     before do
       allow_any_instance_of(PreAssembly::DigitalObject).to receive(:initialize_assembly_workflow)
       allow(Dor::Services::Client).to receive(:object).and_return(dor_services_client_object)
-      allow(Dor::Item).to receive(:find).with(any_args)
+      allow(Dor::Item).to receive(:find).and_return(item)
     end
 
     it 'runs cleanly for new objects' do
       allow_any_instance_of(PreAssembly::DigitalObject).to receive(:'openable?').and_return(false)
       allow_any_instance_of(PreAssembly::DigitalObject).to receive(:current_object_version).and_return(1)
-      expect { b.process_digital_objects }.not_to raise_error
+      expect { bundle.process_digital_objects }.not_to raise_error
     end
 
     it 'runs cleanly for re-accessioned objects that are ready to be versioned' do
       allow_any_instance_of(PreAssembly::DigitalObject).to receive(:'openable?').and_return(true)
       allow_any_instance_of(PreAssembly::DigitalObject).to receive(:current_object_version).and_return(2)
-      expect { b.process_digital_objects }.not_to raise_error
+      expect { bundle.process_digital_objects }.not_to raise_error
     end
 
     it 'throws an exception for re-accessioned objects that are not ready to be versioned' do
       allow_any_instance_of(PreAssembly::DigitalObject).to receive(:'openable?').and_return(false)
       allow_any_instance_of(PreAssembly::DigitalObject).to receive(:current_object_version).and_return(2)
       exp_msg = "druid:aa111aa1111 can't be opened for a new version; cannot re-accession when version > 1 unless object can be opened"
-      expect { b.process_digital_objects }.to raise_error(RuntimeError, exp_msg)
+      expect { bundle.process_digital_objects }.to raise_error(RuntimeError, exp_msg)
     end
   end
 
@@ -92,9 +93,10 @@ RSpec.describe PreAssembly::Bundle do
   end
 
   describe '#digital_objects' do
+    let(:bundle) { bundle_setup(:folder_manifest) }
+
     it 'finds the correct number of objects' do
-      b = bundle_setup(:folder_manifest)
-      expect(b.digital_objects.size).to eq(3)
+      expect(bundle.digital_objects.size).to eq(3)
     end
 
     it 'handles containers correctly' do

--- a/spec/lib/pre_assembly/media_spec.rb
+++ b/spec/lib/pre_assembly/media_spec.rb
@@ -5,52 +5,55 @@ RSpec.describe PreAssembly::Media do
   let(:bc_params) do
     {
       project_name: 'ProjectBar',
-      # :publish_attr  => { :publish => 'no', :shelve => 'no', :preserve => 'yes' },
       bundle_dir: bundle_dir,
       content_metadata_creation: :media_cm_style
     }
   end
   let(:bc) { build(:bundle_context, bc_params) }
 
-  describe '#create_content_metadata - no thumb declaration' do
-    let(:dobj1) { setup_dobj('aa111aa1111', media_manifest) }
-    let(:dobj2) { setup_dobj('bb222bb2222', media_manifest) }
-    let(:media_manifest) do
-      described_class.new(csv_filename: 'media_manifest.csv', bundle_dir: bundle_dir)
-    end
+  describe '#create_content_metadata' do
+    context 'without thumb declaration' do
+      let(:dobj1) { setup_dobj('aa111aa1111', media_manifest) }
+      let(:dobj2) { setup_dobj('bb222bb2222', media_manifest) }
+      let(:media_manifest) do
+        described_class.new(csv_filename: 'media_manifest.csv', bundle_dir: bundle_dir)
+      end
 
-    it 'generates content metadata from a Media manifest with no thumb columns' do
-      expect(noko_doc(dobj1.create_content_metadata)).to be_equivalent_to noko_doc(exp_xml_object_aa111aa1111)
-      expect(noko_doc(dobj2.create_content_metadata)).to be_equivalent_to noko_doc(exp_xml_object_bb222bb2222)
+      it 'generates content metadata from a Media manifest with no thumb columns' do
+        expect(noko_doc(dobj1.send(:create_content_metadata))).to be_equivalent_to noko_doc(exp_xml_object_aa111aa1111)
+        expect(noko_doc(dobj2.send(:create_content_metadata))).to be_equivalent_to noko_doc(exp_xml_object_bb222bb2222)
+      end
     end
   end
 
-  describe '#create_content_metadata - with thumb declaration' do
-    it 'generates content metadata from a Media manifest with a thumb column set to yes' do
-      media_manifest = described_class.new(csv_filename: 'media_manifest_with_thumb.csv', bundle_dir: bundle_dir)
-      dobj1 = setup_dobj('aa111aa1111', media_manifest)
-      dobj2 = setup_dobj('bb222bb2222', media_manifest)
+  describe '#create_content_metadata' do
+    context 'with thumb declaration' do
+      it 'generates content metadata from a Media manifest with a thumb column set to yes' do
+        media_manifest = described_class.new(csv_filename: 'media_manifest_with_thumb.csv', bundle_dir: bundle_dir)
+        dobj1 = setup_dobj('aa111aa1111', media_manifest)
+        dobj2 = setup_dobj('bb222bb2222', media_manifest)
 
-      expect(noko_doc(dobj1.create_content_metadata)).to be_equivalent_to noko_doc(exp_xml_object_aa111aa1111_with_thumb)
-      expect(noko_doc(dobj2.create_content_metadata)).to be_equivalent_to noko_doc(exp_xml_object_bb222bb2222)
-    end
+        expect(noko_doc(dobj1.send(:create_content_metadata))).to be_equivalent_to noko_doc(exp_xml_object_aa111aa1111_with_thumb)
+        expect(noko_doc(dobj2.send(:create_content_metadata))).to be_equivalent_to noko_doc(exp_xml_object_bb222bb2222)
+      end
 
-    it 'generates content metadata from a Media manifest with a thumb column set to true' do
-      media_manifest = described_class.new(csv_filename: 'media_manifest_with_thumb_true.csv', bundle_dir: bundle_dir)
-      dobj1 = setup_dobj('aa111aa1111', media_manifest)
-      dobj2 = setup_dobj('bb222bb2222', media_manifest)
+      it 'generates content metadata from a Media manifest with a thumb column set to true' do
+        media_manifest = described_class.new(csv_filename: 'media_manifest_with_thumb_true.csv', bundle_dir: bundle_dir)
+        dobj1 = setup_dobj('aa111aa1111', media_manifest)
+        dobj2 = setup_dobj('bb222bb2222', media_manifest)
 
-      expect(noko_doc(dobj1.create_content_metadata)).to be_equivalent_to noko_doc(exp_xml_object_aa111aa1111_with_thumb)
-      expect(noko_doc(dobj2.create_content_metadata)).to be_equivalent_to noko_doc(exp_xml_object_bb222bb2222)
-    end
+        expect(noko_doc(dobj1.send(:create_content_metadata))).to be_equivalent_to noko_doc(exp_xml_object_aa111aa1111_with_thumb)
+        expect(noko_doc(dobj2.send(:create_content_metadata))).to be_equivalent_to noko_doc(exp_xml_object_bb222bb2222)
+      end
 
-    it 'generates content metadata from a Media manifest with no thumbs when the thumb column is set to no' do
-      media_manifest = described_class.new(csv_filename: 'media_manifest_thumb_no.csv', bundle_dir: bundle_dir)
-      dobj1 = setup_dobj('aa111aa1111', media_manifest)
-      dobj2 = setup_dobj('bb222bb2222', media_manifest)
+      it 'generates content metadata from a Media manifest with no thumbs when the thumb column is set to no' do
+        media_manifest = described_class.new(csv_filename: 'media_manifest_thumb_no.csv', bundle_dir: bundle_dir)
+        dobj1 = setup_dobj('aa111aa1111', media_manifest)
+        dobj2 = setup_dobj('bb222bb2222', media_manifest)
 
-      expect(noko_doc(dobj1.create_content_metadata)).to be_equivalent_to noko_doc(exp_xml_object_aa111aa1111)
-      expect(noko_doc(dobj2.create_content_metadata)).to be_equivalent_to noko_doc(exp_xml_object_bb222bb2222)
+        expect(noko_doc(dobj1.send(:create_content_metadata))).to be_equivalent_to noko_doc(exp_xml_object_aa111aa1111)
+        expect(noko_doc(dobj2.send(:create_content_metadata))).to be_equivalent_to noko_doc(exp_xml_object_bb222bb2222)
+      end
     end
   end
 


### PR DESCRIPTION


## Why was this change made?
This makes it easier to understand how outside classes interact with this class


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?
n/a