### PR TITLE
Update dor-services to 8.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'uglifier' # compressor for JavaScript assets
 # Stanford gems
 gem 'assembly-image', '~> 1.7'
 gem 'assembly-objectfile', '~> 1.7', '>= 1.7.2' # 1.7.2 is the first version to support 3d content metadata generation
-gem 'dor-services', '~> 7.1'
+gem 'dor-services', '~> 8.1'
 gem 'dor-services-client', '~> 2.4'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,8 @@ GEM
       activesupport (>= 4.2)
       deep_merge (~> 1.2, >= 1.2.1)
       dry-schema (~> 1.0)
-    confstruct (0.2.7)
+    confstruct (1.0.2)
+      hashie (~> 3.3)
     coveralls (0.8.23)
       json (>= 1.8, < 3)
       simplecov (~> 0.16.1)
@@ -143,14 +144,12 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dor-rights-auth (1.4.0)
       nokogiri
-    dor-services (7.2.4)
+    dor-services (8.1.1)
       active-fedora (>= 8.7.0, < 9)
       activesupport (~> 5.1)
-      confstruct (~> 0.2.7)
       deprecation (~> 0)
       dor-rights-auth (~> 1.0, >= 1.2.0)
-      dor-services-client (>= 1.5.0, < 3.0.0)
-      dor-workflow-client (~> 3.0)
+      dor-workflow-client (~> 3.8)
       druid-tools (>= 0.4.1)
       json (>= 1.8.1)
       nokogiri (~> 1.6)
@@ -159,7 +158,6 @@ GEM
       rest-client (>= 1.7, < 3)
       retries (~> 0.0.5)
       rsolr (>= 1.0.3, < 3)
-      ruby-cache (~> 0.3.0)
       rubydora (~> 2.1)
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
@@ -236,6 +234,7 @@ GEM
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
+    hashie (3.6.0)
     honeybadger (4.5.4)
     hooks (0.4.1)
       uber (~> 0.0.14)
@@ -441,7 +440,6 @@ GEM
       unicode-display_width (>= 1.4.0, < 1.7)
     rubocop-rspec (1.37.0)
       rubocop (>= 0.68.1)
-    ruby-cache (0.3.0)
     ruby-prof (1.1.0)
     ruby-progressbar (1.10.1)
     rubydora (2.1.0)
@@ -545,7 +543,7 @@ DEPENDENCIES
   devise
   devise-remote-user
   dlss-capistrano (~> 3.1)
-  dor-services (~> 7.1)
+  dor-services (~> 8.1)
   dor-services-client (~> 2.4)
   equivalent-xml
   factory_bot_rails


### PR DESCRIPTION
## Why was this change made?

To be consistent with the rest of the infrastructure portfolio.  Drops old unnecessary dependencies.


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?
n/a