### PR TITLE
Update shoulda matchers to a released version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ group :test do
   gem 'coveralls', require: false
   gem 'equivalent-xml'
   gem 'factory_bot_rails'
-  gem 'shoulda-matchers', '~> 4.0.0.rc1'
+  gem 'shoulda-matchers', '~> 4.1'
 end
 
 group :deployment do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -462,7 +462,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    shoulda-matchers (4.0.1)
+    shoulda-matchers (4.1.2)
       activesupport (>= 4.2.0)
     simple_form (5.0.1)
       actionpack (>= 5.0)
@@ -569,7 +569,7 @@ DEPENDENCIES
   rubocop-rspec
   ruby-prof
   sassc (~> 2.0.1)
-  shoulda-matchers (~> 4.0.0.rc1)
+  shoulda-matchers (~> 4.1)
   simple_form
   sqlite3 (~> 1.3.13)
   turbolinks


### PR DESCRIPTION
## Why was this change made?

We were previously using a release candidate, not a released version.


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?
n/a