### PR TITLE
Remove book_as_image as an option

### DIFF
--- a/app/lib/pre_assembly/digital_object.rb
+++ b/app/lib/pre_assembly/digital_object.rb
@@ -47,9 +47,9 @@ module PreAssembly
         'Image' => :simple_image,
         'File' => :file,
         'Book (flipbook, ltr)' => :simple_book,
-        'Book (image-only)' => :book_as_image,
+        'Book (image-only)' => :book_as_image, # deprecated
         'Manuscript (flipbook, ltr)' => :simple_book,
-        'Manuscript (image-only)' => :book_as_image,
+        'Manuscript (image-only)' => :book_as_image, # deprecated
         'Map' => :map,
         '3D' => :'3d'
       }

--- a/app/models/bundle_context.rb
+++ b/app/models/bundle_context.rb
@@ -19,7 +19,7 @@ class BundleContext < ApplicationRecord
   enum content_structure: {
     'simple_image' => 0,
     'simple_book' => 1,
-    'book_as_image' => 2,
+    'book_as_image' => 2, # Deprecated
     'file' => 3,
     'media' => 4,
     '3d' => 5

--- a/app/views/bundle_contexts/_new_bc_form.erb
+++ b/app/views/bundle_contexts/_new_bc_form.erb
@@ -26,7 +26,6 @@
             [
                 ['Simple Image', 'simple_image'],
                 ['Simple Book', 'simple_book'],
-                ['Book as Image','book_as_image'],
                 ['File', 'file'],
                 ['Media', 'media'],
                 ['3D', '3d'],


### PR DESCRIPTION

## Why was this change made?
This object type is deprecated and we don't want any new ones to be created.

Fixes #589 


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?
n/a