### PR TITLE
Show an error to the users if their job fails

### DIFF
--- a/app/lib/pre_assembly/bundle.rb
+++ b/app/lib/pre_assembly/bundle.rb
@@ -119,13 +119,13 @@ module PreAssembly
         begin
           # Try to pre_assemble the digital object.
           load_checksums(dobj)
-          dobj.pre_assemble
+          status = dobj.pre_assemble
           # Indicate that we finished.
           dobj.pre_assem_finished = true
           log "Completed #{dobj.druid}"
         ensure
           # Log the outcome no matter what.
-          File.open(progress_log_file, 'a') { |f| f.puts log_progress_info(dobj).to_yaml }
+          File.open(progress_log_file, 'a') { |f| f.puts log_progress_info(dobj, status).to_yaml }
         end
       end
     ensure
@@ -137,13 +137,13 @@ module PreAssembly
       @o2p ||= digital_objects.reject { |dobj| skippables.key?(dobj.container) }
     end
 
-    def log_progress_info(dobj)
+    def log_progress_info(dobj, status)
       {
         container: dobj.container,
         pid: dobj.pid,
         pre_assem_finished: dobj.pre_assem_finished,
         timestamp: Time.now.strftime('%Y-%m-%d %H:%I:%S')
-      }
+      }.merge(status)
     end
 
     private

--- a/app/lib/pre_assembly/digital_object.rb
+++ b/app/lib/pre_assembly/digital_object.rb
@@ -60,9 +60,10 @@ module PreAssembly
     # The main process.
     ####
 
+    # @return [Hash] the status of the attempt and an optional message
     def pre_assemble
       log "  - pre_assemble(#{source_id}) started"
-      raise "#{druid.druid} can't be opened for a new version; cannot re-accession when version > 1 unless object can be opened" if !openable? && current_object_version > 1
+      return { status: 'error', message: "can't be opened for a new version; cannot re-accession when version > 1 unless object can be opened" } if !openable? && current_object_version > 1
       @assembly_directory = AssemblyDirectory.create(druid_id: druid.id)
       stage_files
       generate_content_metadata
@@ -70,6 +71,7 @@ module PreAssembly
       create_new_version if openable?
       initialize_assembly_workflow
       log "    - pre_assemble(#{pid}) finished"
+      { status: 'success' }
     end
 
     attr_reader :assembly_directory

--- a/spec/lib/pre_assembly/bundle_spec.rb
+++ b/spec/lib/pre_assembly/bundle_spec.rb
@@ -60,8 +60,8 @@ RSpec.describe PreAssembly::Bundle do
       end
 
       it 'logs an error' do
-        b.process_digital_objects
-        yaml = YAML.load_file(b.progress_log_file)
+        bundle.process_digital_objects
+        yaml = YAML.load_file(bundle.progress_log_file)
         expect(yaml[:status]).to eq 'error'
         expect(yaml[:message]).to eq "can't be opened for a new version; cannot re-accession when version > 1 unless object can be opened"
       end

--- a/spec/lib/pre_assembly/bundle_spec.rb
+++ b/spec/lib/pre_assembly/bundle_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe PreAssembly::Bundle do
     subject { flat_dir_images.log_progress_info(progress, status: 'success') }
 
     let(:dobj) { flat_dir_images.digital_objects[0] }
-    let(:progress) { dobj: dobj }
+    let(:progress) { { dobj: dobj } }
 
     it {
       is_expected.to eq(

--- a/spec/lib/pre_assembly/bundle_spec.rb
+++ b/spec/lib/pre_assembly/bundle_spec.rb
@@ -52,11 +52,18 @@ RSpec.describe PreAssembly::Bundle do
       expect { b.process_digital_objects }.not_to raise_error
     end
 
-    it 'throws an exception for re-accessioned objects that are not ready to be versioned' do
-      allow_any_instance_of(PreAssembly::DigitalObject).to receive(:'openable?').and_return(false)
-      allow_any_instance_of(PreAssembly::DigitalObject).to receive(:current_object_version).and_return(2)
-      exp_msg = "druid:aa111aa1111 can't be opened for a new version; cannot re-accession when version > 1 unless object can be opened"
-      expect { b.process_digital_objects }.to raise_error(RuntimeError, exp_msg)
+    context 'when there are re-accessioned objects that are not ready to be versioned' do
+      before do
+        allow_any_instance_of(PreAssembly::DigitalObject).to receive(:'openable?').and_return(false)
+        allow_any_instance_of(PreAssembly::DigitalObject).to receive(:current_object_version).and_return(2)
+      end
+
+      it 'logs an error' do
+        b.process_digital_objects
+        yaml = YAML.load_file(b.progress_log_file)
+        expect(yaml[:status]).to eq 'error'
+        expect(yaml[:message]).to eq "can't be opened for a new version; cannot re-accession when version > 1 unless object can be opened"
+      end
     end
   end
 
@@ -137,16 +144,19 @@ RSpec.describe PreAssembly::Bundle do
   end
 
   describe '#log_progress_info' do
-    it 'returns expected info about a digital object' do
-      dobj = flat_dir_images.digital_objects[0]
-      exp = {
+    subject { flat_dir_images.log_progress_info(dobj, status: 'success') }
+
+    let(:dobj) { flat_dir_images.digital_objects[0] }
+
+    it {
+      is_expected.to eq(
         container: dobj.container,
         pid: dobj.pid,
         pre_assem_finished: dobj.pre_assem_finished,
-        timestamp: Time.now.strftime('%Y-%m-%d %H:%I:%S')
-      }
-      expect(flat_dir_images.log_progress_info(dobj)).to eq(exp)
-    end
+        timestamp: Time.now.strftime('%Y-%m-%d %H:%I:%S'),
+        status: 'success'
+      )
+    }
   end
 
   ### Private methods

--- a/spec/lib/pre_assembly/digital_object_spec.rb
+++ b/spec/lib/pre_assembly/digital_object_spec.rb
@@ -44,12 +44,19 @@ RSpec.describe PreAssembly::DigitalObject do
       object.pre_assemble
     end
 
-    it 'throws an exception for existing non-openable objects' do
-      allow(object).to receive(:'openable?').and_return(false)
-      allow(object).to receive(:current_object_version).and_return(2)
-      expect(object).not_to receive(:stage_files)
-      exp_msg = "#{pid} can't be opened for a new version; cannot re-accession when version > 1 unless object can be opened"
-      expect { object.pre_assemble }.to raise_error(RuntimeError, exp_msg)
+    context 'when the object is not openable' do
+      before do
+        allow(object).to receive(:'openable?').and_return(false)
+        allow(object).to receive(:current_object_version).and_return(2)
+      end
+
+      let(:status) { object.pre_assemble }
+
+      it 'logs an error for existing non-openable objects' do
+        expect(object).not_to receive(:stage_files)
+        expect(status).to eq(status: 'error',
+                             message: "can't be opened for a new version; cannot re-accession when version > 1 unless object can be opened")
+      end
     end
 
     it 'calls create_new_version for existing openable objects' do


### PR DESCRIPTION

## Why was this change made?

Presently, it just raises an error and the user never sees their job complete.
Fixes #560


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?
n/a