### PR TITLE
Use hot-swap to restart workers gracefully

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -42,7 +42,6 @@ append :linked_dirs, 'log', 'config/certs', 'config/settings', 'tmp', 'vendor/bu
 before 'deploy:restart', 'shared_configs:update'
 
 # Resque pool
-before 'deploy:migrate', 'resque:pool:stop'
-after 'deploy:restart', 'resque:pool:start'
+after 'deploy:restart', 'resque:pool:hot_swap'
 
 set :honeybadger_env, fetch(:stage)


### PR DESCRIPTION
## Why was this change made?

To make it easier to deal with long-running workers when deploying.

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

no