### PR TITLE
use bundler 2.1.2 for deployment

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -584,4 +584,4 @@ DEPENDENCIES
   uglifier
 
 BUNDLED WITH
-   2.1.1
+   2.1.2


### PR DESCRIPTION
## Why was this change made?

bundler v 2.1.2 is the default when you update rubygems for ruby 2.5.3 in rvm.  This update allowed for a clean deploy (though I did have to reinstall ruby 2.5.3 and update rubygems on the VM)

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

n/a