### PR TITLE
Prevents nil from being passed to log_progress_info.

### DIFF
--- a/app/lib/pre_assembly/bundle.rb
+++ b/app/lib/pre_assembly/bundle.rb
@@ -120,7 +120,7 @@ module PreAssembly
           log "Completed #{dobj.druid}"
         ensure
           # Log the outcome no matter what.
-          File.open(progress_log_file, 'a') { |f| f.puts log_progress_info(progress, status).to_yaml }
+          File.open(progress_log_file, 'a') { |f| f.puts log_progress_info(progress, status || {}).to_yaml }
         end
       end
     ensure


### PR DESCRIPTION
closes #603

## Why was this change made?
To prevent log_progress_info from being passed a nil when it expects a hash.


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?
No.