### PR TITLE
[DRAFT] avoid 'no implicit conversion of nil into Hash' when pre_assemble doesn't complete

### DIFF
--- a/app/lib/pre_assembly/bundle.rb
+++ b/app/lib/pre_assembly/bundle.rb
@@ -120,7 +120,7 @@ module PreAssembly
           log "Completed #{dobj.druid}"
         ensure
           # Log the outcome no matter what.
-          File.open(progress_log_file, 'a') { |f| f.puts log_progress_info(progress, status || {}).to_yaml }
+          File.open(progress_log_file, 'a') { |f| f.puts log_progress_info(progress, status || incomplete_status).to_yaml }
         end
       end
     ensure
@@ -145,6 +145,10 @@ module PreAssembly
 
     def stager
       staging_style_symlink ? LinkStager : CopyStager
+    end
+
+    def incomplete_status
+      { status: 'error', message: 'pre_assemble did not complete' }
     end
 
     # Discover object containers from a manifest.

--- a/spec/lib/pre_assembly/bundle_spec.rb
+++ b/spec/lib/pre_assembly/bundle_spec.rb
@@ -63,6 +63,17 @@ RSpec.describe PreAssembly::Bundle do
         expect(yaml[:message]).to eq "can't be opened for a new version; cannot re-accession when version > 1 unless object can be opened"
       end
     end
+
+    context 'when there are objects that do not complete pre_assemble' do
+      it 'logs an error' do
+        allow(bundle.digital_objects[0]).to receive(:pre_assemble)
+        allow(bundle.digital_objects[1]).to receive(:pre_assemble)
+        bundle.process_digital_objects
+        yaml = YAML.load_file(bundle.progress_log_file)
+        expect(yaml[:status]).to eq 'error'
+        expect(yaml[:message]).to eq 'pre_assemble did not complete'
+      end
+    end
   end
 
   describe '#load_skippables' do


### PR DESCRIPTION
DO NOT MERGE - I need to tweak this

# Why was this change made?

To surface better information to end users when TypeError is encountered for pre-assembly job due to ensure clause:

![image](https://user-images.githubusercontent.com/96775/73214851-d1e14780-4107-11ea-8178-9904568e5678.png)

which ends up as a failed job in resque (and won't any longer after this PR)

![image](https://user-images.githubusercontent.com/96775/73214762-a9f1e400-4107-11ea-8f5c-efe2a3680251.png)


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

n/a