### PR TITLE
bundle.log_progress_info copes with nil status

### DIFF
--- a/app/lib/pre_assembly/bundle.rb
+++ b/app/lib/pre_assembly/bundle.rb
@@ -133,6 +133,7 @@ module PreAssembly
     end
 
     def log_progress_info(info, status)
+      status = incomplete_status unless status&.any?
       {
         container: info[:dobj].container,
         pid: info[:dobj].pid,

--- a/spec/lib/pre_assembly/bundle_spec.rb
+++ b/spec/lib/pre_assembly/bundle_spec.rb
@@ -65,13 +65,13 @@ RSpec.describe PreAssembly::Bundle do
     end
 
     context 'when there are objects that do not complete pre_assemble' do
-      it 'logs an error' do
+      it 'logs incomplete_status error' do
         allow(bundle.digital_objects[0]).to receive(:pre_assemble)
         allow(bundle.digital_objects[1]).to receive(:pre_assemble)
         bundle.process_digital_objects
         yaml = YAML.load_file(bundle.progress_log_file)
-        expect(yaml[:status]).to eq 'error'
-        expect(yaml[:message]).to eq 'pre_assemble did not complete'
+        expect(yaml[:status]).to eq bundle.send(:incomplete_status)[:status]
+        expect(yaml[:message]).to eq bundle.send(:incomplete_status)[:message]
       end
     end
   end
@@ -160,6 +160,13 @@ RSpec.describe PreAssembly::Bundle do
         status: 'success'
       )
     }
+
+    it 'uses incomplete_status if no status is passed' do
+      expect { flat_dir_images.log_progress_info(progress, nil) }.not_to raise_error(TypeError)
+      result = flat_dir_images.log_progress_info(progress, nil)
+      expect(result[:status]).to eq bundle.send(:incomplete_status)[:status]
+      expect(result[:message]).to eq bundle.send(:incomplete_status)[:message]
+    end
   end
 
   ### Private methods


### PR DESCRIPTION
## Why was this change made?

To surface better information to end users when TypeError is encountered for pre-assembly job 

I think the TypeError is coming from somehow getting to `log_progress_info` method without status, so this should sew up that hole, too (See PR #611 for another possible hole plugged).

Trying to avoid this:

![image](https://user-images.githubusercontent.com/96775/73214762-a9f1e400-4107-11ea-8f5c-efe2a3680251.png)

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

n/a