### PR TITLE
okcomputer check: increase allowed queue depth to 15 (was 5)

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -11,7 +11,7 @@ OkComputer::Registry.register 'feature-resque-down', OkComputer::ResqueDownCheck
 
 # check for backed up resque queues: this is a low volume app, so the threshold is low
 Resque.queues.each do |queue|
-  OkComputer::Registry.register "feature-#{queue}-queue-depth", OkComputer::ResqueBackedUpCheck.new(queue, 5)
+  OkComputer::Registry.register "feature-#{queue}-queue-depth", OkComputer::ResqueBackedUpCheck.new(queue, 15)
 end
 
 class DirectoryExistsCheck < OkComputer::Check


### PR DESCRIPTION
## Why was this change made?

to avoid HTTP 500 errors due to queue depth being > 5.   (Nagios was complaining).

rails logs:
```I, [2020-01-28T16:13:58.702213 #10806]  INFO -- : [44dd7e46-6a77-4601-b68f-b4041808fc5a] Started GET "/status/all" for 171.66.183.13 at 2020-01-28 16:13:58 -0800
I, [2020-01-28T16:13:58.703023 #10806]  INFO -- : [44dd7e46-6a77-4601-b68f-b4041808fc5a] Processing by OkComputer::OkComputerController#index as HTML
D, [2020-01-28T16:13:58.707808 #10806] DEBUG -- :    (0.3ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
I, [2020-01-28T16:13:58.709447 #10806]  INFO -- : [44dd7e46-6a77-4601-b68f-b4041808fc5a]   Rendering text template
I, [2020-01-28T16:13:58.709530 #10806]  INFO -- : [44dd7e46-6a77-4601-b68f-b4041808fc5a]   Rendered text template (0.0ms)
I, [2020-01-28T16:13:58.709655 #10806]  INFO -- : [44dd7e46-6a77-4601-b68f-b4041808fc5a] Completed 500 Internal Server Error in 7ms (Views: 0.9ms | ActiveRecord: 0.0ms)
```

status all response:

![image](https://user-images.githubusercontent.com/96775/73317064-b189b980-41e9-11ea-85c5-2e92e52b8f6a.png)


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

n/a