### PR TITLE
Don't pass deprecated options to assembly-objectfile

### DIFF
--- a/app/lib/pre_assembly/digital_object.rb
+++ b/app/lib/pre_assembly/digital_object.rb
@@ -45,9 +45,9 @@ module PreAssembly
         'Image' => :simple_image,
         'File' => :file,
         'Book (flipbook, ltr)' => :simple_book,
-        'Book (image-only)' => :book_as_image, # deprecated
+        'Book (image-only)' => :simple_book,
         'Manuscript (flipbook, ltr)' => :simple_book,
-        'Manuscript (image-only)' => :book_as_image, # deprecated
+        'Manuscript (image-only)' => :simple_book,
         'Map' => :map,
         '3D' => :'3d'
       }


### PR DESCRIPTION
## Why was this change made?
`book_as_image` is deprecated in assembly-objectfile so we don't want to use this style anymore.
This will simplify the logic and make it possible for us to use the cocina types to determine the project style.

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?
n/a.