### PR TITLE
okcomputer: allow queue depth of 40

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -10,8 +10,9 @@ OkComputer::Registry.register 'ruby_version', OkComputer::RubyVersionCheck.new
 OkComputer::Registry.register 'feature-resque-down', OkComputer::ResqueDownCheck.new
 
 # check for backed up resque queues: this is a low volume app, so the threshold is low
+# 2020-02-20:  Mary Ellen asked for a bigger queue so she could submit a bunch of reports at once.
 Resque.queues.each do |queue|
-  OkComputer::Registry.register "feature-#{queue}-queue-depth", OkComputer::ResqueBackedUpCheck.new(queue, 15)
+  OkComputer::Registry.register "feature-#{queue}-queue-depth", OkComputer::ResqueBackedUpCheck.new(queue, 40)
 end
 
 class DirectoryExistsCheck < OkComputer::Check


### PR DESCRIPTION
## Why was this change made?

@Mellen22 submits her pre-assembly reports in clumps;  a higher queue size for okcomputer shouldn't alert.

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

n/a