### PR TITLE
add okcomputer check for number of workers

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -41,5 +41,21 @@ end
 # Confirm job_output_parent_dir exists (or else jobs cannot output)
 OkComputer::Registry.register 'feature-job_output_parent_dir', DirectoryExistsCheck.new(Settings.job_output_parent_dir)
 
+# check for the right number of workers
+class WorkerCountCheck < OkComputer::Check
+  def check
+    expected_count = Settings.expected_worker_count
+    actual_count = Resque.workers.count
+    message = "#{actual_count} out of #{expected_count} expected workers are up."
+    if actual_count >= expected_count
+      mark_message message
+    else
+      mark_failure
+      mark_message "only #{message}"
+    end
+  end
+  OkComputer::Registry.register 'feature-worker-count', WorkerCountCheck.new
+end
+
 # To make checks optional:
 # OkComputer.make_optional %w[feature-resque-down]

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,9 +8,10 @@ DOR_SERVICES:
   URL: 'http://localhost:3003'
   TOKEN: 'secret-token'
 
-
 workflow_url: 'https://workflow-env.stanford.edu/workflow'
 workflow:
   logfile: 'log/workflow_service.log'
   shift_age: 'weekly'
   timeout: 60
+
+expected_worker_count: 5 # for okcomputer endpoint


### PR DESCRIPTION
## Why was this change made?

Fixes #628

So nagios doesn't have to specifically check for number of resque workers - developers have more control over number of expected workers.

See 2nd to last line:

![image](https://user-images.githubusercontent.com/96775/76884307-c0c8d300-683a-11ea-8fda-d519b811fd28.png)

in pushing tweaks, i was able to observe "10 out of 5" workers due to hotswap, which quickly settled back to "5 out of 5"

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

na

## Does this change affect how this application integrates with other services?

Only nagios - i will post in ops when this is deployed to prod.
