### PR TITLE
okcomputer checks: don't connect to Redis unless production

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,3 @@ before_install:
 
 rvm:
   - 2.5.3
-
-services:
-  - redis-server

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -11,8 +11,10 @@ OkComputer::Registry.register 'feature-resque-down', OkComputer::ResqueDownCheck
 
 # check for backed up resque queues: this is a low volume app, so the threshold is low
 # 2020-02-20:  Mary Ellen asked for a bigger queue so she could submit a bunch of reports at once.
-Resque.queues.each do |queue|
-  OkComputer::Registry.register "feature-#{queue}-queue-depth", OkComputer::ResqueBackedUpCheck.new(queue, 40)
+if Rails.env.production?
+  Resque.queues.each do |queue|
+    OkComputer::Registry.register "feature-#{queue}-queue-depth", OkComputer::ResqueBackedUpCheck.new(queue, 40)
+  end
 end
 
 class DirectoryExistsCheck < OkComputer::Check


### PR DESCRIPTION


## Why was this change made?

Currently the only redis connection the app uses in test is in the initializer, then this is never invoked.  This makes it simpler to test the app.

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?
n/a


## Does this change affect how this application integrates with other services?
no
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
