### PR TITLE
fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ bundle install
 
 #### Redis/Resque
 
-The pre-assembly app uses Resque backed by Redis for job queing.  In order to run the tests or run the
+The pre-assembly app uses Resque backed by Redis for job queueing.  In order to run the tests or run the
 webapp locally, you will need to have Redis running.  On MacOSX, use `homebrew` to install:
 
 ```bash


### PR DESCRIPTION
## Why was this change made?

to fix a typo

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

it was the only thing updated

## Does this change affect how this application integrates with other services?

na