### PR TITLE
Extract ObjectFileFinder from Batch

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,7 +45,7 @@ RSpec/EmptyLineAfterExample:
   Enabled: false
 
 RSpec/ExampleLength:
-  Max: 25
+  Enabled: false
 
 RSpec/ImplicitSubject: # we use this for `define_enum_for`, `validate_presence_of`, etc.
   Enabled: false

--- a/app/services/object_file_finder.rb
+++ b/app/services/object_file_finder.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# Finds the ObjectFiles for a digital object.
+class ObjectFileFinder
+  # @param [Array] stageable_items
+  # @param [String] druid
+  # @param [Bool] does the user indicate that these batch should preserve/publish/shelve all files
+  # @param [Bool] does this druid have 'dark' access?
+  def self.run(stageable_items:, druid:, dark:, all_files_public:)
+    new(stageable_items: stageable_items, druid: druid, dark: dark, all_files_public: all_files_public).run
+  end
+
+  def initialize(stageable_items:, druid:, dark:, all_files_public:)
+    @stageable_items = stageable_items
+    @druid = druid
+    @dark_obj = dark
+    @all_files_public = all_files_public
+  end
+
+  # Returns a list of the ObjectFiles for a digital object.
+  # @return [Array<PreAssembly::ObjectFile>]
+  def run
+    object_files = []
+    Array(@stageable_items).each do |stageable|
+      find_files_recursively(stageable).each do |file_path|
+        object_files.push(new_object_file(stageable, file_path))
+      end
+    end
+    object_files
+  end
+
+  # @param [String] stageable the object directory
+  # @param [String] file_path the path to the file in the object directory
+  # @param [Boolean] dark_obj - true if object access is dark, false otherwise
+  # @return [PreAssembly::ObjectFile]
+  def new_object_file(stageable, file_path)
+    options = { relative_path: relative_path(base_dir(stageable), file_path) }
+    if @dark_obj
+      options[:file_attributes] = { preserve: 'yes', shelve: 'no', publish: 'no' }
+    elsif @all_files_public
+      options[:file_attributes] = { preserve: 'yes', shelve: 'yes', publish: 'yes' }
+    end
+    PreAssembly::ObjectFile.new(file_path, options)
+  end
+
+  # @return [String] path
+  # @return [String] directory portion of the path before basename
+  # @example Usage
+  #   b.base_dir('BLAH/BLAH/foo/bar.txt')
+  #   => 'BLAH/BLAH/foo'
+  def base_dir(path)
+    bd = File.dirname(path)
+    return bd unless bd == '.'
+    raise ArgumentError, "Bad arg to get_base_dir(#{path.inspect})"
+  end
+
+  # @return [String] base
+  # @return [String] path
+  # @return [String] portion of the path after the base, without trailing slashes (if directory)
+  # @example Usage
+  #   b.relative_path('BLAH/BLAH', 'BLAH/BLAH/foo/bar.txt'
+  #   => 'foo/bar.txt'
+  #   b.relative_path('BLAH/BLAH', 'BLAH/BLAH/foo///'
+  #   => 'foo'
+  def relative_path(base, path)
+    Pathname.new(path).relative_path_from(Pathname.new(base)).cleanpath.to_s
+  end
+
+  # @param [String] path the path to a file or dir.
+  # @return [Array<String>} all files (but not dirs) contained in the path, recursively.
+  def find_files_recursively(path)
+    patterns = [path, File.join(path, '**', '*')]
+    Dir.glob(patterns).reject { |f| File.directory? f }.sort
+  end
+end

--- a/spec/services/object_file_finder_spec.rb
+++ b/spec/services/object_file_finder_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+RSpec.describe ObjectFileFinder do
+  describe '#run' do
+    subject { finder.run.map(&:path) }
+
+    let(:finder) { described_class.new(stageable_items: stageable_items, druid: 'oo000oo0000', dark: false, all_files_public: false) }
+
+    let(:files) do
+      [
+        'spec/test_data/images_jp2_tif/gn330dv6119/image1.jp2',
+        'spec/test_data/images_jp2_tif/gn330dv6119/image1.tif',
+        'spec/test_data/images_jp2_tif/gn330dv6119/image2.jp2',
+        'spec/test_data/images_jp2_tif/gn330dv6119/image2.tif',
+        'spec/test_data/images_jp2_tif/jy812bp9403/00/image1.tif',
+        'spec/test_data/images_jp2_tif/jy812bp9403/00/image2.tif',
+        'spec/test_data/images_jp2_tif/jy812bp9403/05/image1.jp2',
+        'spec/test_data/images_jp2_tif/tz250tk7584/00/image1.tif',
+        'spec/test_data/images_jp2_tif/tz250tk7584/00/image2.tif'
+      ]
+    end
+
+    context 'when files are provided as stageable items' do
+      let(:stageable_items) { files }
+
+      it { is_expected.to eq files }
+    end
+
+    context 'when directories are provided as stageable items' do
+      let(:stageable_items) do
+        ['spec/test_data/images_jp2_tif/gn330dv6119', 'spec/test_data/images_jp2_tif/jy812bp9403', 'spec/test_data/images_jp2_tif/tz250tk7584']
+      end
+
+      it { is_expected.to eq files }
+    end
+  end
+
+  describe '#base_dir' do
+    let(:finder) { described_class.new(stageable_items: [], druid: 'foo', dark: false, all_files_public: false) }
+
+    it 'returns expected value' do
+      expect(finder.send(:base_dir, 'foo/bar/fubb.txt')).to eq('foo/bar')
+    end
+
+    it 'raises error if given bogus arguments' do
+      exp_msg = /^Bad arg to get_base_dir/
+      expect { finder.send(:base_dir, 'foo.txt')     }.to raise_error(ArgumentError, exp_msg)
+      expect { finder.send(:base_dir, '')            }.to raise_error(ArgumentError, exp_msg)
+      expect { finder.send(:base_dir, 'x\y\foo.txt') }.to raise_error(ArgumentError, exp_msg)
+    end
+  end
+
+  describe '#new_object_file' do
+    let(:finder) { described_class.new(stageable_items: [], druid: 'foo', dark: false, all_files_public: false) }
+
+    it 'returns an ObjectFile with expected path values' do
+      tests = [
+        # Stageable is a file:
+        # - immediately in bundle dir.
+        { stageable: 'BUNDLE/x.tif',
+          file_path: 'BUNDLE/x.tif',
+          exp_rel_path: 'x.tif' },
+        # - within subdir of bundle dir.
+        { stageable: 'BUNDLE/a/b/x.tif',
+          file_path: 'BUNDLE/a/b/x.tif',
+          exp_rel_path: 'x.tif' },
+        # Stageable is a directory:
+        # - immediately in bundle dir
+        { stageable: 'BUNDLE/a',
+          file_path: 'BUNDLE/a/x.tif',
+          exp_rel_path: 'a/x.tif' },
+        # - immediately in bundle dir, with file deeper
+        { stageable: 'BUNDLE/a',
+          file_path: 'BUNDLE/a/b/x.tif',
+          exp_rel_path: 'a/b/x.tif' },
+        # - within a subdir of bundle dir
+        { stageable: 'BUNDLE/a/b',
+          file_path: 'BUNDLE/a/b/x.tif',
+          exp_rel_path: 'b/x.tif' },
+        # - within a subdir of bundle dir, with file deeper
+        { stageable: 'BUNDLE/a/b',
+          file_path: 'BUNDLE/a/b/c/d/x.tif',
+          exp_rel_path: 'b/c/d/x.tif' }
+      ]
+      tests.each do |t|
+        ofile = finder.send(:new_object_file, t[:stageable], t[:file_path])
+        expect(ofile).to be_a PreAssembly::ObjectFile
+        expect(ofile.path).to eq t[:file_path]
+        expect(ofile.relative_path).to eq t[:exp_rel_path]
+      end
+    end
+  end
+
+  describe '#find_files_recursively' do
+    subject { finder.send(:find_files_recursively, bundle_dir).sort }
+
+    let(:finder) { described_class.new(stageable_items: [], druid: 'foo', dark: false, all_files_public: false) }
+    let(:bundle_dir) { batch_context_from_hash(type).bundle_dir }
+
+    context 'with flat_dir_images' do
+      let(:type) { :flat_dir_images }
+
+      it {
+        is_expected.to eq [
+          'spec/test_data/flat_dir_images/checksums.txt',
+          'spec/test_data/flat_dir_images/image1.tif',
+          'spec/test_data/flat_dir_images/image2.tif',
+          'spec/test_data/flat_dir_images/image3.tif',
+          'spec/test_data/flat_dir_images/manifest.csv',
+          'spec/test_data/flat_dir_images/manifest_badsourceid_column.csv'
+        ]
+      }
+    end
+
+    context 'with images_jp2_tif' do
+      let(:type) { :images_jp2_tif }
+
+      it {
+        is_expected.to eq [
+          'spec/test_data/images_jp2_tif/gn330dv6119/image1.jp2',
+          'spec/test_data/images_jp2_tif/gn330dv6119/image1.tif',
+          'spec/test_data/images_jp2_tif/gn330dv6119/image2.jp2',
+          'spec/test_data/images_jp2_tif/gn330dv6119/image2.tif',
+          'spec/test_data/images_jp2_tif/jy812bp9403/00/image1.tif',
+          'spec/test_data/images_jp2_tif/jy812bp9403/00/image2.tif',
+          'spec/test_data/images_jp2_tif/jy812bp9403/05/image1.jp2',
+          'spec/test_data/images_jp2_tif/manifest.csv',
+          'spec/test_data/images_jp2_tif/tz250tk7584/00/image1.tif',
+          'spec/test_data/images_jp2_tif/tz250tk7584/00/image2.tif'
+        ]
+      }
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

Batch has too many responsibilites, this extracts the responsibility for finding the files to it's own class

Fixes #646

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

no

## Does this change affect how this application integrates with other services?
no
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
