### PR TITLE
Exclude testing methods from Metrics/BlockLength

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,8 +24,13 @@ Layout/SpaceBeforeBlockBraces:
     - 'spec/**/*_spec.rb'
 
 Metrics/BlockLength:
-  Exclude:
-    - 'spec/**/*_spec.rb'
+  ExcludedMethods:
+    - SimpleForm.setup
+    - FactoryBot.define
+    - factory
+    - describe
+    - context
+    - it
 
 # Configuration parameters: AllowURI, URISchemes.
 Metrics/LineLength:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,11 +10,6 @@
 Metrics/AbcSize:
   Max: 71
 
-# Offense count: 3
-# Configuration parameters: CountComments, ExcludedMethods.
-# ExcludedMethods: refine
-Metrics/BlockLength:
-  Max: 298
 
 # Offense count: 1
 # Configuration parameters: CountComments.


### PR DESCRIPTION
## Why was this change made?

get rid of one TODO

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?



## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
