### PR TITLE
Remove a duplicate call to dor-services-app

### DIFF
--- a/app/lib/pre_assembly/batch.rb
+++ b/app/lib/pre_assembly/batch.rb
@@ -75,7 +75,7 @@ module PreAssembly
       @digital_objects ||= discover_containers_via_manifest.each_with_index.map do |c, i|
         stageable_items = discover_items_via_crawl(c)
         row = manifest_rows[i]
-        dark = dark?(row[:druid]) # TODO: Put dark in DigitalObject so we don't call it 2x as many times as necessary
+        dark = dark?(row[:druid])
         DigitalObject.new(self,
                           container: c,
                           stageable_items: stageable_items,
@@ -83,7 +83,8 @@ module PreAssembly
                           label: row.fetch('label', ''),
                           source_id: row['sourceid'],
                           pid: row[:druid],
-                          stager: stager)
+                          stager: stager,
+                          dark: dark)
       end
     end
 
@@ -111,7 +112,7 @@ module PreAssembly
         log "  - N object files: #{dobj.object_files.size}"
         num_no_file_warnings += 1 if dobj.object_files.empty?
         progress = { dobj: dobj }
-        file_attributes_supplied = batch_context.all_files_public? || dark?(dobj.pid)
+        file_attributes_supplied = batch_context.all_files_public? || dobj.dark?
         begin
           # Try to pre_assemble the digital object.
           load_checksums(dobj)
@@ -129,6 +130,7 @@ module PreAssembly
       log "#{total_obj || 0} objects pre-assembled"
     end
 
+    # @return [Array<DigitalObject>]
     def objects_to_process
       @objects_to_process ||= digital_objects.reject { |dobj| skippables.key?(dobj.container) }
     end

--- a/app/lib/pre_assembly/digital_object.rb
+++ b/app/lib/pre_assembly/digital_object.rb
@@ -22,9 +22,10 @@ module PreAssembly
     # @param [String] pid The identifier for the item
     # @param [String] source_id The source identifier
     # @param [Object] stager the implementation of how to stage an object
+    # @param [Bool] dark does this object have "dark" access
     # rubocop:disable Metrics/ParameterLists
     def initialize(batch, container: nil, stageable_items: nil, object_files: nil,
-                   label: nil, pid: nil, source_id: nil, stager:)
+                   label: nil, pid: nil, source_id: nil, stager:, dark:)
       @batch = batch
       @container = container
       @stageable_items = stageable_items
@@ -33,6 +34,7 @@ module PreAssembly
       @pid = pid
       @source_id = source_id
       @stager = stager
+      @dark = dark
     end
     # rubocop:enable Metrics/ParameterLists
 
@@ -75,6 +77,10 @@ module PreAssembly
     # @return [DruidTools::Druid]
     def druid
       @druid ||= DruidTools::Druid.new(pid)
+    end
+
+    def dark?
+      @dark
     end
 
     private

--- a/spec/lib/pre_assembly/digital_object_spec.rb
+++ b/spec/lib/pre_assembly/digital_object_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe PreAssembly::DigitalObject do
   subject(:object) do
-    described_class.new(bc.batch, object_files: [], stager: stager)
+    described_class.new(bc.batch, object_files: [], stager: stager, dark: false)
   end
 
   let(:dru) { 'gn330dv6119' }

--- a/spec/lib/pre_assembly/media_spec.rb
+++ b/spec/lib/pre_assembly/media_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe PreAssembly::Media do
   # some helper methods for these tests
   def setup_dobj(druid, media_manifest)
     allow(bc.batch).to receive(:media_manifest).and_return(media_manifest)
-    PreAssembly::DigitalObject.new(bc.batch, container: druid, stager: PreAssembly::CopyStager).tap do |dobj|
+    PreAssembly::DigitalObject.new(bc.batch, container: druid, stager: PreAssembly::CopyStager, dark: false).tap do |dobj|
       allow(dobj).to receive(:pid).and_return("druid:#{druid}")
       allow(dobj).to receive(:content_md_creation).and_return('media_cm_style')
       allow(dobj).to receive(:object_type).and_return(Cocina::Models::Vocab.media)


### PR DESCRIPTION


## Why was this change made?

Previously it was calling dor-services-app twice for each druid to see if it was dark. Now we're caching that value so it only has to call dor-services-app once.

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

no

## Does this change affect how this application integrates with other services?
yes
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
