### PR TITLE
Switch to rails 6.0 defaults

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -12,7 +12,7 @@ Bundler.require(*Rails.groups)
 module PreAssembly
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.2
+    config.load_defaults 6.0
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION

## Why was this change made?

This removes the deprecation warning:
```
Sending mail with DeliveryJob and Parameterized::DeliveryJob is deprecated and will be removed in Rails 6.1
```


## How was this change tested?

test suite

## Which documentation and/or configurations were updated?

n/a

