### PR TITLE
Stop stubbing methods that we don't use

### DIFF
--- a/spec/lib/pre_assembly/batch_spec.rb
+++ b/spec/lib/pre_assembly/batch_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe PreAssembly::Batch do
   let(:batch) { create(:batch_context_with_deleted_output_dir).batch }
   let(:cocina_model_world_access) { instance_double(Cocina::Models::Access, access: 'world') }
   let(:item) { instance_double(Cocina::Models::DRO, type: Cocina::Models::Vocab.image, access: cocina_model_world_access) }
-  let(:dor_services_client_object_version) { instance_double(Dor::Services::Client::ObjectVersion, open: true, close: true) }
-  let(:dor_services_client_object) { instance_double(Dor::Services::Client::Object, version: dor_services_client_object_version, find: item) }
+  let(:dor_services_client_object) { instance_double(Dor::Services::Client::Object, find: item) }
 
   before do
     allow(Dor::Services::Client).to receive(:object).and_return(dor_services_client_object)
@@ -177,7 +176,7 @@ RSpec.describe PreAssembly::Batch do
       let(:batch) { described_class.new(batch_context) }
       let(:cocina_model_dark_access) { instance_double(Cocina::Models::Access, access: 'dark') }
       let(:dark_item) { instance_double(Cocina::Models::DRO, type: Cocina::Models::Vocab.image, access: cocina_model_dark_access) }
-      let(:dsc_object) { instance_double(Dor::Services::Client::Object, version: dor_services_client_object_version, find: dark_item) }
+      let(:dsc_object) { instance_double(Dor::Services::Client::Object, find: dark_item) }
 
       before do
         allow(Dor::Services::Client).to receive(:object).and_return(dsc_object)

--- a/spec/lib/pre_assembly/digital_object_spec.rb
+++ b/spec/lib/pre_assembly/digital_object_spec.rb
@@ -305,7 +305,7 @@ RSpec.describe PreAssembly::DigitalObject do
   end
 
   describe '#openable?' do
-    let(:dor_services_client_object_version) { instance_double(Dor::Services::Client::ObjectVersion, open: true, close: true) }
+    let(:dor_services_client_object_version) { instance_double(Dor::Services::Client::ObjectVersion, openable?: true) }
     let(:dor_services_client_object) { instance_double(Dor::Services::Client::Object, version: dor_services_client_object_version) }
 
     before do
@@ -314,13 +314,13 @@ RSpec.describe PreAssembly::DigitalObject do
     end
 
     it 'checks if the object is openable' do
-      expect(dor_services_client_object_version).to receive(:'openable?')
       object.send(:openable?)
+      expect(dor_services_client_object_version).to have_received(:'openable?')
     end
   end
 
   describe '#current_object_version' do
-    let(:dor_services_client_object_version) { instance_double(Dor::Services::Client::ObjectVersion, open: true, close: true) }
+    let(:dor_services_client_object_version) { instance_double(Dor::Services::Client::ObjectVersion, current: '9') }
     let(:dor_services_client_object) { instance_double(Dor::Services::Client::Object, version: dor_services_client_object_version) }
 
     before do
@@ -329,8 +329,8 @@ RSpec.describe PreAssembly::DigitalObject do
     end
 
     it 'checks the current object version' do
-      expect(dor_services_client_object_version).to receive(:current)
       object.send(:current_object_version)
+      expect(dor_services_client_object_version).to have_received(:current)
     end
   end
 end

--- a/spec/services/discovery_report_spec.rb
+++ b/spec/services/discovery_report_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe DiscoveryReport do
     let(:dobj) { report.batch.objects_to_process.first }
     let(:cocina_model_world_access) { instance_double(Cocina::Models::Access, access: 'world') }
     let(:item) { instance_double(Cocina::Models::DRO, access: cocina_model_world_access) }
-    let(:dsc_object_version) { instance_double(Dor::Services::Client::ObjectVersion, open: true, close: true) }
+    let(:dsc_object_version) { instance_double(Dor::Services::Client::ObjectVersion, open: true) }
     let(:client_object) { instance_double(Dor::Services::Client::Object, version: dsc_object_version, find: item) }
 
     before do


### PR DESCRIPTION
## Why was this change made?

These stubs were unnecessary and misleading.

## How was this change tested?

Test suite

## Which documentation and/or configurations were updated?

none

