### PR TITLE
add progress logging to the discovery report jobs similar to pre-assembly jobs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -60,6 +60,7 @@ RSpec/MultipleExpectations:
   Max: 5
   Exclude:
     - 'spec/features/*'
+    - 'spec/services/discovery_report_spec.rb'
 
 RSpec/NestedGroups:
   Max: 4 # default: 3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,8 +59,7 @@ RSpec/MessageSpies:
 RSpec/MultipleExpectations:
   Max: 5
   Exclude:
-    - 'spec/features/*'
-    - 'spec/services/discovery_report_spec.rb'
+    - 'spec/**/*_spec.rb'
 
 RSpec/NestedGroups:
   Max: 4 # default: 3

--- a/app/services/discovery_report.rb
+++ b/app/services/discovery_report.rb
@@ -25,11 +25,21 @@ class DiscoveryReport
       summary[:total_size] += row.counts[:total_size]
       summary[:objects_with_error] += 1 unless row.errors.empty?
       row.counts[:mimetypes].each { |k, v| summary[:mimetypes][k] += v }
+      # log the output to a running progress file
+      File.open(batch.batch_context.progress_log_file, 'a') { |f| f.puts log_progress_info(dobj).to_yaml }
       yield row
     end
   end
 
-  # @return [String] a different string each time
+  # return [Hash] progress info that will be logged as json in a running log file
+  def log_progress_info(dobj)
+    {
+      pid: dobj.pid,
+      timestamp: Time.now.strftime('%Y-%m-%d %H:%I:%S')
+    }
+  end
+
+  # @return [String] output_path to store report results, generate a different string each time
   def output_path
     Dir::Tmpname.create([self.class.name.underscore + '_', '.json'], batch.batch_context.output_dir) { |path| path }
   end


### PR DESCRIPTION
## Why was this change made?

Long running discovery report jobs cannot be monitored to see if they are stuck or still running.  This would add a running progress log that could be tailed to monitor progress.

fixes #693


## How was this change tested?

once reviewed, can be deployed to stage and tested there with a discovery report job

## Which documentation and/or configurations were updated?

none


