### PR TITLE
upgrade node in travis to work with latest autoprefixer-rails, unpin autoprefixer-rails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ cache: bundler
 before_install:
   # Update rubygems so that bundler will work (for ruby 2.5.3)
   - yes | gem update --system
+  - nvm install 12.18
 
 rvm:
   - 2.5.3

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'autoprefixer-rails', '~> 9.8'
-
 gem 'bootstrap', '~> 4.3', '>= 4.3.1'
 gem 'config'
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,7 @@ GEM
       mini_exiftool
       nokogiri
     ast (2.4.1)
-    autoprefixer-rails (9.8.6.5)
+    autoprefixer-rails (10.0.0.2)
       execjs
     bcrypt (3.1.16)
     bootstrap (4.5.2)
@@ -467,7 +467,6 @@ PLATFORMS
 DEPENDENCIES
   assembly-image (~> 1.7)
   assembly-objectfile (~> 1.10)
-  autoprefixer-rails (~> 9.8)
   bootstrap (~> 4.3, >= 4.3.1)
   capistrano-bundler
   capistrano-passenger


### PR DESCRIPTION
## Why was this change made?

fix the build to work with latest autoprefixer-rails.

see https://github.com/sul-dlss/pre-assembly/pull/713

## How was this change tested?

* CI
* node has been updated on the VMs, will push to stage to smoke test (though now that i think about it, node was upgraded on prod earlier today, and no complaints yet 🙂)

## Which documentation and/or configurations were updated?

just travis config

