### PR TITLE
Use dlss-capistrano to manage resque-pool

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -12,7 +12,7 @@ require 'capistrano/honeybadger'
 require 'capistrano/passenger'
 require 'capistrano/rails'
 require 'dlss/capistrano'
-require 'capistrano-resque-pool'
+require 'dlss/capistrano/resque_pool'
 
 # Loads custom tasks from `lib/capistrano/tasks' if you have any defined.
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -44,8 +44,7 @@ group :deployment do
   gem 'capistrano-bundler'
   gem 'capistrano-passenger'
   gem 'capistrano-rails'
-  gem 'capistrano-resque-pool'
-  gem 'dlss-capistrano', '~> 3.8'
+  gem 'dlss-capistrano', '~> 3.10'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,9 +102,6 @@ GEM
     capistrano-rails (1.6.1)
       capistrano (~> 3.1)
       capistrano-bundler (>= 1.1, < 3)
-    capistrano-resque-pool (0.2.0)
-      capistrano
-      resque-pool
     capistrano-shared_configs (0.2.2)
     capybara (3.33.0)
       addressable
@@ -148,7 +145,7 @@ GEM
     devise-remote-user (1.0.0)
       devise
     diff-lcs (1.4.4)
-    dlss-capistrano (3.9.0)
+    dlss-capistrano (3.10.1)
       capistrano (~> 3.0)
       capistrano-bundle_audit (>= 0.3.0)
       capistrano-one_time_key
@@ -472,13 +469,12 @@ DEPENDENCIES
   capistrano-bundler
   capistrano-passenger
   capistrano-rails
-  capistrano-resque-pool
   capybara
   config
   coveralls
   devise
   devise-remote-user
-  dlss-capistrano (~> 3.8)
+  dlss-capistrano (~> 3.10)
   dor-services-client (~> 6.13)
   dor-workflow-client
   druid-tools

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -27,7 +27,7 @@ set :deploy_to, '/opt/app/preassembly/pre-assembly'
 # set :pty, true
 
 # Default value for :linked_files is []
-append :linked_files, 'config/master.key', 'config/honeybadger.yml', 'config/database.yml'
+append :linked_files, 'config/master.key', 'config/honeybadger.yml', 'config/database.yml', 'tmp/resque-pool.lock'
 
 # Default value for linked_dirs is []
 append :linked_dirs, 'log', 'config/certs', 'config/settings', 'tmp', 'vendor/bundle'
@@ -40,9 +40,6 @@ append :linked_dirs, 'log', 'config/certs', 'config/settings', 'tmp', 'vendor/bu
 
 # update shared_configs before restarting app
 before 'deploy:restart', 'shared_configs:update'
-
-# Resque pool
-after 'deploy:restart', 'resque:pool:hot_swap'
 
 set :honeybadger_env, fetch(:stage)
 


### PR DESCRIPTION
This replaces capistrano-resque-pool and works as expected with a hot-swappable pool.

Also includes:

Store resque-pool lockfile in shared dir
This allows the resque:pool:hot_swap capistrano task to do what we expect it to do.
