### PR TITLE
fix failing test in rails 6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,8 @@ env:
 cache: bundler
 
 before_install:
-  # Update rubygems so that bundler will work (for ruby 2.5.3)
-  - yes | gem update --system
   - nvm install 12.18
 
 rvm:
-  - 2.5.3
+  - 2.6.3
   - 2.7.1

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -19,6 +19,7 @@ Dir[Rails.root.join('spec', 'support', '*.rb')].each { |f| require f }
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
+  config.include ActiveSupport::Testing::Assertions
   config.include FactoryBot::Syntax::Methods
   config.include Devise::Test::IntegrationHelpers, type: :feature
 


### PR DESCRIPTION
## Why was this change made?

- Fix failing test from Rails 6.1 upgrade
- Remove ruby 2.5.3 from test matrix and add the ruby version currently on the pre-assembly prod server

## How was this change tested?

Unit tests

## Which documentation and/or configurations were updated?

n/a

