### PR TITLE
Updates README and config to use main instead of master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pre-Assembly
-[![Build Status](https://travis-ci.com/sul-dlss/pre-assembly.svg?branch=master)](https://travis-ci.com/sul-dlss/pre-assembly)
-[![Coverage Status](https://coveralls.io/repos/github/sul-dlss/pre-assembly/badge.svg?branch=master)](https://coveralls.io/github/sul-dlss/pre-assembly?branch=master)
+[![Build Status](https://travis-ci.com/sul-dlss/pre-assembly.svg?branch=main)](https://travis-ci.com/sul-dlss/pre-assembly)
+[![Coverage Status](https://coveralls.io/repos/github/sul-dlss/pre-assembly/badge.svg?branch=main)](https://coveralls.io/github/sul-dlss/pre-assembly?branch=main)
 [![GitHub version](https://badge.fury.io/gh/sul-dlss%2Fpre-assembly.svg)](https://badge.fury.io/gh/sul-dlss%2Fpre-assembly)
 
 This is a Ruby implementation of services needed to prepare objects to be

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -8,7 +8,7 @@ set :ssh_options,
     forward_agent: true,
     auth_methods: %w[publickey password]
 
-# Default branch is :master
+# Default branch is :main
 ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }.call
 
 # Default deploy_to directory is /var/www/my_app


### PR DESCRIPTION
## Why was this change made?
Updates README and deploy config comment to use `main` instead of `master` branch.


## How was this change tested?
Test suite


## Which documentation and/or configurations were updated?
Yes


