### PR TITLE
agreements should accession in pre-assembly

### DIFF
--- a/app/lib/pre_assembly/digital_object.rb
+++ b/app/lib/pre_assembly/digital_object.rb
@@ -55,7 +55,8 @@ module PreAssembly
         Cocina::Models::Vocab.document => :document,
         Cocina::Models::Vocab.map => :map,
         Cocina::Models::Vocab.three_dimensional => :'3d',
-        Cocina::Models::Vocab.webarchive_seed => :'webarchive-seed'
+        Cocina::Models::Vocab.webarchive_seed => :'webarchive-seed',
+        Cocina::Models::Vocab.agreement => :file
       }.fetch(object_type, content_structure.to_sym)
     end
 


### PR DESCRIPTION
## Why was this change made?

Fixes #743 - ensure agreement objects can accession properly and create the appropriate contentMetadata
See the ticket for details of the investigation/analysis performed.  There is only one change that is needed -- ensuring that agreement type objects get "file" type contentMetadata by mapping the object type "agreement" ==> "file"

Mostly useful when sul-dlss/argo#2687 is also done, but not dependent on it.

## How was this change tested?

In -stage:
- This object was re-accessioned and it now has the newly updated file I added and the `contentMetadata` was correctly set to `file` with the correct `publish/preserve/shelve` attributes for a dark object.  Even though I told it to use `content structure == 'image'` when I setup the job, it correctly deduced this was an agreement, and that it should actually be of type `file`: https://argo-stage.stanford.edu/view/druid:fc962rq4671
- This object was registered in argo-stage using the form for creating agreements (sul-dlss/argo#2687), and then run through pre-assembly to change the file.  This is essentially the same as first test above (since registering a new agreement in argo with the new form automatically creates a v1), but it ensures it works with agreements created with the new form: https://argo-stage.stanford.edu/view/druid:xd706rn1742  (also verified that despite selecting "image" as the content structure, it created the valid contentMetadata with the correct attributes)


## Which documentation and/or configurations were updated?



