### PR TITLE
Require simplecov before the app

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -16,12 +16,6 @@ Dir[Rails.root.join('spec', 'support', '*.rb')].each { |f| require f }
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
-require 'simplecov'
-SimpleCov.start :rails do
-  add_filter '/spec/'
-  add_filter '/vendor/'
-end
-
 RSpec.configure do |config|
   config.include ActiveSupport::Testing::Assertions
   config.include FactoryBot::Syntax::Methods

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,12 @@ require 'tmpdir'
 require 'equivalent-xml/rspec_matchers'
 require 'byebug'
 
+require 'simplecov'
+SimpleCov.start :rails do
+  add_filter '/spec/'
+  add_filter '/vendor/'
+end
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
Fixes #825 

This is now required under Rails 7 at least in terms of getting CodeClimate to accurately report test coverage.
