### PR TITLE
re-enable resque as the queue adapter

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,7 +59,7 @@ Rails.application.configure do
   # config.cache_store = :mem_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_adapter     = :resque
+  config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "pre_assembly_production"
 
   config.action_mailer.default_url_options = { host: Settings.mailer_host, protocol: 'https' } # needed by url_for() in mail templates


### PR DESCRIPTION
## Why was this change made?

The Rails 7 upgrade mistakenly disable resque as a queue adapter, preventing it from queuing jobs.  This re-enables it.

see https://github.com/sul-dlss/pre-assembly/pull/819/files#diff-da60b4e96eff2b132991226d308949e23f4ef3aad45ad59edd09cbc32cc6251eL62-L64

## How was this change tested?



## Which documentation and/or configurations were updated?



