### PR TITLE
remove unused contentMetadata option from prepare content script

### DIFF
--- a/bin/prepare_content
+++ b/bin/prepare_content
@@ -13,9 +13,9 @@
 # November 14, 2017
 #
 # Run with
-# RAILS_ENV=production bin/prepare_content INPUT_CSV_FILE.csv FULL_PATH_TO_CONTENT FULL_PATH_TO_STAGING_AREA [--no-object-folders] [--report] [--content-metadata] [--content-metadata-style map]
+# RAILS_ENV=production bin/prepare_content INPUT_CSV_FILE.csv FULL_PATH_TO_CONTENT FULL_PATH_TO_STAGING_AREA [--no-object-folders] [--report]
 #  e.g.
-# RAILS_ENV=production bin/prepare_content /maps/ThirdParty/Rumsey/Rumsey_Batch1.csv /maps/ThirdParty/Rumsey/content /maps/ThirdParty/Rumsey [--no-object-folders] [--report] [--content-metadata] [--content-metadata-style map]
+# RAILS_ENV=production bin/prepare_content /maps/ThirdParty/Rumsey/Rumsey_Batch1.csv /maps/ThirdParty/Rumsey/content /maps/ThirdParty/Rumsey [--no-object-folders] [--report]
 
 # the first parameter is the input CSV (with columns labeled "Object", "Image", and "Label" (image is the filename, object is the object identifier which can be turned into a folder)
 # second parameter is the full path to the content folder that will be searched (i.e. the base content folder)
@@ -23,28 +23,19 @@
 # third parameter is optional and is the full path to a folder to stage (i.e. symlink) content to - if not provided, will use same path as csv file, and append "staging"
 #
 # if you set the --report switch, it will only produce the output report, it will not symlink any files
-# if you set the --content-metadata switch, it will only generate content metadata for each object using the log file for successfully found files, assuming you also have columns in your input CSV labeled "Druid", "Sequence" and "Label"
 # if you set the --no-object-folders switch, then all symlinks will be flat in the staging directory (i.e. no object level folders) -- this requires all filenames to be unique across objects, if left off, then object folders will be created to store symlinks
 # note that file extensions do not matter when matching
 
 require 'optparse'
 content_metadata_filename = 'contentMetadata.xml'
 report = false # if set to true, will only show output and produce report, won't actually symlink files or create anything, can be overriden with --report switch
-content_metadata = false # if set to true, will also generate content-metadata from values supplied in spreadsheet, can be set via switch
-cm_style = 'map' # defaults to map type content metadata unless overriden
 no_object_folders = false # if false, then each new object will be in a separately created folder, with symlinks contained inside it; if true, you will get a flat list
 
-help = "Usage:\n    #{$PROGRAM_NAME} INPUT_CSV_FILE BASE_CONTENT_FOLDER [STAGING_FOLDER] [--no-object-folders] [--report] [--content_metadata] [--content_metadata_style STYLE]\n"
+help = "Usage:\n    #{$PROGRAM_NAME} INPUT_CSV_FILE BASE_CONTENT_FOLDER [STAGING_FOLDER] [--no-object-folders] [--report]\n"
 OptionParser.new do |opts|
   opts.banner = help
   opts.on('--report') do |_dr|
     report = true
-  end
-  opts.on('--content_metadata') do |_cm|
-    content_metadata = true
-  end
-  opts.on('--content_metadata_style [STYLE]') do |st|
-    cm_style = st
   end
   opts.on('--no-object-folders') do |_ob|
     no_object_folders = true
@@ -91,7 +82,6 @@ start_time = Time.now
 puts ''
 puts '***Prepare Content***'
 puts 'Only producing report' if report
-puts "Producing content metadata with style '#{cm_style}'" if content_metadata
 puts 'Creating object folders' unless no_object_folders
 puts "Input CSV File: #{csv_in}"
 puts "Logging to: #{csv_out}"
@@ -107,135 +97,89 @@ num_files_not_found = 0
 num_objects = 0
 num_files_copied = 0
 
-# only running content_metadata
-if content_metadata # create the content metadata
+FileUtils.cd(base_content_folder)
+FileUtils.mkdir_p staging_folder unless report
+files_to_search = Dir.glob('**/**').reject { |f| ['.', '..', '.DS_Store'].include?(f) }
 
-  log_file_data.each do |row| # loop over log file data
-    object = row['Object'].gsub(',', '-') # commas are no good in filenames, use a dash instead
-    druid = row['Druid']
+csv_data.each do |row|
+  n += 1
+  puts "Row #{n} out of #{csv_data.size}"
+  $stdout.flush
 
-    unless druid # if we don't have a druid in the output log file, look in the input spreadsheet for this object
-      input_csv_druids = csv_data.select { |s| s['Object'] == object } # read the druid from the input spreadsheet in case you want to add it later
-      input_csv_druids.uniq! { |e| e['Druid'] } # remove any duped entries
-      druid = input_csv_druids.first['Druid']
+  object = row['Object'].gsub(',', '-') # commas are no good in filenames, use a dash instead
+  row_filename = row['Image']
+  label = row['Label']
+  sequence = row['Sequence']
+  druid = row['Druid']
+
+  success = false
+
+  filename = File.basename(row_filename, File.extname(row_filename)) # remove any extension from the filename that was provided
+
+  previously_found = !log_file_data.select { |log_row| log_row['Image'] == row_filename && log_row['Success'].downcase == 'true' }.empty?
+  previously_missed = !log_file_data.select { |log_row| log_row['Image'] == row_filename && log_row['Success'].downcase == 'false' }.empty?
+
+  if previously_found
+    puts "......#{Time.now}: skipping #{object} - already run"
+    next
+  end
+
+  # only look for this file if it has not already been found according to the output log file
+
+  object_folder = File.join(staging_folder, object)
+
+  unless found_objects.include? object # check to see if we have a new object so we can create a new output folder for it
+    msg = "...#{Time.now}: Found new object: '#{object}'"
+    unless no_object_folders || report
+      FileUtils.mkdir_p object_folder
+      msg += " - creating object folder '#{object_folder}' if it does not exist"
     end
+    found_objects << object
+    num_objects += 1
+    puts msg
+  end
 
-    all_files = log_file_data.select { |s| s['Object'] == object && s['Success'] == 'true' } # find all files in this object that successfully staged
-
-    all_files.uniq! { |e| e['Filename'] } # remove any duped filenames (for example, if the log file has multiple entries from multiple runs)
-    all_files.sort_by! { |e| e['Sequence'].to_i } # sort the list of files by sequence
-
-    if druid && !all_files.empty? # be sure we have a druid and files
-
-      object_folder = File.join(staging_folder, object)
-
-      cm_file = File.join(object_folder, content_metadata_filename)
-
-      content_object_files = [] # build list of assembly objectfiles for creating content metadata
-      all_files.each { |object_file| content_object_files << Assembly::ObjectFile.new(File.join(object_folder, File.basename(object_file['Filename'])), label: object_file['Label']) }
-
-      params = { druid: druid, objects: content_object_files, add_exif: false, style: cm_style.to_sym }
-      content_md_xml = Assembly::ContentMetadata.create_content_metadata(params)
-      File.open(cm_file, 'w') { |fh| fh.puts content_md_xml }
-      puts "Writing content metadata file #{cm_file} for #{druid} and object #{object}"
-
-    else
-
-      puts "ERROR: Did not create content metadata file #{cm_file} -- missing druid or no files found"
-
+  # now search for any file which ends with the filename (trying to catch cases where the filename has 0s at the beginning that were dropped from the spreadsheet)
+  puts "......#{Time.now}: looking for file '#{filename}', object '#{object}', label '#{label}'"
+  # this regular expression will look for files that either match exactly (ignoring extension)
+  #  or that match exacatly but are in a sub-directory (as indicated by having a path separator, e.g. a "/" right before the filename)
+  # e.g. if you are looking for a file called "test.csv", this will match "test", "test.csv", "test.jpg", "dir/test.csv", "dir/test", but NOT "0test", or "dir/0test.jpg"
+  files_found = files_to_search.grep(/((.+\/{1}#{filename})|(^#{filename}))\.\S+/i)
+  # if found, symlink files that match
+  files_found.each do |input_file|
+    input_filename = File.basename(input_file)
+    message = "found #{input_file}, symlink to object folder #{object_folder}"
+    output_file_full_path = no_object_folders ? File.join(staging_folder, input_filename) : File.join(object_folder, input_filename)
+    input_file_full_path = Pathname.new(File.join(base_content_folder, input_file)).cleanpath(true).to_s
+    FileUtils.ln_s(input_file_full_path, output_file_full_path, force: true) unless report || File.exist?(output_file_full_path)
+    num_files_copied += 1
+    success = true
+    CSV.open(csv_out, 'a') do |f|
+      output_row = [object, filename, input_filename, sequence, label, druid, success, message, Time.now]
+      f << output_row
     end
+    puts "......#{message}"
+  end
+
+  # do not log if it was previously missed and we missed it again
+  if !previously_missed && !success
+    message = "ERROR #{filename} NOT FOUND"
+    num_files_not_found += 1
+    CSV.open(csv_out, 'a') do |f|
+      output_row = [object, filename, '', sequence, label, druid, success, message, Time.now]
+      f << output_row
+    end
+    puts "......#{message}"
   end
 
   puts ''
-
-else
-  # either a report or symlink operation
-
-  FileUtils.cd(base_content_folder)
-  FileUtils.mkdir_p staging_folder unless report
-  files_to_search = Dir.glob('**/**').reject { |f| ['.', '..', '.DS_Store'].include?(f) }
-
-  csv_data.each do |row|
-    n += 1
-    puts "Row #{n} out of #{csv_data.size}"
-    $stdout.flush
-
-    object = row['Object'].gsub(',', '-') # commas are no good in filenames, use a dash instead
-    row_filename = row['Image']
-    label = row['Label']
-    sequence = row['Sequence']
-    druid = row['Druid']
-
-    success = false
-
-    filename = File.basename(row_filename, File.extname(row_filename)) # remove any extension from the filename that was provided
-
-    previously_found = !log_file_data.select { |log_row| log_row['Image'] == row_filename && log_row['Success'].downcase == 'true' }.empty?
-    previously_missed = !log_file_data.select { |log_row| log_row['Image'] == row_filename && log_row['Success'].downcase == 'false' }.empty?
-
-    if previously_found
-      puts "......#{Time.now}: skipping #{object} - already run"
-      next
-    end
-
-    # only look for this file if it has not already been found according to the output log file
-
-    object_folder = File.join(staging_folder, object)
-
-    unless found_objects.include? object # check to see if we have a new object so we can create a new output folder for it
-      msg = "...#{Time.now}: Found new object: '#{object}'"
-      unless no_object_folders || report
-        FileUtils.mkdir_p object_folder
-        msg += " - creating object folder '#{object_folder}' if it does not exist"
-      end
-      found_objects << object
-      num_objects += 1
-      puts msg
-    end
-
-    # now search for any file which ends with the filename (trying to catch cases where the filename has 0s at the beginning that were dropped from the spreadsheet)
-    puts "......#{Time.now}: looking for file '#{filename}', object '#{object}', label '#{label}'"
-    # this regular expression will look for files that either match exactly (ignoring extension)
-    #  or that match exacatly but are in a sub-directory (as indicated by having a path separator, e.g. a "/" right before the filename)
-    # e.g. if you are looking for a file called "test.csv", this will match "test", "test.csv", "test.jpg", "dir/test.csv", "dir/test", but NOT "0test", or "dir/0test.jpg"
-    files_found = files_to_search.grep(/((.+\/{1}#{filename})|(^#{filename}))\.\S+/i)
-    # if found, symlink files that match
-    files_found.each do |input_file|
-      input_filename = File.basename(input_file)
-      message = "found #{input_file}, symlink to object folder #{object_folder}"
-      output_file_full_path = no_object_folders ? File.join(staging_folder, input_filename) : File.join(object_folder, input_filename)
-      input_file_full_path = Pathname.new(File.join(base_content_folder, input_file)).cleanpath(true).to_s
-      FileUtils.ln_s(input_file_full_path, output_file_full_path, force: true) unless report || File.exist?(output_file_full_path)
-      num_files_copied += 1
-      success = true
-      CSV.open(csv_out, 'a') do |f|
-        output_row = [object, filename, input_filename, sequence, label, druid, success, message, Time.now]
-        f << output_row
-      end
-      puts "......#{message}"
-    end
-
-    # do not log if it was previously missed and we missed it again
-    if !previously_missed && !success
-      message = "ERROR #{filename} NOT FOUND"
-      num_files_not_found += 1
-      CSV.open(csv_out, 'a') do |f|
-        output_row = [object, filename, '', sequence, label, druid, success, message, Time.now]
-        f << output_row
-      end
-      puts "......#{message}"
-    end
-
-    puts ''
-    $stdout.flush
-  end
-
-  puts ''
-  puts "Total objects staged: #{num_objects}"
-  puts "Total files symlinked: #{num_files_copied}"
-  puts "Total rows: #{csv_data.size}"
-  puts "Total files not found: #{num_files_not_found}"
-
+  $stdout.flush
 end
+
+puts ''
+puts "Total objects staged: #{num_objects}"
+puts "Total files symlinked: #{num_files_copied}"
+puts "Total rows: #{csv_data.size}"
+puts "Total files not found: #{num_files_not_found}"
 
 puts "Completed at #{Time.now}, total time was #{format('%.2f', ((Time.now - start_time) / 60.0))} minutes"


### PR DESCRIPTION
## Why was this change made?

This script is used by the Maps team to prepare content for accessioning.  They do not need it to create contentMetadata, so remove this option to avoid future confusion.

The diff looks more complicated than it is -- basically removed mention of this option in the comments/instructions, and removed the `if...then...else` block that used to check if that options was being used to run a different part of the script.

## How was this change tested?



## Which documentation and/or configurations were updated?



