### PR TITLE
remove unused CLI option exclude_from_content

### DIFF
--- a/app/lib/pre_assembly/content_metadata_creator.rb
+++ b/app/lib/pre_assembly/content_metadata_creator.rb
@@ -24,7 +24,7 @@ module PreAssembly
 
       # otherwise use the content metadata generation gem (assembly-objectfile)
       Assembly::ContentMetadata.create_content_metadata(druid: druid_id,
-                                                        objects: content_object_files,
+                                                        objects: object_files.sort,
                                                         add_exif: false,
                                                         bundle: content_md_creation.to_sym,
                                                         style: content_md_creation_style,
@@ -36,10 +36,5 @@ module PreAssembly
 
     attr_reader :druid_id, :content_md_creation, :object_files, :using_file_manifest, :object,
                 :content_md_creation_style, :file_manifest, :reading_order, :add_file_attributes
-
-    # Object files that should be included in content metadata.
-    def content_object_files
-      object_files.reject(&:exclude_from_content).sort
-    end
   end
 end

--- a/app/lib/pre_assembly/object_file.rb
+++ b/app/lib/pre_assembly/object_file.rb
@@ -3,7 +3,6 @@
 module PreAssembly
   class ObjectFile < Assembly::ObjectFile
     include ActiveModel::AttributeMethods
-    attr_accessor :exclude_from_content
 
     alias_attribute :checksum, :provider_md5
 
@@ -13,7 +12,6 @@ module PreAssembly
     def initialize(path, params = {})
       super
       @provider_md5 ||= params[:checksum]
-      @exclude_from_content = params[:exclude_from_content] || false
     end
 
     # This is a bit of a lie.  ObjectFiles with the same relative_path but different checksums

--- a/spec/lib/pre_assembly/batch_spec.rb
+++ b/spec/lib/pre_assembly/batch_spec.rb
@@ -257,14 +257,6 @@ RSpec.describe PreAssembly::Batch do
     end
   end
 
-  describe '#exclude_from_content' do
-    it 'behaves correctly' do
-      skip 'web app does not need to support exclude_from_content'
-      expect(multimedia.send(:exclude_from_content, multimedia.bundle_dir_with_path('image1.tif'))).to be_falsey
-      expect(multimedia.send(:exclude_from_content, multimedia.bundle_dir_with_path('descMetadata.xml'))).to be_truthy
-    end
-  end
-
   describe '#all_object_files' do
     it 'returns Array of object_files from all DigitalObjects' do
       fake_files = [[1, 2], [3, 4], [5, 6]]

--- a/spec/lib/pre_assembly/content_metadata_creator_spec.rb
+++ b/spec/lib/pre_assembly/content_metadata_creator_spec.rb
@@ -20,28 +20,6 @@ RSpec.describe PreAssembly::ContentMetadataCreator do
   let(:reading_order) { 'ltr' }
   let(:file_manifest) { 'quix' }
 
-  describe '#content_object_files' do
-    let(:files) { %w[file5.tif file4.tif file3.tif file2.tif file1.tif file0.tif] }
-    let(:object_files) do
-      files.map do |f|
-        PreAssembly::ObjectFile.new("/path/to/#{f}", relative_path: f)
-      end
-    end
-
-    it 'filters @object_files correctly' do
-      m = files.size / 2
-
-      # All of them are included in content.
-      expect(creator.send(:content_object_files).size).to eq(files.size)
-      # Now exclude some. Make sure we got correct N of items.
-      (0...m).each { |i| object_files[i].exclude_from_content = true }
-      ofiles = creator.send(:content_object_files)
-      expect(ofiles.size).to eq(m)
-      # Also check their ordering.
-      expect(ofiles.map(&:relative_path)).to eq(files[m..].sort)
-    end
-  end
-
   describe '#create' do
     let(:files) { %w[file5.tif] }
     let(:object_files) do


### PR DESCRIPTION
## Why was this change made? 🤔

Running specs for PR #866, noticed the spec skip message and realized there was more purging of unused code to be done!!!!

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


