### PR TITLE
remove references to Fedora datastream concept

### DIFF
--- a/app/lib/pre_assembly/assembly_directory.rb
+++ b/app/lib/pre_assembly/assembly_directory.rb
@@ -18,7 +18,7 @@ module PreAssembly
     end
 
     def path_for(item_path)
-      # these are the names of special datastream files that will be staged in the 'metadata' folder instead of the 'content' folder
+      # these are the names of files that will be staged in the 'metadata' folder instead of the 'content' folder
       metadata_files = ['descMetadata.xml', 'contentMetadata.xml'].map(&:downcase)
 
       metadata_files.include?(File.basename(item_path).downcase) ? metadata_dir : content_dir

--- a/app/lib/pre_assembly/digital_object.rb
+++ b/app/lib/pre_assembly/digital_object.rb
@@ -22,7 +22,7 @@ module PreAssembly
     # @param [String] label The label for this object
     # @param [String] pid The identifier for the item
     # @param [String] source_id The source identifier
-    # @param [Object] stager the implementation of how to stage an object
+    # @param [PreAssembly::CopyStager or PreAssembly::LinkStager] stager the implementation of how to stage an object
     # @param [Bool] dark does this object have "dark" access
     # rubocop:disable Metrics/ParameterLists
     def initialize(batch, container: '', stageable_items: nil, object_files: nil,
@@ -114,7 +114,6 @@ module PreAssembly
     def stage_files
       log "    - staging(druid_tree_dir = #{assembly_directory.druid_tree_dir.inspect})"
       stageable_items.each do |si_path|
-        # determine destination of staged file by looking to see if it is a known datastream XML file or not
         destination = assembly_directory.path_for(si_path)
         log "      - staging(#{si_path}, #{destination})", :debug
         stager.stage si_path, destination

--- a/app/lib/pre_assembly/digital_object.rb
+++ b/app/lib/pre_assembly/digital_object.rb
@@ -22,7 +22,7 @@ module PreAssembly
     # @param [String] label The label for this object
     # @param [String] pid The identifier for the item
     # @param [String] source_id The source identifier
-    # @param [PreAssembly::CopyStager or PreAssembly::LinkStager] stager the implementation of how to stage an object
+    # @param [PreAssembly::CopyStager, PreAssembly::LinkStager] stager the implementation of how to stage an object
     # @param [Bool] dark does this object have "dark" access
     # rubocop:disable Metrics/ParameterLists
     def initialize(batch, container: '', stageable_items: nil, object_files: nil,


### PR DESCRIPTION
## Why was this change made? 🤔

Fedora3 and datastreams are no more in the SDR.  Long live the SDR!

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


