### PR TITLE
add job run state and catch exceptions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'resque', '~> 2.0' # needs to match redis on VM
 gem 'resque-pool'
 gem 'simple_form' # rails form that handles errors internally and easily integrated w/ Bootstrap
 gem 'propshaft' # The modern asset pipeline for Rails [https://github.com/rails/propshaft]
+gem 'state_machines-activerecord'
 
 # Stanford gems
 gem 'assembly-image', '~> 1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -431,6 +431,13 @@ GEM
     sshkit (1.21.2)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    state_machines (0.5.0)
+    state_machines-activemodel (0.8.0)
+      activemodel (>= 5.1)
+      state_machines (>= 0.5.0)
+    state_machines-activerecord (0.8.0)
+      activerecord (>= 5.1)
+      state_machines-activemodel (>= 0.8.0)
     strscan (3.0.3)
     super_diff (0.9.0)
       attr_extras (>= 6.2.4)
@@ -497,6 +504,7 @@ DEPENDENCIES
   simple_form
   simplecov
   sqlite3
+  state_machines-activerecord
 
 BUNDLED WITH
    2.3.9

--- a/app/jobs/discovery_report_job.rb
+++ b/app/jobs/discovery_report_job.rb
@@ -11,7 +11,5 @@ class DiscoveryReportJob < ApplicationJob
     job_run.output_location = file.path # don't call report.output_path again
     job_run.save!
     job_run.completed
-  rescue StandardError
-    job_run.errored
   end
 end

--- a/app/jobs/discovery_report_job.rb
+++ b/app/jobs/discovery_report_job.rb
@@ -11,5 +11,7 @@ class DiscoveryReportJob < ApplicationJob
     job_run.output_location = file.path # don't call report.output_path again
     job_run.save!
     job_run.completed
+  rescue StandardError
+    job_run.errored
   end
 end

--- a/app/jobs/discovery_report_job.rb
+++ b/app/jobs/discovery_report_job.rb
@@ -5,9 +5,11 @@ class DiscoveryReportJob < ApplicationJob
 
   # @param [JobRun] job_run
   def perform(job_run)
+    job_run.started
     report = job_run.to_discovery_report
     file = File.open(report.output_path, 'w') { |f| f << report.to_builder.target! }
     job_run.output_location = file.path # don't call report.output_path again
     job_run.save!
+    job_run.completed
   end
 end

--- a/app/jobs/preassembly_job.rb
+++ b/app/jobs/preassembly_job.rb
@@ -5,9 +5,11 @@ class PreassemblyJob < ApplicationJob
 
   # @param [JobRun] job_run
   def perform(job_run)
+    job_run.started
     bc = job_run.batch_context
     bc.batch.run_pre_assembly
     job_run.output_location = bc.progress_log_file
     job_run.save!
+    job_run.completed
   end
 end

--- a/app/jobs/preassembly_job.rb
+++ b/app/jobs/preassembly_job.rb
@@ -7,9 +7,9 @@ class PreassemblyJob < ApplicationJob
   def perform(job_run)
     job_run.started
     bc = job_run.batch_context
-    bc.batch.run_pre_assembly
+    result = bc.batch.run_pre_assembly
     job_run.output_location = bc.progress_log_file
     job_run.save!
-    job_run.completed
+    result ? job_run.completed : job_run.errored
   end
 end

--- a/app/lib/pre_assembly/batch.rb
+++ b/app/lib/pre_assembly/batch.rb
@@ -46,9 +46,9 @@ module PreAssembly
     # @return [boolean] true if all objects succeeded, false if any errors
     def run_pre_assembly
       log "\nstarting run_pre_assembly(#{run_log_msg})"
-      result = process_digital_objects
+      had_errors = process_digital_objects
       log "\nfinishing run_pre_assembly(#{run_log_msg})"
-      result
+      had_errors
     end
 
     def run_log_msg

--- a/app/lib/pre_assembly/batch.rb
+++ b/app/lib/pre_assembly/batch.rb
@@ -113,13 +113,13 @@ module PreAssembly
         log "  - Processing object: #{dobj.container}"
         log "  - N object files: #{dobj.object_files.size}"
         num_no_file_warnings += 1 if dobj.object_files.empty?
-        progress = { dobj: dobj }
         file_attributes_supplied = batch_context.all_files_public? || dobj.dark?
         load_checksums(dobj)
         progress = dobj.pre_assemble(file_attributes_supplied)
+        progress.merge!(pid: dobj.pid, container: dobj.container, timestamp: Time.now.utc.strftime('%Y-%m-%d %H:%M:%S'))
         num_failures += 1 if progress[:status] == 'error'
         log "Completed #{dobj.druid}"
-        File.open(progress_log_file, 'a') { |f| f.puts progress.merge(timestamp: Time.now.utc.strftime('%Y-%m-%d %H:%M:%S')).to_yaml }
+        File.open(progress_log_file, 'a') { |f| f.puts progress.to_yaml }
       end
       log "**WARNING**: #{num_no_file_warnings} objects had no files" if num_no_file_warnings > 0
       log "**WARNING**: #{num_failures} objects had errors during pre-assembly" if num_failures > 0

--- a/app/lib/pre_assembly/digital_object.rb
+++ b/app/lib/pre_assembly/digital_object.rb
@@ -72,7 +72,8 @@ module PreAssembly
     def pre_assemble(file_attributes_supplied = false)
       log "  - pre_assemble(#{source_id}) started"
       if !openable? && current_object_version > 1
-        return { pre_assem_finished: false, status: 'error',
+        return { pre_assem_finished: false,
+                 status: 'error',
                  message: "can't be opened for a new version; cannot re-accession when version > 1 unless object can be opened" }
       end
 

--- a/app/models/job_run.rb
+++ b/app/models/job_run.rb
@@ -6,7 +6,6 @@ class JobRun < ApplicationRecord
   validates :state, presence: true
   after_initialize :default_enums
   after_create :enqueue!
-  after_update :send_notification, if: -> { saved_change_to_output_location? }
 
   enum job_type: {
     'discovery_report' => 0,
@@ -24,6 +23,10 @@ class JobRun < ApplicationRecord
 
     event :completed do
       transition running: :complete
+    end
+
+    after_transition do |job_run, transition|
+      job_run.send_notification if transition.from_name == :running
     end
   end
 

--- a/app/views/job_runs/_recent_history.erb
+++ b/app/views/job_runs/_recent_history.erb
@@ -4,7 +4,7 @@
           <td><a href="/job_runs/{%= o[i].id %}">{%= o[i].id %}</a></td>
           <td>{%= o[i].job_type %}</td>
           <td>{%= o[i].sunet_id %}</td>
-          <td>{%= o[i].output_location ? "done" : "not done" %}</td>
+          <td>{%= o[i].state %}</td>
           <td>{%= o[i].created_at.split('T')[0] %}</td>
       </tr>
       {% } %}

--- a/app/views/job_runs/index.html.erb
+++ b/app/views/job_runs/index.html.erb
@@ -20,7 +20,7 @@
         <td><%=link_to "Job ##{job_run.id}",job_run%></td>
         <td><%=job_run.job_type%></td>
         <td><%=job_run.batch_context.user.sunet_id%></td>
-        <td><%=job_run.output_location ? "complete" : "not complete"%></td>
+        <td><%=job_run.state %></td>
         <td><%=job_run.created_at.in_time_zone('Pacific Time (US & Canada)').to_formatted_s(:long)%></td>
       </tr>
     <% end %>

--- a/app/views/job_runs/show.html.erb
+++ b/app/views/job_runs/show.html.erb
@@ -18,7 +18,7 @@
 
 <div class="container">
   <dl class="row">
-    <% ['job_type', 'created_at', 'updated_at'].each do |attribute| %>
+    <% ['job_type', 'created_at', 'updated_at', 'state'].each do |attribute| %>
       <dt class="col-sm-2"><%= attribute.humanize %></dt>
       <dd class="col-sm-10"><%= @job_run.attributes[attribute].to_s %></dd>
     <% end %>

--- a/db/migrate/20220531215736_add_job_status.rb
+++ b/db/migrate/20220531215736_add_job_status.rb
@@ -1,0 +1,6 @@
+class AddJobStatus < ActiveRecord::Migration[7.0]
+  def change
+    add_column :job_runs, :state, :string, null: false, default: 'waiting'
+    add_index :job_runs, :state
+  end
+end

--- a/db/migrate/20220531215736_add_job_status.rb
+++ b/db/migrate/20220531215736_add_job_status.rb
@@ -1,6 +1,12 @@
 class AddJobStatus < ActiveRecord::Migration[7.0]
-  def change
+  def up
     add_column :job_runs, :state, :string, null: false, default: 'waiting'
     add_index :job_runs, :state
+    # set all existing jobs with a finished output_location to completed
+    JobRun.where.not(output_location: nil).find_each {|j| j.update_column(:state, 'complete')}
+  end
+
+  def down
+    remove_column :job_runs, :state
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2021_04_07_162118) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_31_215736) do
   create_table "batch_contexts", force: :cascade do |t|
     t.string "project_name", null: false
     t.integer "content_structure", null: false
@@ -32,7 +32,9 @@ ActiveRecord::Schema[7.0].define(version: 2021_04_07_162118) do
     t.integer "batch_context_id", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.string "state", default: "waiting", null: false
     t.index ["batch_context_id"], name: "index_job_runs_on_batch_context_id"
+    t.index ["state"], name: "index_job_runs_on_state"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/factories/job_runs.rb
+++ b/spec/factories/job_runs.rb
@@ -2,8 +2,15 @@
 
 FactoryBot.define do
   factory :job_run do
-    job_type { 'discovery_report' }
     output_location { '/path/to/report' }
     association :batch_context, factory: :batch_context_with_deleted_output_dir
+
+    trait :preassembly do
+      job_type { 'preassembly' }
+    end
+
+    trait :discovery_report do
+      job_type { 'discovery_report' }
+    end
   end
 end

--- a/spec/jobs/discovery_report_job_spec.rb
+++ b/spec/jobs/discovery_report_job_spec.rb
@@ -10,19 +10,30 @@ RSpec.describe DiscoveryReportJob, type: :job do
   after { FileUtils.rm(outfile) if File.exist?(outfile) } # cleanup
 
   describe '#perform' do
-    let(:jbuilder) { instance_double(Jbuilder, target!: '{"x":1}') } # mock the expensive stuff
+    context 'when success' do
+      let(:jbuilder) { instance_double(Jbuilder, target!: '{"x":1}') } # mock the expensive stuff
 
-    before { allow(job_run.to_discovery_report).to receive(:to_builder).and_return(jbuilder) }
+      before { allow(job_run.to_discovery_report).to receive(:to_builder).and_return(jbuilder) }
 
-    it 'requires param' do
-      expect { job.perform }.to raise_error(ArgumentError)
-      expect { job.perform(job_run) }.not_to raise_error
+      it 'requires param' do
+        expect { job.perform }.to raise_error(ArgumentError)
+        expect { job.perform(job_run) }.not_to raise_error
+      end
+
+      it 'writes JSON file and saves job_run.output_location' do
+        expect { job.perform(job_run) }.to change { File.exist?(outfile) }.to(true)
+        expect(job_run.reload.output_location).to eq(outfile)
+        expect(job_run).to be_complete
+      end
     end
 
-    it 'writes JSON file and saves job_run.output_location' do
-      expect { job.perform(job_run) }.to change { File.exist?(outfile) }.to(true)
-      expect(job_run.reload.output_location).to eq(outfile)
-      expect(job_run).to be_complete
+    context 'when errors' do
+      before { allow(job_run.to_discovery_report).to receive(:to_builder).and_return(StandardError) }
+
+      it 'starts report and ends in an error state' do
+        job.perform(job_run)
+        expect(job_run).to be_error
+      end
     end
   end
 end

--- a/spec/jobs/discovery_report_job_spec.rb
+++ b/spec/jobs/discovery_report_job_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe DiscoveryReportJob, type: :job do
   let(:job) { described_class.new }
-  let(:job_run) { create(:job_run) }
+  let(:job_run) { create(:job_run, :discovery_report) }
   let(:outfile) { 'tmp/foo.out' }
 
   before { allow(job_run.to_discovery_report).to receive(:output_path).and_return(outfile) }
@@ -22,6 +22,7 @@ RSpec.describe DiscoveryReportJob, type: :job do
     it 'writes JSON file and saves job_run.output_location' do
       expect { job.perform(job_run) }.to change { File.exist?(outfile) }.to(true)
       expect(job_run.reload.output_location).to eq(outfile)
+      expect(job_run).to be_complete
     end
   end
 end

--- a/spec/jobs/discovery_report_job_spec.rb
+++ b/spec/jobs/discovery_report_job_spec.rb
@@ -26,14 +26,5 @@ RSpec.describe DiscoveryReportJob, type: :job do
         expect(job_run).to be_complete
       end
     end
-
-    context 'when errors' do
-      before { allow(job_run.to_discovery_report).to receive(:to_builder).and_return(StandardError) }
-
-      it 'starts report and ends in an error state' do
-        job.perform(job_run)
-        expect(job_run).to be_error
-      end
-    end
   end
 end

--- a/spec/jobs/discovery_report_job_spec.rb
+++ b/spec/jobs/discovery_report_job_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe DiscoveryReportJob, type: :job do
   let(:job) { described_class.new }
-  let(:job_run) { create(:job_run, :discovery_report) }
+  let(:job_run) { create(:job_run) }
   let(:outfile) { 'tmp/foo.out' }
 
   before { allow(job_run.to_discovery_report).to receive(:output_path).and_return(outfile) }
@@ -10,21 +10,18 @@ RSpec.describe DiscoveryReportJob, type: :job do
   after { FileUtils.rm(outfile) if File.exist?(outfile) } # cleanup
 
   describe '#perform' do
-    context 'when success' do
-      let(:jbuilder) { instance_double(Jbuilder, target!: '{"x":1}') } # mock the expensive stuff
+    let(:jbuilder) { instance_double(Jbuilder, target!: '{"x":1}') } # mock the expensive stuff
 
-      before { allow(job_run.to_discovery_report).to receive(:to_builder).and_return(jbuilder) }
+    before { allow(job_run.to_discovery_report).to receive(:to_builder).and_return(jbuilder) }
 
-      it 'requires param' do
-        expect { job.perform }.to raise_error(ArgumentError)
-        expect { job.perform(job_run) }.not_to raise_error
-      end
+    it 'requires param' do
+      expect { job.perform }.to raise_error(ArgumentError)
+      expect { job.perform(job_run) }.not_to raise_error
+    end
 
-      it 'writes JSON file and saves job_run.output_location' do
-        expect { job.perform(job_run) }.to change { File.exist?(outfile) }.to(true)
-        expect(job_run.reload.output_location).to eq(outfile)
-        expect(job_run).to be_complete
-      end
+    it 'writes JSON file and saves job_run.output_location' do
+      expect { job.perform(job_run) }.to change { File.exist?(outfile) }.to(true)
+      expect(job_run.reload.output_location).to eq(outfile)
     end
   end
 end

--- a/spec/lib/pre_assembly/digital_object_spec.rb
+++ b/spec/lib/pre_assembly/digital_object_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe PreAssembly::DigitalObject do
 
       it 'logs an error for existing non-openable objects' do
         expect(object).not_to receive(:stage_files)
-        expect(status).to eq(status: 'error',
+        expect(status).to eq(status: 'error', pre_assem_finished: false,
                              message: "can't be opened for a new version; cannot re-accession when version > 1 unless object can be opened")
       end
     end

--- a/spec/mailers/job_mailer_spec.rb
+++ b/spec/mailers/job_mailer_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe JobMailer, type: :mailer do
-  let(:job_run) { create(:job_run) }
+  let(:job_run) { create(:job_run, :discovery_report) }
   let(:job_notification) { described_class.with(job_run: job_run).completion_email }
 
   it 'renders the headers' do

--- a/spec/views/job_runs/show.html.erb_spec.rb
+++ b/spec/views/job_runs/show.html.erb_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe 'job_runs/show.html.erb', type: :view do
-  let(:job_run) { create(:job_run) }
+  let(:job_run) { create(:job_run, :discovery_report) }
 
   before { assign(:job_run, job_run) }
 


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #535 and fixes #532 and fixes #695, specifically:

- rescue exceptions that occur when processing a single object on preassembly jobs and allow them to continue....previously an exception when processing an object would just cause the job to fail, with no visible indication in the UI...it would just appear to be running forever when it might have failed on the first object
- track the status of the job run in database state using a state machine (instead of relying on the existence of a progress log file) and use this when showing status to the user
- preassembly jobs will now be marked as complete if all objects succeed or marked as error if there was at least one object that threw an exception (status will also show if still running)
- email notifications will occur when the job transitions out of the running state (instead of relying on the progress log file field being updated)

Note: we may consider using state machine transitions to do other things, like enqueue jobs

Todo: 
- [x] put the whole job run into an error state if any one object errors out
- [x] add test for the job run going into an error state
- [x] add test for an exception occurring during pre-assemble that triggers the digital object erroring out
- [x] run integration tests
- [x] have Andrew test

## How was this change tested? 🤨

Updated and adding tests