### PR TITLE
Allow user to download log for discovery reports; better labels

### DIFF
--- a/app/controllers/job_runs_controller.rb
+++ b/app/controllers/job_runs_controller.rb
@@ -21,7 +21,17 @@ class JobRunsController < ApplicationController
     @job_run = JobRun.find(params[:id])
   end
 
-  def download
+  def download_log
+    @job_run = JobRun.find(params[:id])
+    if @job_run.progress_log_file && File.exist?(@job_run.progress_log_file)
+      send_file @job_run.progress_log_file
+    else
+      flash[:warning] = 'Progress log file not available.'
+      render 'show'
+    end
+  end
+
+  def download_report
     @job_run = JobRun.find(params[:id])
     if @job_run.output_location
       send_file @job_run.output_location

--- a/app/jobs/preassembly_job.rb
+++ b/app/jobs/preassembly_job.rb
@@ -8,8 +8,6 @@ class PreassemblyJob < ApplicationJob
     job_run.started
     bc = job_run.batch_context
     result = bc.batch.run_pre_assembly
-    job_run.output_location = bc.progress_log_file
-    job_run.save!
     result ? job_run.completed : job_run.errored
   end
 end

--- a/app/models/job_run.rb
+++ b/app/models/job_run.rb
@@ -7,6 +7,8 @@ class JobRun < ApplicationRecord
   after_initialize :default_enums
   after_create :enqueue!
 
+  delegate :progress_log_file, to: :batch_context
+
   enum job_type: {
     'discovery_report' => 0,
     'preassembly' => 1

--- a/app/views/job_runs/show.html.erb
+++ b/app/views/job_runs/show.html.erb
@@ -24,11 +24,15 @@
     <% end %>
     <dt class="col-sm-2">Job Output Log</dt>
     <dd class="col-sm-10">
-    <% if @job_run.output_location %>
-      <%= link_to 'Download', download_path(@job_run) %>
+    <% if @job_run.complete? %>
+      <%= link_to 'Download', download_log_path(@job_run) %>
     <% else %>
       Job is not yet complete.  Please check back later.
     <% end %>
     </dd>
+    <% if @job_run.complete? && @job_run.job_type == 'discovery_report' %>
+      <dt class="col-sm-2">Discovery Report</dt>
+      <dd class="col-sm-10"><%= link_to 'Download', download_report_path(@job_run) %></dd>
+    <% end %>
   </dl>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   root to: 'batch_contexts#new'
   resources :batch_contexts, only: %i[create index new show]
   resources :job_runs, only: [:create, :index, :show]
-  get 'job_runs/:id/download', to: 'job_runs#download', as: 'download'
+  get 'job_runs/:id/download_log', to: 'job_runs#download_log', as: 'download_log'
+  get 'job_runs/:id/download_report', to: 'job_runs#download_report', as: 'download_report'
   mount Resque::Server.new, at: '/resque'
 end

--- a/spec/controllers/job_runs_controller_spec.rb
+++ b/spec/controllers/job_runs_controller_spec.rb
@@ -61,17 +61,17 @@ RSpec.describe JobRunsController, type: :controller do
     end
   end
 
-  describe '#download' do
-    it 'before job is complete, renders page with flash' do
-      allow(JobRun).to receive(:find).with('123').and_return(instance_double(JobRun, output_location: nil))
-      get :download, params: { id: 123 }
-      expect(flash[:warning]).to eq('Job is not complete. Please check back later.')
+  describe '#download_log' do
+    it 'before job is started, renders page with flash' do
+      allow(JobRun).to receive(:find).with('123').and_return(instance_double(JobRun, progress_log_file: nil))
+      get :download_log, params: { id: 123 }
+      expect(flash[:warning]).to eq('Progress log file not available.')
     end
 
-    it 'when job is complete, returns file attachment' do
-      job_run_double = instance_double(JobRun, output_location: 'spec/test_data/input/mock_progress_log.yaml')
+    it 'returns file attachment' do
+      job_run_double = instance_double(JobRun, progress_log_file: 'spec/test_data/input/mock_progress_log.yaml')
       allow(JobRun).to receive(:find).with('123').and_return(job_run_double)
-      get :download, params: { id: 123 }
+      get :download_log, params: { id: 123 }
       expect(response).to have_http_status(:success)
       expect(response.header['Content-Type']).to eq 'application/x-yaml'
       expect(response.header['Content-Disposition']).to start_with 'attachment; filename="mock_progress_log.yaml"'
@@ -79,7 +79,29 @@ RSpec.describe JobRunsController, type: :controller do
     end
 
     it 'requires ID param' do
-      expect { get :download }.to raise_error(ActionController::UrlGenerationError)
+      expect { get :download_log }.to raise_error(ActionController::UrlGenerationError)
+    end
+  end
+
+  describe '#download_report' do
+    it 'before job is complete, renders page with flash' do
+      allow(JobRun).to receive(:find).with('123').and_return(instance_double(JobRun, output_location: nil))
+      get :download_report, params: { id: 123 }
+      expect(flash[:warning]).to eq('Job is not complete. Please check back later.')
+    end
+
+    it 'when job is complete, returns file attachment' do
+      job_run_double = instance_double(JobRun, output_location: 'spec/test_data/input/mock_discovery_report.json')
+      allow(JobRun).to receive(:find).with('123').and_return(job_run_double)
+      get :download_report, params: { id: 123 }
+      expect(response).to have_http_status(:success)
+      expect(response.header['Content-Type']).to eq 'application/json'
+      expect(response.header['Content-Disposition']).to start_with 'attachment; filename="mock_discovery_report.json"'
+      expect(flash[:warning]).to be_nil
+    end
+
+    it 'requires ID param' do
+      expect { get :download_report }.to raise_error(ActionController::UrlGenerationError)
     end
   end
 end

--- a/spec/jobs/preassembly_job_spec.rb
+++ b/spec/jobs/preassembly_job_spec.rb
@@ -19,9 +19,8 @@ RSpec.describe PreassemblyJob, type: :job do
     context 'when success' do
       before { allow(job_run.batch_context.batch).to receive(:run_pre_assembly).and_return(true) }
 
-      it 'calls run_pre_assembly, saves job_run.output_location, and ends in an complete state' do
+      it 'calls run_pre_assembly and ends in an complete state' do
         job.perform(job_run)
-        expect(job_run.reload.output_location).to eq(outfile)
         expect(job_run).to be_complete
       end
     end
@@ -29,9 +28,8 @@ RSpec.describe PreassemblyJob, type: :job do
     context 'when errors' do
       before { allow(job_run.batch_context.batch).to receive(:run_pre_assembly).and_return(false) }
 
-      it 'calls run_pre_assembly, saves job_run.output_location, and ends in an error state' do
+      it 'calls run_pre_assembly and ends in an error state' do
         job.perform(job_run)
-        expect(job_run.reload.output_location).to eq(outfile)
         expect(job_run).to be_error
       end
     end

--- a/spec/test_data/input/mock_discovery_report.json
+++ b/spec/test_data/input/mock_discovery_report.json
@@ -1,0 +1,1 @@
+{"rows":[{"druid":"druid:cm165rg4037","errors":{},"counts":{"total_size":29634,"mimetypes":{"image/jpeg":1},"filename_no_extension":0}}],"summary":{"objects_with_error":0,"mimetypes":{"image/jpeg":1},"start_time":"2022-06-02 22:24:37 UTC","total_size":29634}}

--- a/spec/views/job_runs/show.html.erb_spec.rb
+++ b/spec/views/job_runs/show.html.erb_spec.rb
@@ -1,28 +1,58 @@
 # frozen_string_literal: true
 
 RSpec.describe 'job_runs/show.html.erb', type: :view do
-  let(:job_run) { create(:job_run, :discovery_report) }
-
   before { assign(:job_run, job_run) }
 
-  it 'displays a job_run' do
-    render template: 'job_runs/show'
-    expect(rendered).to include("Discovery report \##{job_run.id}")
+  context 'discovery_report job' do
+    let(:job_run) { create(:job_run, :discovery_report) }
+
+    it 'displays a job_run' do
+      render template: 'job_runs/show'
+      expect(rendered).to include("Discovery report \##{job_run.id}")
+    end
+
+    it 'with a completed job, presents a download link to the report and the log file' do
+      job_run.started
+      job_run.completed
+      render template: 'job_runs/show'
+      expect(rendered).to include("<a href=\"/job_runs/#{job_run.id}/download_log\">Download</a>")
+      expect(rendered).to include("<a href=\"/job_runs/#{job_run.id}/download_report\">Download</a>")
+    end
+
+    it 'with an incomplete job, urges user patience and does not link to report or log' do
+      render template: 'job_runs/show'
+      expect(rendered).to include('Job is not yet complete')
+      expect(rendered).not_to include("<a href=\"/job_runs/#{job_run.id}/download_log\">Download</a>")
+      expect(rendered).not_to include("<a href=\"/job_runs/#{job_run.id}/download_report\">Download</a>")
+    end
+
+    it 'displays user email from batch context' do
+      render template: 'job_runs/show'
+      expect(rendered).to include(job_run.batch_context.user.email)
+    end
   end
 
-  it 'with an output_location, presents a download link' do
-    render template: 'job_runs/show'
-    expect(rendered).to include("<a href=\"/job_runs/#{job_run.id}/download\">Download</a>")
-  end
+  context 'preassembly job' do
+    let(:job_run) { create(:job_run, :preassembly) }
 
-  it 'without an output_location, urges user patience' do
-    job_run.output_location = nil
-    render template: 'job_runs/show'
-    expect(rendered).to include('Job is not yet complete')
-  end
+    it 'displays a job_run' do
+      render template: 'job_runs/show'
+      expect(rendered).to include("Preassembly \##{job_run.id}")
+    end
 
-  it 'displays user email from batch context' do
-    render template: 'job_runs/show'
-    expect(rendered).to include(job_run.batch_context.user.email)
+    it 'with a completed job, presents a download link to only the log file' do
+      job_run.started
+      job_run.completed
+      render template: 'job_runs/show'
+      expect(rendered).to include("<a href=\"/job_runs/#{job_run.id}/download_log\">Download</a>")
+      expect(rendered).not_to include("<a href=\"/job_runs/#{job_run.id}/download_report\">Download</a>")
+    end
+
+    it 'with an incomplete job, urges user patience and does not link to report or log' do
+      render template: 'job_runs/show'
+      expect(rendered).to include('Job is not yet complete')
+      expect(rendered).not_to include("<a href=\"/job_runs/#{job_run.id}/download_log\">Download</a>")
+      expect(rendered).not_to include("<a href=\"/job_runs/#{job_run.id}/download_report\">Download</a>")
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #939 

- correctly label report download link for discovery report
- allow user to download discovery report log file (like they do for preassembly jobs)
- behavior for pre-assembly jobs is unchanged

### Before:

Currently discovery reports have a link that says "Job output Log", but it's really the report itself in JSON format. There is no way to actually get the log.

![Screen Shot 2022-06-07 at 11 02 36 AM](https://user-images.githubusercontent.com/47137/172452037-766c3538-1664-40bc-8cba-edd17a5c6068.png)

## After:

Show both the report and the log, correctly labelled.

![Screen Shot 2022-06-07 at 11 02 05 AM](https://user-images.githubusercontent.com/47137/172452385-321b94cd-9a18-4605-ad09-d2f7c52cba9d.png)



## How was this change tested? 🤨

Updated tests