### PR TITLE
store errors in the job run and show to the user

### DIFF
--- a/app/jobs/discovery_report_job.rb
+++ b/app/jobs/discovery_report_job.rb
@@ -8,17 +8,17 @@ class DiscoveryReportJob < ApplicationJob
   def perform(job_run)
     job_run.started
     report = job_run.to_discovery_report
-    # the .to_builder is where all the work of the report happens, it iterates over the objects and produces JSON
+    # .to_builder produces JSON report by iterating over the objects
     file = File.open(report.output_path, 'w') { |f| f << report.to_builder.target! }
     job_run.output_location = file.path
     job_run.save!
-    if report.objects_had_errors # this is when errors occur on individual objects when running the report
+    if report.objects_had_errors # individual objects processed had errors
       job_run.error_message = report.error_message
       job_run.completed_with_errors
     else
       job_run.completed
     end
-  rescue StandardError => e # this catches an exception that occurs on the entire job
+  rescue StandardError => e # catch any error preventing the whole job from running (e.g. bad header in csv)
     job_run.error_message = e.message
     job_run.failed
   end

--- a/app/jobs/discovery_report_job.rb
+++ b/app/jobs/discovery_report_job.rb
@@ -8,16 +8,17 @@ class DiscoveryReportJob < ApplicationJob
   def perform(job_run)
     job_run.started
     report = job_run.to_discovery_report
+    # the .to_builder is where all the work of the report happens, it iterates over the objects and produces JSON
     file = File.open(report.output_path, 'w') { |f| f << report.to_builder.target! }
-    job_run.output_location = file.path # don't call report.output_path again
+    job_run.output_location = file.path
     job_run.save!
-    if report.had_errors
+    if report.objects_had_errors # this is when errors occur on individual objects when running the report
       job_run.error_message = report.error_message
       job_run.completed_with_errors
     else
       job_run.completed
     end
-  rescue StandardError => e
+  rescue StandardError => e # this catches an exception that occurs on the entire job
     job_run.error_message = e.message
     job_run.failed
   end

--- a/app/jobs/discovery_report_job.rb
+++ b/app/jobs/discovery_report_job.rb
@@ -6,10 +6,15 @@ class DiscoveryReportJob < ApplicationJob
   # @param [JobRun] job_run
   def perform(job_run)
     job_run.started
-    report = job_run.to_discovery_report
-    file = File.open(report.output_path, 'w') { |f| f << report.to_builder.target! }
-    job_run.output_location = file.path # don't call report.output_path again
-    job_run.save!
-    job_run.completed
+    begin
+      report = job_run.to_discovery_report
+      file = File.open(report.output_path, 'w') { |f| f << report.to_builder.target! }
+      job_run.output_location = file.path # don't call report.output_path again
+      job_run.save!
+      job_run.completed
+    rescue StandardError => e
+      job_run.error_message = e.message
+      job_run.failed
+    end
   end
 end

--- a/app/jobs/discovery_report_job.rb
+++ b/app/jobs/discovery_report_job.rb
@@ -4,17 +4,22 @@ class DiscoveryReportJob < ApplicationJob
   queue_as :discovery_report
 
   # @param [JobRun] job_run
+  # rubocop:disable Metrics/AbcSize
   def perform(job_run)
     job_run.started
-    begin
-      report = job_run.to_discovery_report
-      file = File.open(report.output_path, 'w') { |f| f << report.to_builder.target! }
-      job_run.output_location = file.path # don't call report.output_path again
-      job_run.save!
+    report = job_run.to_discovery_report
+    file = File.open(report.output_path, 'w') { |f| f << report.to_builder.target! }
+    job_run.output_location = file.path # don't call report.output_path again
+    job_run.save!
+    if report.had_errors
+      job_run.error_message = report.error_message
+      job_run.completed_with_errors
+    else
       job_run.completed
-    rescue StandardError => e
-      job_run.error_message = e.message
-      job_run.failed
     end
+  rescue StandardError => e
+    job_run.error_message = e.message
+    job_run.failed
   end
+  # rubocop:enable Metrics/AbcSize
 end

--- a/app/jobs/preassembly_job.rb
+++ b/app/jobs/preassembly_job.rb
@@ -7,14 +7,15 @@ class PreassemblyJob < ApplicationJob
   def perform(job_run)
     job_run.started
     batch = job_run.batch_context.batch
+    # the .run_pre_assembly is where all the work occurs
     batch.run_pre_assembly
-    if batch.had_errors
+    if batch.objects_had_errors # this is when errors occur on individual objects when running the report
       job_run.error_message = batch.error_message
       job_run.completed_with_errors
     else
       job_run.completed
     end
-  rescue StandardError => e
+  rescue StandardError => e # this catches an exception that occurs on the entire job
     job_run.error_message = e.message
     job_run.failed
   end

--- a/app/jobs/preassembly_job.rb
+++ b/app/jobs/preassembly_job.rb
@@ -7,17 +7,15 @@ class PreassemblyJob < ApplicationJob
   def perform(job_run)
     job_run.started
     batch = job_run.batch_context.batch
-    begin
-      batch.run_pre_assembly
-      if batch.had_errors
-        job_run.error_message = batch.error_message
-        job_run.completed_with_errors
-      else
-        job_run.completed
-      end
-    rescue StandardError => e
-      job_run.error_message = e.message
-      job_run.failed
+    batch.run_pre_assembly
+    if batch.had_errors
+      job_run.error_message = batch.error_message
+      job_run.completed_with_errors
+    else
+      job_run.completed
     end
+  rescue StandardError => e
+    job_run.error_message = e.message
+    job_run.failed
   end
 end

--- a/app/jobs/preassembly_job.rb
+++ b/app/jobs/preassembly_job.rb
@@ -6,8 +6,13 @@ class PreassemblyJob < ApplicationJob
   # @param [JobRun] job_run
   def perform(job_run)
     job_run.started
-    bc = job_run.batch_context
-    result = bc.batch.run_pre_assembly
-    result ? job_run.completed : job_run.completed_with_errors
+    batch = job_run.batch_context.batch
+    batch.run_pre_assembly
+    if batch.had_errors
+      job_run.error_message = batch.error_message
+      job_run.completed_with_errors
+    else
+      job_run.completed
+    end
   end
 end

--- a/app/jobs/preassembly_job.rb
+++ b/app/jobs/preassembly_job.rb
@@ -7,15 +7,15 @@ class PreassemblyJob < ApplicationJob
   def perform(job_run)
     job_run.started
     batch = job_run.batch_context.batch
-    # the .run_pre_assembly is where all the work occurs
+    # .run_pre_assembly iterates over all objects and runs preassembly on each
     batch.run_pre_assembly
-    if batch.objects_had_errors # this is when errors occur on individual objects when running the report
+    if batch.objects_had_errors # individual objects processed had errors
       job_run.error_message = batch.error_message
       job_run.completed_with_errors
     else
       job_run.completed
     end
-  rescue StandardError => e # this catches an exception that occurs on the entire job
+  rescue StandardError => e # catch any error preventing the whole job from running (e.g. bad header in csv)
     job_run.error_message = e.message
     job_run.failed
   end

--- a/app/jobs/preassembly_job.rb
+++ b/app/jobs/preassembly_job.rb
@@ -7,12 +7,17 @@ class PreassemblyJob < ApplicationJob
   def perform(job_run)
     job_run.started
     batch = job_run.batch_context.batch
-    batch.run_pre_assembly
-    if batch.had_errors
-      job_run.error_message = batch.error_message
-      job_run.completed_with_errors
-    else
-      job_run.completed
+    begin
+      batch.run_pre_assembly
+      if batch.had_errors
+        job_run.error_message = batch.error_message
+        job_run.completed_with_errors
+      else
+        job_run.completed
+      end
+    rescue StandardError => e
+      job_run.error_message = e.message
+      job_run.failed
     end
   end
 end

--- a/app/lib/pre_assembly/batch.rb
+++ b/app/lib/pre_assembly/batch.rb
@@ -6,11 +6,11 @@ module PreAssembly
 
     attr_reader :batch_context
     attr_writer :digital_objects
-    attr_accessor :user_params,
-                  :skippables,
+    attr_accessor :error_message,
                   :file_manifest,
-                  :error_message,
-                  :objects_had_errors
+                  :objects_had_errors,
+                  :skippables,
+                  :user_params
 
     delegate :apo_druid_id,
              :apply_tag,

--- a/app/lib/pre_assembly/batch.rb
+++ b/app/lib/pre_assembly/batch.rb
@@ -10,7 +10,7 @@ module PreAssembly
                   :skippables,
                   :file_manifest,
                   :error_message,
-                  :had_errors
+                  :objects_had_errors
 
     delegate :apo_druid_id,
              :apply_tag,
@@ -126,7 +126,7 @@ module PreAssembly
       errors << "#{num_no_file_warnings} objects had no files" if num_no_file_warnings > 0
       errors << "#{num_failures} objects had errors during pre-assembly" if num_failures > 0
       errors.each { |error| log "**WARNING**: #{error}" }
-      @had_errors = !errors.size.zero? # indicate if we had any errors
+      @objects_had_errors = !errors.size.zero? # indicate if we had any errors
       @error_message = errors.join(', ') # set the error message so they can be saved in the job_run
 
       log "#{total_obj} objects pre-assembled"

--- a/app/models/job_run.rb
+++ b/app/models/job_run.rb
@@ -51,9 +51,14 @@ class JobRun < ApplicationRecord
     "[#{batch_context.project_name}] Your #{job_type.humanize} job completed"
   end
 
-  # the states that indicate this job is either not staretd or is currently running
+  # the states that indicate this job is either not started or is currently running
   def in_progress?
     (waiting? || running?)
+  end
+
+  # the states that indicate a job is completed
+  def finished?
+    !in_progress?
   end
 
   def send_notification

--- a/app/models/job_run.rb
+++ b/app/models/job_run.rb
@@ -51,8 +51,13 @@ class JobRun < ApplicationRecord
     "[#{batch_context.project_name}] Your #{job_type.humanize} job completed"
   end
 
+  # the states that indicate this job is either not staretd or is currently running
+  def in_progress?
+    (waiting? || running?)
+  end
+
   def send_notification
-    return unless output_location
+    return if in_progress?
 
     JobMailer.with(job_run: self).completion_email.deliver_later
   end

--- a/app/services/discovery_report.rb
+++ b/app/services/discovery_report.rb
@@ -6,7 +6,7 @@
 #   report.to_builder.target!  # generates the report as a JSON string
 class DiscoveryReport
   attr_reader :batch, :start_time, :summary
-  attr_accessor :objects_had_errors, :error_message
+  attr_accessor :error_message, :objects_had_errors
 
   delegate :bundle_dir, :content_md_creation, :manifest, :project_style, :using_file_manifest, to: :batch
   delegate :object_filenames_unique?, to: :batch

--- a/app/services/discovery_report.rb
+++ b/app/services/discovery_report.rb
@@ -6,7 +6,7 @@
 #   report.to_builder.target!  # generates the report as a JSON string
 class DiscoveryReport
   attr_reader :batch, :start_time, :summary
-  attr_accessor :had_errors, :error_message
+  attr_accessor :objects_had_errors, :error_message
 
   delegate :bundle_dir, :content_md_creation, :manifest, :project_style, :using_file_manifest, to: :batch
   delegate :object_filenames_unique?, to: :batch
@@ -81,8 +81,8 @@ class DiscoveryReport
       json.rows { json.array!(each_row) }
       json.summary summary
     end
-    @had_errors = (@summary[:objects_with_error] > 0) # indicate if any objects generated errors
-    @error_message = "#{@summary[:objects_with_error]} objects had errors in the discovery report" if @had_errors
+    @objects_had_errors = (@summary[:objects_with_error] > 0) # indicate if any objects generated errors
+    @error_message = "#{@summary[:objects_with_error]} objects had errors in the discovery report" if @objects_had_errors
     json_report
   end
 end

--- a/app/services/discovery_report.rb
+++ b/app/services/discovery_report.rb
@@ -6,6 +6,7 @@
 #   report.to_builder.target!  # generates the report as a JSON string
 class DiscoveryReport
   attr_reader :batch, :start_time, :summary
+  attr_accessor :had_errors, :error_message
 
   delegate :bundle_dir, :content_md_creation, :manifest, :project_style, :using_file_manifest, to: :batch
   delegate :object_filenames_unique?, to: :batch
@@ -80,5 +81,8 @@ class DiscoveryReport
       json.rows { json.array!(each_row) }
       json.summary summary
     end
+
+    @had_errors = (@summary[:objects_with_error] > 0) # indicate if any objects generated errors
+    @error_error_message = "#{@summary[:objects_with_error]} objects had errors in the discovery report" if @had_errors
   end
 end

--- a/app/services/discovery_report.rb
+++ b/app/services/discovery_report.rb
@@ -81,8 +81,8 @@ class DiscoveryReport
       json.rows { json.array!(each_row) }
       json.summary summary
     end
-    @objects_had_errors = (@summary[:objects_with_error] > 0) # indicate if any objects generated errors
-    @error_message = "#{@summary[:objects_with_error]} objects had errors in the discovery report" if @objects_had_errors
+    @objects_had_errors = (summary[:objects_with_error] > 0) # indicate if any objects generated errors
+    @error_message = "#{summary[:objects_with_error]} objects had errors in the discovery report" if objects_had_errors
     json_report
   end
 end

--- a/app/services/discovery_report.rb
+++ b/app/services/discovery_report.rb
@@ -77,12 +77,12 @@ class DiscoveryReport
   # By using jbuilder on an enumerator, we reduce memory footprint (vs. to_a)
   # @return [Jbuilder] (caller needs obj.to_builder.target! for the JSON string)
   def to_builder
-    Jbuilder.new do |json|
+    json_report = Jbuilder.new do |json|
       json.rows { json.array!(each_row) }
       json.summary summary
     end
-
     @had_errors = (@summary[:objects_with_error] > 0) # indicate if any objects generated errors
-    @error_error_message = "#{@summary[:objects_with_error]} objects had errors in the discovery report" if @had_errors
+    @error_message = "#{@summary[:objects_with_error]} objects had errors in the discovery report" if @had_errors
+    json_report
   end
 end

--- a/app/views/job_runs/show.html.erb
+++ b/app/views/job_runs/show.html.erb
@@ -32,8 +32,10 @@
     <dd class="col-sm-10">
     <% if @job_run.in_progress? %>
       Job is not yet complete.  Please check back later.
-    <% else %>
+    <% elsif File.exist? @job_run.progress_log_file %>
       <%= link_to 'Download', download_log_path(@job_run) %>
+    <% else %>
+      No progress log file is available.
     <% end %>
     </dd>
     <% if @job_run.complete? && @job_run.job_type == 'discovery_report' %>

--- a/app/views/job_runs/show.html.erb
+++ b/app/views/job_runs/show.html.erb
@@ -24,6 +24,10 @@
     <% end %>
     <dt class="col-sm-2">State</dt>
     <dd class="col-sm-10"><%= @job_run.human_state_name %></dd>
+    <% if @job_run.error_message %>
+      <dt class="col-sm-2">Errors</dt>
+      <dd class="col-sm-10"><%= @job_run.error_message%></dd>
+    <% end %>
     <dt class="col-sm-2">Job Output Log</dt>
     <dd class="col-sm-10">
     <% if @job_run.complete? %>

--- a/app/views/job_runs/show.html.erb
+++ b/app/views/job_runs/show.html.erb
@@ -38,7 +38,7 @@
       No progress log file is available.
     <% end %>
     </dd>
-    <% if @job_run.complete? && @job_run.job_type == 'discovery_report' %>
+    <% if @job_run.finished? && @job_run.job_type == 'discovery_report' && @job_run.output_location && File.exist?(@job_run.output_location) %>
       <dt class="col-sm-2">Discovery Report</dt>
       <dd class="col-sm-10"><%= link_to 'Download', download_report_path(@job_run) %></dd>
     <% end %>

--- a/app/views/job_runs/show.html.erb
+++ b/app/views/job_runs/show.html.erb
@@ -30,10 +30,10 @@
     <% end %>
     <dt class="col-sm-2">Job Output Log</dt>
     <dd class="col-sm-10">
-    <% if @job_run.complete? %>
-      <%= link_to 'Download', download_log_path(@job_run) %>
-    <% else %>
+    <% if @job_run.in_progress? %>
       Job is not yet complete.  Please check back later.
+    <% else %>
+      <%= link_to 'Download', download_log_path(@job_run) %>
     <% end %>
     </dd>
     <% if @job_run.complete? && @job_run.job_type == 'discovery_report' %>

--- a/db/migrate/20220607221157_error_message.rb
+++ b/db/migrate/20220607221157_error_message.rb
@@ -1,0 +1,5 @@
+class ErrorMessage < ActiveRecord::Migration[7.0]
+  def change
+    add_column :job_runs, :error_message, :text, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_31_215736) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_07_221157) do
   create_table "batch_contexts", force: :cascade do |t|
     t.string "project_name", null: false
     t.integer "content_structure", null: false
@@ -33,6 +33,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_31_215736) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "state", default: "waiting", null: false
+    t.text "error_message"
     t.index ["batch_context_id"], name: "index_job_runs_on_batch_context_id"
     t.index ["state"], name: "index_job_runs_on_state"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -46,4 +46,5 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_07_221157) do
   end
 
   add_foreign_key "batch_contexts", "users"
+  add_foreign_key "job_runs", "batch_contexts"
 end

--- a/spec/jobs/discovery_report_job_spec.rb
+++ b/spec/jobs/discovery_report_job_spec.rb
@@ -43,7 +43,12 @@ RSpec.describe DiscoveryReportJob, type: :job do
     context 'when errors' do
       let(:error_message) { 'something bad happened' }
 
-      xit 'calls to_discovery_report and ends in a completed with error state, and saves error message to the database' do
+      before do
+        allow(job_run.to_discovery_report).to receive(:had_errors).and_return(true)
+        allow(job_run.to_discovery_report).to receive(:error_message).and_return(error_message)
+      end
+
+      it 'calls to_discovery_report and ends in a completed with error state, and saves error message to the database' do
         job.perform(job_run)
         expect(job_run).to be_complete_with_errors
         expect(job_run.error_message).to eq error_message

--- a/spec/jobs/discovery_report_job_spec.rb
+++ b/spec/jobs/discovery_report_job_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe DiscoveryReportJob, type: :job do
       let(:error_message) { 'something bad happened' }
 
       before do
-        allow(job_run.to_discovery_report).to receive(:had_errors).and_return(true)
+        allow(job_run.to_discovery_report).to receive(:objects_had_errors).and_return(true)
         allow(job_run.to_discovery_report).to receive(:error_message).and_return(error_message)
       end
 

--- a/spec/jobs/discovery_report_job_spec.rb
+++ b/spec/jobs/discovery_report_job_spec.rb
@@ -19,9 +19,35 @@ RSpec.describe DiscoveryReportJob, type: :job do
       expect { job.perform(job_run) }.not_to raise_error
     end
 
-    it 'writes JSON file and saves job_run.output_location' do
-      expect { job.perform(job_run) }.to change { File.exist?(outfile) }.to(true)
-      expect(job_run.reload.output_location).to eq(outfile)
+    context 'when success' do
+      it 'writes JSON file and saves job_run.output_location' do
+        expect { job.perform(job_run) }.to change { File.exist?(outfile) }.to(true)
+        expect(job_run.reload.output_location).to eq(outfile)
+        expect(job_run).to be_complete
+      end
+    end
+
+    context 'when failed' do
+      let(:error_message) { 'something really unexpected happened' }
+      # simulate an uncaught exception while running the job
+
+      before { allow(job_run.to_discovery_report).to receive(:to_builder).and_raise(StandardError, error_message) }
+
+      it 'ends in a failed state with an uncaught exception, and saves error message to the database' do
+        job.perform(job_run)
+        expect(job_run).to be_failed
+        expect(job_run.error_message).to eq error_message
+      end
+    end
+
+    context 'when errors' do
+      let(:error_message) { 'something bad happened' }
+
+      xit 'calls to_discovery_report and ends in a completed with error state, and saves error message to the database' do
+        job.perform(job_run)
+        expect(job_run).to be_complete_with_errors
+        expect(job_run.error_message).to eq error_message
+      end
     end
   end
 end

--- a/spec/jobs/preassembly_job_spec.rb
+++ b/spec/jobs/preassembly_job_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe PreassemblyJob, type: :job do
     end
 
     context 'when success' do
-      before { allow(batch).to receive(:had_errors).and_return(false) }
+      before { allow(batch).to receive(:objects_had_errors).and_return(false) }
 
       it 'calls run_pre_assembly and ends in an complete state' do
         expect(batch).to receive(:run_pre_assembly)
@@ -48,7 +48,7 @@ RSpec.describe PreassemblyJob, type: :job do
       let(:error_message) { 'something bad happened' }
 
       before do
-        allow(batch).to receive(:had_errors).and_return(true)
+        allow(batch).to receive(:objects_had_errors).and_return(true)
         allow(batch).to receive(:error_message).and_return(error_message)
       end
 

--- a/spec/jobs/preassembly_job_spec.rb
+++ b/spec/jobs/preassembly_job_spec.rb
@@ -5,10 +5,11 @@ RSpec.describe PreassemblyJob, type: :job do
   let(:job_run) { create(:job_run, :preassembly) }
   let(:outfile) { 'tmp/foobar_progress.yaml' }
   let(:batch_context) { job_run.batch_context }
+  let(:batch) { job_run.batch_context.batch }
 
   before do
     allow(batch_context).to receive(:progress_log_file).and_return(outfile)
-    allow(batch_context.batch).to receive(:process_digital_objects)
+    allow(batch).to receive(:process_digital_objects)
   end
 
   after { FileUtils.rm(outfile) if File.exist?(outfile) } # cleanup
@@ -20,12 +21,26 @@ RSpec.describe PreassemblyJob, type: :job do
     end
 
     context 'when success' do
-      before { allow(batch_context.batch).to receive(:had_errors).and_return(false) }
+      before { allow(batch).to receive(:had_errors).and_return(false) }
 
       it 'calls run_pre_assembly and ends in an complete state' do
+        expect(batch).to receive(:run_pre_assembly)
         job.perform(job_run)
         expect(job_run).to be_complete
         expect(job_run.error_message).to be_nil
+      end
+    end
+
+    context 'when failed' do
+      let(:error_message) { 'something really unexpected happened' }
+      # simulate an uncaught exception while running the job
+
+      before { allow(batch).to receive(:process_digital_objects).and_raise(StandardError, error_message) }
+
+      it 'ends in a failed state with an uncaught exception, and saves error message to the database' do
+        job.perform(job_run)
+        expect(job_run).to be_failed
+        expect(job_run.error_message).to eq error_message
       end
     end
 
@@ -33,11 +48,12 @@ RSpec.describe PreassemblyJob, type: :job do
       let(:error_message) { 'something bad happened' }
 
       before do
-        allow(batch_context.batch).to receive(:had_errors).and_return(true)
-        allow(batch_context.batch).to receive(:error_message).and_return(error_message)
+        allow(batch).to receive(:had_errors).and_return(true)
+        allow(batch).to receive(:error_message).and_return(error_message)
       end
 
       it 'calls run_pre_assembly and ends in a completed with error state, and saves error message to the database' do
+        expect(batch).to receive(:run_pre_assembly)
         job.perform(job_run)
         expect(job_run).to be_complete_with_errors
         expect(job_run.error_message).to eq error_message

--- a/spec/jobs/preassembly_job_spec.rb
+++ b/spec/jobs/preassembly_job_spec.rb
@@ -4,33 +4,43 @@ RSpec.describe PreassemblyJob, type: :job do
   let(:job) { described_class.new }
   let(:job_run) { create(:job_run, :preassembly) }
   let(:outfile) { 'tmp/foobar_progress.yaml' }
+  let(:batch_context) { job_run.batch_context }
 
-  before { allow(job_run.batch_context).to receive(:progress_log_file).and_return(outfile) }
+  before do
+    allow(batch_context).to receive(:progress_log_file).and_return(outfile)
+    allow(batch_context.batch).to receive(:process_digital_objects)
+  end
 
   after { FileUtils.rm(outfile) if File.exist?(outfile) } # cleanup
 
   describe '#perform' do
     it 'requires param' do
-      allow(job_run.batch_context.batch).to receive(:process_digital_objects) # not testing actual work here
       expect { job.perform }.to raise_error(ArgumentError)
       expect { job.perform(job_run) }.not_to raise_error
     end
 
     context 'when success' do
-      before { allow(job_run.batch_context.batch).to receive(:run_pre_assembly).and_return(true) }
+      before { allow(batch_context.batch).to receive(:had_errors).and_return(false) }
 
       it 'calls run_pre_assembly and ends in an complete state' do
         job.perform(job_run)
         expect(job_run).to be_complete
+        expect(job_run.error_message).to be_nil
       end
     end
 
     context 'when errors' do
-      before { allow(job_run.batch_context.batch).to receive(:run_pre_assembly).and_return(false) }
+      let(:error_message) { 'something bad happened' }
 
-      it 'calls run_pre_assembly and ends in a completed with error state' do
+      before do
+        allow(batch_context.batch).to receive(:had_errors).and_return(true)
+        allow(batch_context.batch).to receive(:error_message).and_return(error_message)
+      end
+
+      it 'calls run_pre_assembly and ends in a completed with error state, and saves error message to the database' do
         job.perform(job_run)
         expect(job_run).to be_complete_with_errors
+        expect(job_run.error_message).to eq error_message
       end
     end
   end

--- a/spec/lib/pre_assembly/batch_spec.rb
+++ b/spec/lib/pre_assembly/batch_spec.rb
@@ -43,14 +43,14 @@ RSpec.describe PreAssembly::Batch do
       allow_any_instance_of(PreAssembly::DigitalObject).to receive(:openable?).and_return(false)
       allow_any_instance_of(PreAssembly::DigitalObject).to receive(:current_object_version).and_return(1)
       expect(batch.process_digital_objects).to be true
-      expect(batch.had_errors).to be false
+      expect(batch.objects_had_errors).to be false
     end
 
     it 'runs cleanly for re-accessioned objects that are ready to be versioned' do
       allow_any_instance_of(PreAssembly::DigitalObject).to receive(:openable?).and_return(true)
       allow_any_instance_of(PreAssembly::DigitalObject).to receive(:current_object_version).and_return(2)
       expect(batch.process_digital_objects).to be true
-      expect(batch.had_errors).to be false
+      expect(batch.objects_had_errors).to be false
     end
 
     context 'when there are re-accessioned objects that are not ready to be versioned' do
@@ -63,7 +63,7 @@ RSpec.describe PreAssembly::Batch do
 
       it 'indicates errors occured, then logs the error and sets the error message' do
         batch.process_digital_objects
-        expect(batch.had_errors).to be true
+        expect(batch.objects_had_errors).to be true
         expect(batch.error_message).to eq '2 objects had errors during pre-assembly'
         expect(yaml[:status]).to eq 'error'
         expect(yaml[:message]).to eq "can't be opened for a new version; cannot re-accession when version > 1 unless object can be opened"
@@ -80,7 +80,7 @@ RSpec.describe PreAssembly::Batch do
 
       it 'indicates errors occured, then logs the error and sets the error message' do
         batch.process_digital_objects
-        expect(batch.had_errors).to be true
+        expect(batch.objects_had_errors).to be true
         expect(batch.error_message).to eq '1 objects had errors during pre-assembly'
         # first object logs an error
         expect(yaml[0]).to include(status: 'error', message: 'oops', pre_assem_finished: false)
@@ -99,7 +99,7 @@ RSpec.describe PreAssembly::Batch do
 
       it 'calls digital_object.pre_assemble with true for the dark objects' do
         expect(batch.process_digital_objects).to be true
-        expect(batch.had_errors).to be false
+        expect(batch.objects_had_errors).to be false
         expect(batch.digital_objects[0]).to have_received(:pre_assemble).with(true)
         expect(batch.digital_objects[1]).to have_received(:pre_assemble).with(false)
       end
@@ -117,7 +117,7 @@ RSpec.describe PreAssembly::Batch do
 
       it 'rescues the exception and proceeds, logs the error, indicates errors occurred, and sets the error message' do
         batch.process_digital_objects
-        expect(batch.had_errors).to be true
+        expect(batch.objects_had_errors).to be true
         expect(batch.error_message).to eq '1 objects had errors during pre-assembly'
         # first object logs an error
         expect(yaml[0]).to include(status: 'error', message: 'Read-only file system - Read-only file system @ rb_sysopen - /destination', pre_assem_finished: false)

--- a/spec/models/job_run_spec.rb
+++ b/spec/models/job_run_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe JobRun, type: :model do
       expect(job_run).not_to receive(:send_notification)
     end
 
-    it 'guards against sending a notification email when there is no log file available' do
-      job_run.output_location = nil
+    it 'guards against sending a notification email when the job is not done yet' do
+      job_run.state = 'running'
       job_run.send_notification
       expect(JobMailer).not_to receive(:with)
     end

--- a/spec/services/discovery_report_spec.rb
+++ b/spec/services/discovery_report_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe DiscoveryReport do
     it 'produces the json, indicates if errors occurs and records the error message' do
       json = JSON.parse(report.to_builder.target!)
       expect(json['rows'].size).to eq 3
-      expect(report.had_errors).to be true
+      expect(report.objects_had_errors).to be true
       expect(report.error_message).to eq '2 objects had errors in the discovery report'
       expect(report.summary).to include(objects_with_error: 2, total_size: 636_563)
     end

--- a/spec/services/discovery_report_spec.rb
+++ b/spec/services/discovery_report_spec.rb
@@ -5,6 +5,15 @@ RSpec.describe DiscoveryReport do
 
   let(:batch) { batch_setup(:flat_dir_images) }
 
+  before do
+    # make sure that for these tests
+    # (a) the tmp job output dir exists for the progress log file to be written to
+    # (b) we get a new clean progress log file for the tests each time we run them
+    # In the actual application, `batch_context.output_dir_no_exists!` would get run and thus we would always have a unique folder created for each job
+    FileUtils.mkdir_p(batch.batch_context.output_dir)
+    FileUtils.rm_f(batch.batch_context.progress_log_file)
+  end
+
   describe '#initialize' do
     it 'raises if PreAssembly::Batch not received' do
       expect { described_class.new }.to raise_error(ArgumentError)
@@ -29,12 +38,6 @@ RSpec.describe DiscoveryReport do
     end
 
     it 'yields per objects_to_process, building an aggregate summary and logging status per druid' do
-      # make sure that for this particular test
-      # (a) the tmp job output dir exists for the progress log file to be written to
-      # (b) we get a new clean progress log file for the tests each time we run them
-      # In the actual application, `batch_context.output_dir_no_exists!` would get run and thus we would always have a unique folder created for each job
-      FileUtils.mkdir_p(batch.batch_context.output_dir)
-      FileUtils.rm_f(batch.batch_context.progress_log_file)
       expect(report).to receive(:process_dobj).with(dig_obj1).and_return(validator1)
       expect(report).to receive(:process_dobj).with(dig_obj2).and_return(validator2)
       expect(report).to receive(:process_dobj).with(dig_obj3).and_return(validator3)
@@ -106,6 +109,14 @@ RSpec.describe DiscoveryReport do
       expect(report.summary).to include(
         objects_with_error: 0, mimetypes: {}, total_size: 0
       )
+    end
+
+    it 'produces the json, indicates if errors occurs and records the error message' do
+      json = JSON.parse(report.to_builder.target!)
+      expect(json['rows'].size).to eq 3
+      expect(report.had_errors).to be true
+      expect(report.error_message).to eq '2 objects had errors in the discovery report'
+      expect(report.summary).to include(objects_with_error: 2, total_size: 636_563)
     end
   end
 end

--- a/spec/views/job_runs/show.html.erb_spec.rb
+++ b/spec/views/job_runs/show.html.erb_spec.rb
@@ -30,6 +30,12 @@ RSpec.describe 'job_runs/show.html.erb', type: :view do
       render template: 'job_runs/show'
       expect(rendered).to include(job_run.batch_context.user.email)
     end
+
+    it 'displays an error message if present' do
+      job_run.error_message = 'Oops, that was bad.'
+      render template: 'job_runs/show'
+      expect(rendered).to include('Oops, that was bad.')
+    end
   end
 
   context 'preassembly job' do
@@ -53,6 +59,12 @@ RSpec.describe 'job_runs/show.html.erb', type: :view do
       expect(rendered).to include('Job is not yet complete')
       expect(rendered).not_to include("<a href=\"/job_runs/#{job_run.id}/download_log\">Download</a>")
       expect(rendered).not_to include("<a href=\"/job_runs/#{job_run.id}/download_report\">Download</a>")
+    end
+
+    it 'displays an error message if present' do
+      job_run.error_message = 'Oops, that was bad.'
+      render template: 'job_runs/show'
+      expect(rendered).to include('Oops, that was bad.')
     end
   end
 end

--- a/spec/views/job_runs/show.html.erb_spec.rb
+++ b/spec/views/job_runs/show.html.erb_spec.rb
@@ -3,10 +3,12 @@
 RSpec.describe 'job_runs/show.html.erb', type: :view do
   before do
     assign(:job_run, job_run)
-    allow(job_run).to receive(:progress_log_file).and_return(Rails.root.join('spec/test_data/input/mock_progress_log.yaml')) # this file exists
+    allow(job_run).to receive(:progress_log_file).and_return(actual_file)
+    allow(job_run).to receive(:output_location).and_return(actual_file)
   end
 
   let(:job_run) { create(:job_run, :discovery_report) }
+  let(:actual_file) { Rails.root.join('spec/test_data/input/mock_progress_log.yaml') } # an existing file we can use for tests
 
   context 'discovery_report job' do
     it 'displays a job_run' do


### PR DESCRIPTION
## Why was this change made? 🤔

Todo:
- [x] run integration tests
- [ ] validate with PO

Fixes #945 and fixes #936:

 - store any errors that occurred during processing in the database so we can show to the user (for both pre-assembly and discovery jobs)
 - put discovery report and pre-assembly jobs into an error or failure state based on if individual objects had an error or the whole job failed


Example error message display to user on detail page:

![Screen Shot 2022-06-08 at 11 54 14 AM](https://user-images.githubusercontent.com/47137/172694750-3494c552-db94-4e82-a45c-6ac2747231bc.png)


## How was this change tested? 🤨

New tests