### PR TITLE
show friendly state name in recent history

### DIFF
--- a/app/views/job_runs/recent_history.html.erb
+++ b/app/views/job_runs/recent_history.html.erb
@@ -17,7 +17,7 @@
             <td><%= link_to job_run.id, job_run %></td>
             <td><%= job_run.job_type %></td>
             <td><%= job_run.batch_context.user.sunet_id %></td>
-            <td><%= job_run.state %></td>
+            <td><%= job_run.human_state_name %></td>
             <td><%= job_run.created_at.in_time_zone('Pacific Time (US & Canada)').to_formatted_s(:long) %></td>
           </tr>
         <% end %>


### PR DESCRIPTION
## Why was this change made? 🤔

Follow up from #960 -- missed one spot in the UI in that PR to show the friendly state name to the user (recent history)

## How was this change tested? 🤨

Localhost