### PR TITLE
refactor job display, fix turbo issue

### DIFF
--- a/app/views/job_runs/_job_runs.html.erb
+++ b/app/views/job_runs/_job_runs.html.erb
@@ -1,0 +1,9 @@
+<% @job_runs.each do |job_run| %>
+    <tr>
+    <td><%=link_to job_run.id,job_run, data: { turbo_frame: "_top" } %></td>
+    <td><%=job_run.job_type%></td>
+    <td><%=job_run.batch_context.user.sunet_id%></td>
+    <td><%=job_run.human_state_name %></td>
+    <td><%=job_run.created_at.in_time_zone('Pacific Time (US & Canada)').to_formatted_s(:long)%></td>
+    </tr>
+<% end %>

--- a/app/views/job_runs/_job_runs.html.erb
+++ b/app/views/job_runs/_job_runs.html.erb
@@ -1,9 +1,9 @@
 <% @job_runs.each do |job_run| %>
     <tr>
-    <td><%=link_to job_run.id,job_run, data: { turbo_frame: "_top" } %></td>
-    <td><%=job_run.job_type%></td>
-    <td><%=job_run.batch_context.user.sunet_id%></td>
-    <td><%=job_run.human_state_name %></td>
-    <td><%=job_run.created_at.in_time_zone('Pacific Time (US & Canada)').to_formatted_s(:long)%></td>
+    <td><%= link_to "#{job_prefix}#{job_run.id}", job_run, data: { turbo_frame: "_top" } %></td>
+    <td><%= job_run.job_type %></td>
+    <td><%= job_run.batch_context.user.sunet_id %></td>
+    <td><%= job_run.human_state_name %></td>
+    <td><%= job_run.created_at.in_time_zone('Pacific Time (US & Canada)').to_formatted_s(:long) %></td>
     </tr>
 <% end %>

--- a/app/views/job_runs/index.html.erb
+++ b/app/views/job_runs/index.html.erb
@@ -15,15 +15,7 @@
       </tr>
     </thead>
     <tbody>
-    <% @job_runs.each do |job_run| %>
-      <tr>
-        <td><%=link_to "Job ##{job_run.id}",job_run%></td>
-        <td><%=job_run.job_type%></td>
-        <td><%=job_run.batch_context.user.sunet_id%></td>
-        <td><%=job_run.human_state_name %></td>
-        <td><%=job_run.created_at.in_time_zone('Pacific Time (US & Canada)').to_formatted_s(:long)%></td>
-      </tr>
-    <% end %>
+      <%= render partial: 'job_runs' %>
    </tbody>
   </table>
 

--- a/app/views/job_runs/index.html.erb
+++ b/app/views/job_runs/index.html.erb
@@ -15,7 +15,7 @@
       </tr>
     </thead>
     <tbody>
-      <%= render partial: 'job_runs' %>
+      <%= render 'job_runs', job_prefix: 'Job #' %>
    </tbody>
   </table>
 

--- a/app/views/job_runs/recent_history.html.erb
+++ b/app/views/job_runs/recent_history.html.erb
@@ -12,7 +12,7 @@
           </th>
         </thead>
       <tbody id="job-history-table">
-        <%= render partial: 'job_runs' %>
+        <%= render 'job_runs', job_prefix: '' %>
        </tbody>
     </table>
   </div>

--- a/app/views/job_runs/recent_history.html.erb
+++ b/app/views/job_runs/recent_history.html.erb
@@ -12,15 +12,7 @@
           </th>
         </thead>
       <tbody id="job-history-table">
-        <% @job_runs.each do |job_run| %>
-          <tr>
-            <td><%= link_to job_run.id, job_run %></td>
-            <td><%= job_run.job_type %></td>
-            <td><%= job_run.batch_context.user.sunet_id %></td>
-            <td><%= job_run.human_state_name %></td>
-            <td><%= job_run.created_at.in_time_zone('Pacific Time (US & Canada)').to_formatted_s(:long) %></td>
-          </tr>
-        <% end %>
+        <%= render partial: 'job_runs' %>
        </tbody>
     </table>
   </div>


### PR DESCRIPTION
## Why was this change made? 🤔

Now that we are using turbo instead of javascript for recent history, we can use a partial instead of duplicating that code.

Also, we need to tell turbo to replace the entire page when viewing job run detail pages (else you will get odd behavior from the recent history panel).

## How was this change tested? 🤨

Localhost