### PR TITLE
tweak object instantiation and iteration to reduce discovery report peak memory consumption

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -512,4 +512,4 @@ DEPENDENCIES
   turbo-rails (~> 1.1)
 
 BUNDLED WITH
-   2.3.8
+   2.3.15

--- a/app/services/discovery_report.rb
+++ b/app/services/discovery_report.rb
@@ -38,7 +38,7 @@ class DiscoveryReport
       row.counts[:mimetypes].each { |k, v| summary[:mimetypes][k] += v }
       # log the output to a running progress file
       File.open(batch.batch_context.progress_log_file, 'a') { |f| f.puts log_progress_info(dobj, status).to_yaml }
-      yield row
+      yield row.to_h
     end
   end
   # rubocop:enable Metrics/AbcSize

--- a/app/services/object_file_validator.rb
+++ b/app/services/object_file_validator.rb
@@ -52,6 +52,10 @@ class ObjectFileValidator
   # rubocop:enable Metrics/MethodLength
 
   def as_json(*)
+    to_h
+  end
+
+  def to_h
     { druid: druid.druid, errors: errors.compact, counts: counts }
   end
 

--- a/spec/services/discovery_report_spec.rb
+++ b/spec/services/discovery_report_spec.rb
@@ -26,9 +26,12 @@ RSpec.describe DiscoveryReport do
   end
 
   describe '#each_row' do
-    let(:validator1) { instance_double(ObjectFileValidator, counts: { total_size: 1, mimetypes: { a: 1, b: 2 } }, errors: {}) }
-    let(:validator2) { instance_double(ObjectFileValidator, counts: { total_size: 2, mimetypes: { b: 3, q: 4 } }, errors: {}) }
-    let(:validator3) { instance_double(ObjectFileValidator, counts: { total_size: 3, mimetypes: { q: 9 } }, errors: { foo: true }) }
+    let(:h1) { { druid: 'druid:1', errors: {}, counts:  { total_size: 1, mimetypes: { a: 1, b: 2 } } } }
+    let(:h2) { { druid: 'druid:2', errors: {}, counts:  { total_size: 2, mimetypes: { b: 3, q: 4 } } } }
+    let(:h3) { { druid: 'druid:2', errors: { foo: true }, counts: { total_size: 3, mimetypes: { q: 9 } } } }
+    let(:validator1) { instance_double(ObjectFileValidator, counts: h1[:counts], errors: h1[:errors], to_h: h1) }
+    let(:validator2) { instance_double(ObjectFileValidator, counts: h2[:counts], errors: h2[:errors], to_h: h2) }
+    let(:validator3) { instance_double(ObjectFileValidator, counts: h3[:counts], errors: h3[:errors], to_h: h3) }
     let(:dig_obj1) { instance_double(PreAssembly::DigitalObject, pid: 'druid:1') }
     let(:dig_obj2) { instance_double(PreAssembly::DigitalObject, pid: 'druid:2') }
     let(:dig_obj3) { instance_double(PreAssembly::DigitalObject, pid: 'druid:3') }
@@ -41,7 +44,7 @@ RSpec.describe DiscoveryReport do
       expect(report).to receive(:process_dobj).with(dig_obj1).and_return(validator1)
       expect(report).to receive(:process_dobj).with(dig_obj2).and_return(validator2)
       expect(report).to receive(:process_dobj).with(dig_obj3).and_return(validator3)
-      expect(batch).to receive(:un_pre_assembled_objects).and_return([dig_obj1, dig_obj2, dig_obj3])
+      expect(batch).to receive(:un_pre_assembled_objects).and_return([dig_obj1, dig_obj2, dig_obj3].to_enum)
       report.each_row { |_r| } # no-op
       expect(report.summary).to match a_hash_including(
         total_size: 6,


### PR DESCRIPTION
## Why was this change made? 🤔

closes #961

* Batch#digital_objects, Batch#un_pre_assembled_objects, and Batch#containers_via_manifest now all return an Enumerator, instead of loading all their respective arrays into memory at once and memoizing the result
* DiscoveryReport#each_row now yields a lighter-weight hash, instead of an ObjectFileValidator instance, since the validator's hash represenation was the only part of the result being used anyway (for JSON serialization).

it surprised me somewhat, and i can't explain why exactly, but the second change was as important as the first: the first allowed a discovery report for which memory usage ballooned past 6 GB (before being killed for using too much memory) to run for longer and balloon less quickly; the second change in conjunction with the first allowed the same report to not balloon continuously, and to complete successfully.

see https://github.com/sul-dlss/pre-assembly/issues/961 and https://github.com/sul-dlss/pre-assembly/issues/908

**NOTE** (relative to the original analysis ticket's title): this is unlikely to change the runtime of _most_ discovery reports and pre-assembly jobs.  what it should do is reduce the execution time of discovery reports that took a very long time because they were eating into swap space without using enough memory to get killed, and it should allow jobs that were getting killed because of memory consumption to complete (because memory consumption shouldn't grow nearly so quickly).

## How was this change tested? 🤨

- [x] unit tests
- [x] testing on stage by running discovery report using clones of [this pre-assembly batch context](https://sul-preassembly-stage.stanford.edu/job_runs/1745), and [this one](https://sul-preassembly-stage.stanford.edu/job_runs/1744).  the first doesn't use a file manifest, the second does.  will do one last run using both at the same time with this branch, and will put it up for review if that's successful (has been on a few runs so far today).  before the changes in this branch, the report that used a file manifest would run for around an hour, before being killed for using too much memory.  see #908 for more detail.
- [x] `spec/features/create_preassembly_image_spec.rb` from integration test suite

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


