### PR TITLE
fix bootstrap close alert

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -26,8 +26,8 @@
 </div>
 <% flash.each do |key, value| %>
   <div class="container">
-    <div class="alert alert-<%= key %> alert-dismissible" role="alert">
-      <button type="button" class="close" data-dismiss="alert" aria-label="Close"><i class="fa-solid xmark"></i></button>
+   <div class="alert alert-<%= key %> alert-dismissible fade show" role="alert">
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
       <%= value %>
     </div>
   </div>


### PR DESCRIPTION
## Why was this change made? 🤔

Update to bootstrap 5 broke the close button on alert dialogs - this fixes it

## How was this change tested? 🤨

Localhost