### PR TITLE
add job state to notification email

### DIFF
--- a/app/views/job_mailer/completion_email.text.erb
+++ b/app/views/job_mailer/completion_email.text.erb
@@ -1,2 +1,2 @@
-Your <%= @job_run.job_type.humanize %> job #<%= @job_run.id %> completed.
+Your <%= @job_run.job_type.humanize %> job #<%= @job_run.id %> finished with status '<%= @job_run.human_state_name %>'.
 You can view the job details and log file at: <%= job_run_url(@job_run); %>

--- a/spec/mailers/job_mailer_spec.rb
+++ b/spec/mailers/job_mailer_spec.rb
@@ -11,15 +11,19 @@ RSpec.describe JobMailer, type: :mailer do
   end
 
   describe 'subject' do
-    before { job_run.job_type = 1 }
+    before { job_run.job_type = 1 } # switch job type to verify the subject line changes
 
     it 'adapts depending on job_type' do
       expect(job_notification.subject).to eq('[Test_Project] Your Preassembly job completed')
     end
   end
 
-  it 'renders the body' do
-    expect(job_notification.body.encoded).to include("Your Discovery report job \##{job_run.id} completed")
-      .and include("http://localhost:3000/job_runs/#{job_run.id}")
+  describe 'body' do
+    before { job_run.state = 'complete' }
+
+    it 'renders the body' do
+      expect(job_notification.body.encoded).to include("Your Discovery report job \##{job_run.id} finished with status 'Completed'")
+        .and include("http://localhost:3000/job_runs/#{job_run.id}")
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #976 - add the final state of the job in the notification email (e.g. "completed", "failed", etc.)


## How was this change tested? 🤨

Updated test