### PR TITLE
batch.rb: shrink public attrs and methods

### DIFF
--- a/app/lib/pre_assembly/batch.rb
+++ b/app/lib/pre_assembly/batch.rb
@@ -72,13 +72,6 @@ module PreAssembly
     end
     # rubocop:enable Metrics/AbcSize
 
-    # For each of the passed DigitalObject's ObjectFiles, sets the checksum attribute.
-    # @param [DigitalObject] dobj
-    def load_checksums(dobj)
-      log '  - load_checksums()'
-      dobj.object_files.each { |file| file.provider_md5 = file.md5 }
-    end
-
     # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/CyclomaticComplexity
@@ -178,6 +171,13 @@ module PreAssembly
       { item_not_registered: true }
     rescue RuntimeError # HTTP timeout, network error, whatever
       { dor_connection_error: true }
+    end
+
+    # For each of the passed DigitalObject's ObjectFiles, sets the checksum attribute.
+    # @param [DigitalObject] dobj
+    def load_checksums(dobj)
+      log '  - load_checksums()'
+      dobj.object_files.each { |file| file.provider_md5 = file.md5 }
     end
 
     def object_client(druid)

--- a/app/lib/pre_assembly/batch.rb
+++ b/app/lib/pre_assembly/batch.rb
@@ -45,6 +45,7 @@ module PreAssembly
       log_params.map { |k, v| "#{k}=#{v.inspect}" }.join(', ')
     end
 
+    # used by discovery report
     def object_filenames_unique?(dobj)
       filenames = dobj.object_files.map { |objfile| File.basename(objfile.path) }
       filenames.count == filenames.uniq.count
@@ -112,6 +113,7 @@ module PreAssembly
     # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable Metrics/PerceivedComplexity
 
+    # used by discovery report
     # @return [Array<DigitalObject>]
     def objects_to_process
       @objects_to_process ||= digital_objects.reject { |dobj| skippables&.key?(dobj.container) }

--- a/app/lib/pre_assembly/batch.rb
+++ b/app/lib/pre_assembly/batch.rb
@@ -29,8 +29,8 @@ module PreAssembly
 
     def initialize(batch_context)
       @batch_context = batch_context
-      self.file_manifest = PreAssembly::FileManifest.new(csv_filename: batch_context.file_manifest, bundle_dir: bundle_dir) if batch_context.using_file_manifest
-      self.skippables = {}
+      @file_manifest = PreAssembly::FileManifest.new(csv_filename: batch_context.file_manifest, bundle_dir: bundle_dir) if batch_context.using_file_manifest
+      @skippables = {}
       load_skippables
     end
 

--- a/app/lib/pre_assembly/batch.rb
+++ b/app/lib/pre_assembly/batch.rb
@@ -29,20 +29,9 @@ module PreAssembly
     # Runs the pre-assembly process
     # @return [void]
     def run_pre_assembly
-      log "\nstarting run_pre_assembly(#{run_log_msg})"
+      log "\nstarting run_pre_assembly(#{info_for_log})"
       process_digital_objects
-      log "\nfinishing run_pre_assembly(#{run_log_msg})"
-    end
-
-    def run_log_msg
-      log_params = {
-        content_structure: content_structure,
-        project_name: project_name,
-        bundle_dir: bundle_dir,
-        assembly_staging_dir: Settings.assembly_staging_dir,
-        environment: Rails.env
-      }
-      log_params.map { |k, v| "#{k}=#{v.inspect}" }.join(', ')
+      log "\nfinishing run_pre_assembly(#{info_for_log})"
     end
 
     # used by discovery report
@@ -180,6 +169,17 @@ module PreAssembly
     def load_checksums(dobj)
       log '  - load_checksums()'
       dobj.object_files.each { |file| file.provider_md5 = file.md5 }
+    end
+
+    def info_for_log
+      log_params = {
+        content_structure: content_structure,
+        project_name: project_name,
+        bundle_dir: bundle_dir,
+        assembly_staging_dir: Settings.assembly_staging_dir,
+        environment: Rails.env
+      }
+      log_params.map { |k, v| "#{k}=#{v.inspect}" }.join(', ')
     end
 
     def object_client(druid)

--- a/spec/jobs/preassembly_job_spec.rb
+++ b/spec/jobs/preassembly_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PreassemblyJob, type: :job do
 
   before do
     allow(batch_context).to receive(:progress_log_file).and_return(outfile)
-    allow(batch).to receive(:process_digital_objects)
+    allow(batch).to receive(:pre_assemble_objects)
   end
 
   after { FileUtils.rm(outfile) if File.exist?(outfile) } # cleanup
@@ -35,7 +35,7 @@ RSpec.describe PreassemblyJob, type: :job do
       let(:error_message) { 'something really unexpected happened' }
       # simulate an uncaught exception while running the job
 
-      before { allow(batch).to receive(:process_digital_objects).and_raise(StandardError, error_message) }
+      before { allow(batch).to receive(:pre_assemble_objects).and_raise(StandardError, error_message) }
 
       it 'ends in a failed state with an uncaught exception, and saves error message to the database' do
         job.perform(job_run)

--- a/spec/lib/pre_assembly/batch_spec.rb
+++ b/spec/lib/pre_assembly/batch_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe PreAssembly::Batch do
   describe '#load_checksums' do
     it 'loads checksums and attach them to the ObjectFiles' do
       multimedia.send(:all_object_files).each { |f| expect(f.checksum).to be_nil }
-      multimedia.digital_objects.each { |dobj| multimedia.load_checksums(dobj) }
+      multimedia.digital_objects.each { |dobj| multimedia.send(:load_checksums, dobj) }
       multimedia.send(:all_object_files).each { |f| expect(f.checksum).to match(md5_regex) }
     end
   end

--- a/spec/lib/pre_assembly/batch_spec.rb
+++ b/spec/lib/pre_assembly/batch_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe PreAssembly::Batch do
     end
 
     it 'logs the start and finish of the run' do
-      expect(batch).to receive(:log).with("\nstarting run_pre_assembly(#{batch.run_log_msg})")
-      expect(batch).to receive(:log).with("\nfinishing run_pre_assembly(#{batch.run_log_msg})")
+      expect(batch).to receive(:log).with("\nstarting run_pre_assembly(#{batch.send(:info_for_log)})")
+      expect(batch).to receive(:log).with("\nfinishing run_pre_assembly(#{batch.send(:info_for_log)})")
       batch.run_pre_assembly
     end
 
@@ -148,17 +148,14 @@ RSpec.describe PreAssembly::Batch do
     end
   end
 
-  describe '#run_log_msg' do
-    it 'returns a string' do
-      expect(flat_dir_images.run_log_msg).to be_a(String)
-    end
-
+  describe '#info_for_log' do
     it 'returns a string with the expected values' do
-      expect(flat_dir_images.run_log_msg).to match(/content_structure="#{flat_dir_images.content_structure}"/)
-      expect(flat_dir_images.run_log_msg).to match(/project_name="#{flat_dir_images.project_name}"/)
-      expect(flat_dir_images.run_log_msg).to match(/bundle_dir="#{flat_dir_images.bundle_dir}"/)
-      expect(flat_dir_images.run_log_msg).to match(/assembly_staging_dir="#{Settings.assembly_staging_dir}"/)
-      expect(flat_dir_images.run_log_msg).to match(/environment="test"/)
+      info_for_log = flat_dir_images.send(:info_for_log)
+      expect(info_for_log).to match(/content_structure="#{flat_dir_images.content_structure}"/)
+      expect(info_for_log).to match(/project_name="#{flat_dir_images.project_name}"/)
+      expect(info_for_log).to match(/bundle_dir="#{flat_dir_images.bundle_dir}"/)
+      expect(info_for_log).to match(/assembly_staging_dir="#{Settings.assembly_staging_dir}"/)
+      expect(info_for_log).to match(/environment="test"/)
     end
   end
 

--- a/spec/lib/pre_assembly/batch_spec.rb
+++ b/spec/lib/pre_assembly/batch_spec.rb
@@ -141,12 +141,10 @@ RSpec.describe PreAssembly::Batch do
     end
   end
 
-  describe '#load_skippables' do
+  describe '#skippables' do
     it 'returns expected hash of skippable items' do
       allow(multimedia).to receive(:progress_log_file).and_return('spec/test_data/input/mock_progress_log.yaml')
-      expect(multimedia.skippables).to eq({})
-      multimedia.load_skippables
-      expect(multimedia.skippables).to eq('aa' => true, 'bb' => true)
+      expect(multimedia.send(:skippables)).to eq('aa' => true, 'bb' => true)
     end
   end
 
@@ -232,13 +230,11 @@ RSpec.describe PreAssembly::Batch do
 
   describe '#objects_to_process' do
     it 'returns all objects if there are no skippables' do
-      flat_dir_images.skippables = {}
       expect(flat_dir_images.objects_to_process).to eq(flat_dir_images.digital_objects)
     end
 
     it 'returns a filtered list of digital objects' do
-      flat_dir_images.skippables = {}
-      flat_dir_images.skippables[flat_dir_images.digital_objects.last.container] = true
+      allow(flat_dir_images).to receive(:skippables).and_return({ flat_dir_images.digital_objects.last.container => true })
       o2p = flat_dir_images.objects_to_process
       expect(o2p.size).to eq(flat_dir_images.digital_objects.size - 1)
       expect(o2p).to eq(flat_dir_images.digital_objects[0..-2])

--- a/spec/support/batch_setup.rb
+++ b/spec/support/batch_setup.rb
@@ -7,7 +7,7 @@ end
 
 def hash_from_proj(proj)
   filename = "spec/test_data/project_config_files/#{proj}.yaml"
-  YAML.safe_load(File.read(filename)).merge('config_filename' => filename)
+  YAML.safe_load(File.read(filename))
 end
 
 def noko_doc(text_xml)


### PR DESCRIPTION
## Why was this change made? 🤔

A lot of the "public" interface of `batch.rb` doesn't need to be public.  This is a beginning of removing unused attributes and delegations as well as making methods only used by the Batch class private.

There are more methods to be made private, but I wanted to get a PR of progress so far up and merged.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


