### PR TITLE
refactor display of reports; fix cleanup of non-empty directories

### DIFF
--- a/app/models/job_run.rb
+++ b/app/models/job_run.rb
@@ -59,9 +59,9 @@ class JobRun < ApplicationRecord
     (waiting? || running?)
   end
 
-  # the states that indicate a job is completed
-  def finished?
-    !in_progress?
+  # indicates if the discovery report job is ready for display and is avaiable (some jobs may fail, leaving no report)
+  def report_ready?
+    job_type == 'discovery_report' && !in_progress? && output_location && File.exist?(output_location)
   end
 
   def send_notification

--- a/app/views/job_runs/show.html.erb
+++ b/app/views/job_runs/show.html.erb
@@ -38,7 +38,7 @@
       No progress log file is available.
     <% end %>
     </dd>
-    <% if @job_run.finished? && @job_run.job_type == 'discovery_report' && @job_run.output_location && File.exist?(@job_run.output_location) %>
+    <% if @job_run.report_ready? %>
       <dt class="col-sm-2">Discovery Report</dt>
       <dd class="col-sm-10"><%= link_to 'Download', download_report_path(@job_run) %></dd>
     <% end %>

--- a/spec/controllers/batch_contexts_controller_spec.rb
+++ b/spec/controllers/batch_contexts_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe BatchContextsController, type: :controller do
       context 'Valid Parameters' do
         let(:output_dir) { "#{Settings.job_output_parent_dir}/#{subject.current_user.email}/Multimedia" }
 
-        before { Dir.delete(output_dir) if Dir.exist?(output_dir) }
+        before { FileUtils.remove_dir(output_dir) if Dir.exist?(output_dir) }
 
         it 'passes newly created object' do
           post :create, params: params
@@ -70,7 +70,7 @@ RSpec.describe BatchContextsController, type: :controller do
         it 'persists the first JobRun, rejects dups' do
           expect { post :create, params: params }.to change(JobRun, :count).by(1)
           expect { post :create, params: params }.not_to change(BatchContext, :count)
-          Dir.delete(output_dir) if Dir.exist?(output_dir) # even if the directory is missing, cannot reuse user & project_name
+          FileUtils.remove_dir(output_dir) if Dir.exist?(output_dir) # even if the directory is missing, cannot reuse user & project_name
           expect { post :create, params: params }.to raise_error(ActiveRecord::RecordNotUnique)
         end
       end

--- a/spec/factories/batch_contexts.rb
+++ b/spec/factories/batch_contexts.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
     # some tests require BCs with clean output_dir
     factory :batch_context_with_deleted_output_dir do
       after(:build) do |bc|
-        Dir.delete(bc.output_dir) if Dir.exist?(bc.output_dir)
+        FileUtils.remove_dir(bc.output_dir) if Dir.exist?(bc.output_dir)
       end
     end
 

--- a/spec/factories/job_runs.rb
+++ b/spec/factories/job_runs.rb
@@ -2,7 +2,6 @@
 
 FactoryBot.define do
   factory :job_run do
-    output_location { '/path/to/report' }
     association :batch_context, factory: :batch_context_with_deleted_output_dir
 
     trait :preassembly do
@@ -11,6 +10,7 @@ FactoryBot.define do
 
     trait :discovery_report do
       job_type { 'discovery_report' }
+      output_location { '/path/to/report' }
     end
   end
 end

--- a/spec/lib/pre_assembly/batch_spec.rb
+++ b/spec/lib/pre_assembly/batch_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe PreAssembly::Batch do
     allow(Dor::Services::Client).to receive(:object).and_return(dor_services_client_object)
   end
 
-  after { FileUtils.rm_rf(batch.batch_context.output_dir) if Dir.exist?(batch.batch_context.output_dir) } # cleanup
+  after { FileUtils.remove_dir(batch.batch_context.output_dir) if Dir.exist?(batch.batch_context.output_dir) } # cleanup
 
   describe '#run_pre_assembly' do
     before do

--- a/spec/lib/pre_assembly/digital_object_spec.rb
+++ b/spec/lib/pre_assembly/digital_object_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe PreAssembly::DigitalObject do
   let(:druid) { DruidTools::Druid.new(pid) }
   let(:tmp_dir_args) { [nil, 'tmp'] }
 
-  before(:all) { FileUtils.rm_rf('log/test_jobs') }
+  before(:all) { FileUtils.remove_dir('log/test_jobs') }
 
   before do
     allow(bc).to receive(:progress_log_file).and_return(Tempfile.new('images_jp2_tif').path)

--- a/spec/models/batch_context_spec.rb
+++ b/spec/models/batch_context_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe BatchContext, type: :model do
   describe '#output_dir_no_exists!' do
     before { FileUtils.mkdir_p(Settings.job_output_parent_dir) }
 
-    after { Dir.delete(bc.output_dir) if Dir.exist?(bc.output_dir) } # cleanup
+    after { FileUtils.remove_dir(bc.output_dir) if Dir.exist?(bc.output_dir) } # cleanup
 
     context 'when batch_context is new' do
       before { allow(bc).to receive(:persisted?).and_return(false) }

--- a/spec/views/job_runs/show.html.erb_spec.rb
+++ b/spec/views/job_runs/show.html.erb_spec.rb
@@ -4,13 +4,14 @@ RSpec.describe 'job_runs/show.html.erb', type: :view do
   before do
     assign(:job_run, job_run)
     allow(job_run).to receive(:progress_log_file).and_return(actual_file)
-    allow(job_run).to receive(:output_location).and_return(actual_file)
   end
 
   let(:job_run) { create(:job_run, :discovery_report) }
   let(:actual_file) { Rails.root.join('spec/test_data/input/mock_progress_log.yaml') } # an existing file we can use for tests
 
   context 'discovery_report job' do
+    before { allow(job_run).to receive(:output_location).and_return(actual_file) }
+
     it 'displays a job_run' do
       render template: 'job_runs/show'
       expect(rendered).to include("Discovery report \##{job_run.id}")
@@ -19,6 +20,14 @@ RSpec.describe 'job_runs/show.html.erb', type: :view do
     it 'with a completed job, presents a download link to the report and the log file' do
       job_run.started
       job_run.completed
+      render template: 'job_runs/show'
+      expect(rendered).to include("<a href=\"/job_runs/#{job_run.id}/download_log\">Download</a>")
+      expect(rendered).to include("<a href=\"/job_runs/#{job_run.id}/download_report\">Download</a>")
+    end
+
+    it 'with a completed with errors job, presents a download link to the report and the log file' do
+      job_run.started
+      job_run.completed_with_errors
       render template: 'job_runs/show'
       expect(rendered).to include("<a href=\"/job_runs/#{job_run.id}/download_log\">Download</a>")
       expect(rendered).to include("<a href=\"/job_runs/#{job_run.id}/download_report\">Download</a>")


### PR DESCRIPTION
## Why was this change made? 🤔

1. The condition under which we show the discovery report link was in the view ... this makes it easier to understand and puts it in the model.
2. Re-running individual specs could sometimes fail when a test directory was not cleaned up correctly, this just forces cleanup even if the directory is not empty (using `FileUtils.remove_dir`, which is also used elsewhere in the tests instead of `Dir.delete`)
3. Changing some fixture data and mocking to better reflect the actual differences between preassembly and discovery_report jobs in the database.  It doesn't currently affect existing tests, but could become a source of unexpected test behavior in future tests.


## How was this change tested? 🤨

Localhost
