### PR TITLE
speed up test execution while avoiding SQLite contention issue

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -24,7 +24,12 @@ Rails.application.configure do
 
   # To deal with running tests with SQLite and ActiveJob, which can sometimes cause concurrency locking issues
   # see https://github.com/rails/rails/issues/30937
-  config.active_job.queue_adapter = :inline
+  # see also https://api.rubyonrails.org/classes/ActiveJob/QueueAdapters/AsyncAdapter.html
+  # per the GH issue, "default is :async to help tests catch code that's inadvertently assuming synchronous execution".
+  # switching to :inline slows tests down and loses that benefit, but limiting to exactly 1 thread prevents SQLite
+  # write contention while still testing with async job execution.
+  config.active_job.queue_adapter = ActiveJob::QueueAdapters::AsyncAdapter.new(min_threads: 1, max_threads: 1)
+
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true


### PR DESCRIPTION
## Why was this change made? 🤔

i too was hitting the annoying SQLite contention errors fixed by #982.  but then i also noticed a big increase in the time it took the test suite to execute once i rebased my WIP on that fix.  i went to look into alternate test adapters after @jcoyne mentioned the `:test` adapter.  i didn't end up going that route, but i did come up with a tweak that i think addresses both the SQLite contention issue and the slow test execution (and brings back the benefit that the default `:async` adapter gives in terms of test quality).  explained in the config comment.

## How was this change tested? 🤨

local test suite execution.  across 4 or 5 runs, i noticed the tests running at their old speed, and i also ran into no SQLite errors.

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


