### PR TITLE
add info to progress log file for discovery reports

### DIFF
--- a/app/services/discovery_report.rb
+++ b/app/services/discovery_report.rb
@@ -48,6 +48,7 @@ class DiscoveryReport
   def log_progress_info(dobj, status)
     {
       status: status,
+      discovery_finished: true,
       pid: dobj.pid,
       timestamp: Time.now.utc.strftime('%Y-%m-%d %H:%M:%S')
     }

--- a/app/services/discovery_report.rb
+++ b/app/services/discovery_report.rb
@@ -5,7 +5,7 @@
 #   report = DiscoveryReport.new(batch_context.batch)
 #   report.to_builder.target!  # generates the report as a JSON string
 class DiscoveryReport
-  attr_reader :batch, :start_time, :summary
+  attr_reader :batch, :summary
   attr_accessor :error_message, :objects_had_errors
 
   delegate :bundle_dir, :content_md_creation, :manifest, :project_style, :using_file_manifest, to: :batch
@@ -15,9 +15,8 @@ class DiscoveryReport
   def initialize(batch)
     raise ArgumentError unless batch.is_a?(PreAssembly::Batch)
 
-    @start_time = Time.now.utc
     @batch = batch
-    @summary = { objects_with_error: 0, mimetypes: Hash.new(0), start_time: start_time.to_s, total_size: 0 }
+    @summary = { objects_with_error: 0, mimetypes: Hash.new(0), start_time: Time.now.utc.to_s, total_size: 0 }
   end
 
   # this is where we do the work -- by calling process_dobj on each object in the batch
@@ -80,7 +79,7 @@ class DiscoveryReport
   def to_builder
     json_report = Jbuilder.new do |json|
       json.rows { json.array!(each_row) }
-      json.summary summary
+      json.summary summary.merge(end_time: Time.now.utc.to_s)
     end
     @objects_had_errors = (summary[:objects_with_error] > 0) # indicate if any objects generated errors
     @error_message = "#{summary[:objects_with_error]} objects had errors in the discovery report" if objects_had_errors

--- a/spec/features/discovery_report/build_manifest_image_spec.rb
+++ b/spec/features/discovery_report/build_manifest_image_spec.rb
@@ -48,6 +48,9 @@ RSpec.describe 'Discovery Report creation using build manifest', type: :feature 
     expect(discovery_report_json['summary']['objects_with_error']).to eq 0
     expect(discovery_report_json['rows'].first['druid']).to eq "druid:#{bare_druid}"
     expect(discovery_report_json['summary']['mimetypes']['image/jpeg']).to eq 1
+    # verify the timestamps in the summary are for today
+    expect(discovery_report_json['summary']['start_time'].to_date).to eq Time.now.utc.to_date
+    expect(discovery_report_json['summary']['end_time'].to_date).to eq Time.now.utc.to_date
 
     log_path = Rails.root.join(Settings.job_output_parent_dir, user_id, project_name, "#{project_name}_progress.yml")
     # rubocop:disable Security/YAMLLoad

--- a/spec/features/discovery_report/build_manifest_image_spec.rb
+++ b/spec/features/discovery_report/build_manifest_image_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'Discovery Report creation using build manifest', type: :feature 
     # rubocop:disable Security/YAMLLoad
     log_hash = YAML.load(File.read(log_path))
     # rubocop:enable Security/YAMLLoad
-    expect(log_hash[:status]).to eq 'success'
-    expect(log_hash.keys.size).to eq 3
+    expect(log_hash).to include(status: 'success', pid: bare_druid, discovery_finished: true)
+    expect(log_hash.keys.size).to eq 4
   end
 end

--- a/spec/features/discovery_report/file_manifest_book_spec.rb
+++ b/spec/features/discovery_report/file_manifest_book_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'Discovery Report creation using file_manifest.csv', type: :featu
     # rubocop:disable Security/YAMLLoad
     log_hash = YAML.load(File.read(log_path))
     # rubocop:enable Security/YAMLLoad
-    expect(log_hash[:status]).to eq 'success'
-    expect(log_hash.keys.size).to eq 3
+    expect(log_hash).to include(status: 'success', pid: bare_druid, discovery_finished: true)
+    expect(log_hash.keys.size).to eq 4
   end
 end

--- a/spec/features/discovery_report/file_manifest_book_spec.rb
+++ b/spec/features/discovery_report/file_manifest_book_spec.rb
@@ -53,6 +53,9 @@ RSpec.describe 'Discovery Report creation using file_manifest.csv', type: :featu
     expect(discovery_report_json['summary']['objects_with_error']).to eq 0
     expect(discovery_report_json['rows'].first['druid']).to eq "druid:#{bare_druid}"
     expect(discovery_report_json['summary']['mimetypes']['image/jpeg']).to eq 3
+    # verify the timestamps in the summary are for today
+    expect(discovery_report_json['summary']['start_time'].to_date).to eq Time.now.utc.to_date
+    expect(discovery_report_json['summary']['end_time'].to_date).to eq Time.now.utc.to_date
 
     log_path = Rails.root.join(Settings.job_output_parent_dir, user_id, project_name, "#{project_name}_progress.yml")
     # rubocop:disable Security/YAMLLoad

--- a/spec/test_data/input/mock_discovery_report.json
+++ b/spec/test_data/input/mock_discovery_report.json
@@ -1,1 +1,1 @@
-{"rows":[{"druid":"druid:cm165rg4037","errors":{},"counts":{"total_size":29634,"mimetypes":{"image/jpeg":1},"filename_no_extension":0}}],"summary":{"objects_with_error":0,"mimetypes":{"image/jpeg":1},"start_time":"2022-06-02 22:24:37 UTC","total_size":29634}}
+{"rows":[{"druid":"druid:cm165rg4037","errors":{},"counts":{"total_size":29634,"mimetypes":{"image/jpeg":1},"filename_no_extension":0}}],"summary":{"objects_with_error":0,"mimetypes":{"image/jpeg":1},"start_time":"2022-06-02 22:24:37 UTC","end_time":"2022-06-02 23:24:37 UTC","total_size":29634}}


### PR DESCRIPTION
## Why was this change made? 🤔

While working on #948, I was starting to examine the YAML progress log files to see if they could mined for information.

1. I noted that we use the same log file for both discovery reports and pre-assembly jobs for the same BatchContext (e.g. project).  This is fine and works with the existing code for restarting a pre-assembly job, but I thought it would be useful to explicitly indicate for each druid in the log file which type of job the log entry was for.  We do this for pre-assembly jobs already (which is how we use this YAML file for restarting pre-assembly jobs), but we don't do it for discovery report jobs.  This adds info the existing log entry.  It has no user interface impact, but would be useful for implementing restarting of discovery jobs or analysis using the YAML files.

e.g. in the same YAML file, we currently have this for the pre-assembly job:

```
---
:container: "/smpl2/projqueue-235/b121/content/zx884by2333"
:pid: zx884by2333
:pre_assem_finished: true
:timestamp: '2022-06-10 19:21:27'
:status: success
```

and this for discovery report jobs
```
:pid: zx884by2333
:timestamp: '2022-06-10 16:04:04'
:status: success
```

This adds a key to the discovery report entry to make it clear it is a discovery report log entry.

2. I noticed we a start time in the discovery report, but no end time.  This adds the end time of the report to the summary block, so we can use it in future analysis.

3. This start_time is currently an accessor but is never used anywhere else except `#initialize`, so removed it as an accessor.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


