### PR TITLE
objects with no files should complete the pre-assembly job successfully

### DIFF
--- a/spec/features/preassembly_run/no_files_spec.rb
+++ b/spec/features/preassembly_run/no_files_spec.rb
@@ -35,8 +35,7 @@ RSpec.describe 'Run preassembly on object with no files', type: :feature do
     end
   end
 
-  # FIXME: job status doesn't match progress log!
-  it 'has status Completed (with errors) and creates log file showing "success"' do
+  it 'has status "Completed" and creates log file showing "success"' do
     visit '/'
     expect(page).to have_selector('h3', text: 'Complete the form below')
 
@@ -52,13 +51,12 @@ RSpec.describe 'Run preassembly on object with no files', type: :feature do
     # go to job details page, wait for preassembly to finish
     first('td  > a').click
     expect(page).to have_content project_name
-    expect(page).to have_content 'Completed (with errors)' # FIXME: this doesn't match progress log!
-    expect(page).to have_content '1 objects had no files'
+    expect(page).to have_content 'Completed'
     expect(page).to have_link('Download').once
 
     result_file = Rails.root.join(Settings.job_output_parent_dir, user_id, project_name, "#{project_name}_progress.yml")
     yaml = YAML.load_file(result_file)
-    expect(yaml[:status]).to eq 'success' # FIXME: this doesn't match job status!
+    expect(yaml[:status]).to eq 'success'
 
     # we got all the expected content files
     expect(Dir.children(File.join(object_staging_dir, 'content')).size).to eq 0


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #998 - when a pre-assembly job runs and an object has no files, this is marked as "success" (current behavior), but should not put the job run into a "completed (with errors)" state, but instead should just be "completed" (new behavior).

Update the recently added integration test to verify these jobs end in a completed state with no error.
~~Wait until #997 is merged, rebased here and then updated to reflect this new behavior~~

## How was this change tested? 🤨

Updated existing test from #997 (that new test started failing with my code change here until I adjusted the test)