### PR TITLE
remove unused assembly-image gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ gem 'simple_form' # rails form that handles errors internally and easily integra
 gem 'state_machines-activerecord'
 
 # Stanford gems
-gem 'assembly-image', '~> 1.7'
 gem 'assembly-objectfile', '~> 1.10', '>= 1.10.3' # webarchive-seed and reading order is supported in 1.10.2 and better
 gem 'dor-services-client', '~> 12.0'
 gem 'dor-workflow-client', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,9 +70,6 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
-    assembly-image (1.8.0)
-      assembly-objectfile (>= 1.6.4)
-      mini_exiftool (>= 1.6, < 3)
     assembly-objectfile (1.12.0)
       activesupport (>= 5.2.0)
       deprecation
@@ -467,7 +464,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  assembly-image (~> 1.7)
   assembly-objectfile (~> 1.10, >= 1.10.3)
   capistrano-bundler
   capistrano-passenger


### PR DESCRIPTION
## Why was this change made? 🤔

It turns out that pre-assembly doesn't create images.   Who knew?

If you're dubious, do a search on "image" in the app directory.

It does make me wonder how long this has been true ...

## How was this change tested? 🤨

unit tests, and for good measure, I deployed this branch on qa and ran the integration test that uses pre-assembly.

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


