### PR TITLE
remove reference to Assembly::ObjectFileable

### DIFF
--- a/app/lib/pre_assembly/object_file.rb
+++ b/app/lib/pre_assembly/object_file.rb
@@ -9,7 +9,7 @@ module PreAssembly
 
     # @param [String] path full path
     # @param [Hash<Symbol => Object>] params
-    # @see Assembly::ObjectFile, Assembly::ObjectFileable
+    # @see Assembly::ObjectFile
     def initialize(path, params = {})
       super
       @provider_md5 ||= params[:checksum]


### PR DESCRIPTION
## Why was this change made? 🤔

assembly-objectfile will soon not have the module named Assembly::ObjectFileable

## How was this change tested? 🤨

it was a comment change.

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


