### PR TITLE
define DigitalObject#==, let it be used implicitly in test comparisons

### DIFF
--- a/app/lib/pre_assembly/digital_object.rb
+++ b/app/lib/pre_assembly/digital_object.rb
@@ -40,6 +40,12 @@ module PreAssembly
     end
     # rubocop:enable Metrics/ParameterLists
 
+    def ==(other)
+      %i[batch container stageable_items object_files label pid source_id stager].all? do |field_name|
+        send(field_name) == other.send(field_name)
+      end
+    end
+
     # set this object's content_md_creation_style
     # @return [Symbol]
     def content_md_creation_style

--- a/app/lib/pre_assembly/digital_object.rb
+++ b/app/lib/pre_assembly/digital_object.rb
@@ -40,12 +40,6 @@ module PreAssembly
     end
     # rubocop:enable Metrics/ParameterLists
 
-    def ==(other)
-      %i[batch container stageable_items object_files label pid source_id stager].all? do |field_name|
-        send(field_name) == other.send(field_name)
-      end
-    end
-
     # set this object's content_md_creation_style
     # @return [Symbol]
     def content_md_creation_style

--- a/spec/lib/pre_assembly/batch_spec.rb
+++ b/spec/lib/pre_assembly/batch_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe PreAssembly::Batch do
 
   describe '#un_pre_assembled_objects' do
     it 'returns all objects if there are no pre_assembled_object_containers' do
-      expect(flat_dir_images.un_pre_assembled_objects.to_a).to eq(flat_dir_images.digital_objects.to_a)
+      expect(digital_objects_equivalent?(flat_dir_images.un_pre_assembled_objects.to_a, flat_dir_images.digital_objects.to_a)).to be true
     end
 
     it 'calculates size correctly' do
@@ -275,7 +275,7 @@ RSpec.describe PreAssembly::Batch do
       allow(flat_dir_images).to receive(:pre_assembled_object_containers).and_return({ flat_dir_images.digital_objects.to_a.last.container => true })
       o2p = flat_dir_images.un_pre_assembled_objects.to_a
       expect(o2p.size).to eq(flat_dir_images.digital_objects.size - 1)
-      expect(o2p).to eq(flat_dir_images.digital_objects.to_a[0..-2])
+      expect(digital_objects_equivalent?(o2p, flat_dir_images.digital_objects.to_a[0..-2])).to be true
     end
   end
 

--- a/spec/lib/pre_assembly/batch_spec.rb
+++ b/spec/lib/pre_assembly/batch_spec.rb
@@ -263,17 +263,7 @@ RSpec.describe PreAssembly::Batch do
 
   describe '#un_pre_assembled_objects' do
     it 'returns all objects if there are no pre_assembled_object_containers' do
-      all_dobj_array = flat_dir_images.digital_objects.to_a
-      un_preassembled_dobj_array = flat_dir_images.un_pre_assembled_objects.to_a
-      un_preassembled_dobj_array.each_with_index do |dobj, i|
-        # Each time it's called, #to_a iterates over the Enumerable and re-instantiates the yeilded
-        # objects anew.  DigitalObject doesn't have an == method, so compare the relevant fields here
-        # since default == will just check whether the two are the same instance.
-        %i[batch container stageable_items object_files label pid source_id stager].all? do |field_name|
-          expect(dobj.send(field_name)).to eq(all_dobj_array[i].send(field_name))
-        end
-        expect(all_dobj_array.size).to eq(un_preassembled_dobj_array.size)
-      end
+      expect(flat_dir_images.un_pre_assembled_objects.to_a).to eq(flat_dir_images.digital_objects.to_a)
     end
 
     it 'calculates size correctly' do
@@ -285,12 +275,7 @@ RSpec.describe PreAssembly::Batch do
       allow(flat_dir_images).to receive(:pre_assembled_object_containers).and_return({ flat_dir_images.digital_objects.to_a.last.container => true })
       o2p = flat_dir_images.un_pre_assembled_objects.to_a
       expect(o2p.size).to eq(flat_dir_images.digital_objects.size - 1)
-      truncated_dobj_array = flat_dir_images.digital_objects.to_a[0..-2]
-      o2p.each_with_index do |dobj, i|
-        %i[batch container stageable_items object_files label pid source_id stager].all? do |field_name|
-          expect(dobj.send(field_name)).to eq(truncated_dobj_array[i].send(field_name))
-        end
-      end
+      expect(o2p).to eq(flat_dir_images.digital_objects.to_a[0..-2])
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -72,3 +72,12 @@ RSpec.configure do |config|
   # particularly slow.
   # config.profile_examples = 10
 end
+
+# iterate over an array of digital objects, and verify they have equivalent attributes to a second array of digital objects
+def digital_objects_equivalent?(objects1, objects2)
+  objects1.each_with_index.map do |obj, i|
+    %i[batch container stageable_items object_files label pid source_id stager].all? do |field_name|
+      obj.send(field_name) == objects2[i].send(field_name)
+    end
+  end.all?
+end


### PR DESCRIPTION
## Why was this change made? 🤔

* pro: this makes the tests more concise and adds a possibly useful equality checking method
* con: i'm not sure that this is actually captures the desired semantics of `DigitalObject#==`.  also, only the tests use it at present.  i think the comparison works for the tests, but for example, should it rely on the default instance-equivalence equality check for `Batch`, or should `Batch` be compared for semantic equality between possibly different instances instead?

## How was this change tested? 🤨

unit tests

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


