### PR TITLE
user should see a 1-based index for messages

### DIFF
--- a/app/lib/pre_assembly/batch.rb
+++ b/app/lib/pre_assembly/batch.rb
@@ -107,7 +107,7 @@ module PreAssembly
     def containers_via_manifest(&block)
       return enum_for(:containers_via_manifest) { manifest_rows.size } unless block_given?
 
-      manifest_rows.each.with_index do |manifest_row, i|
+      manifest_rows.each.with_index(1) do |manifest_row, i|
         next if manifest_row[:object]
 
         raise "Missing 'object' in row #{i}: #{manifest_row}"

--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -14,8 +14,8 @@ namespace :reports do
     puts "Running discovery report analytics for #{total} discovery report job runs"
     CSV.open(output_file, 'w') do |csv|
       csv << %w[num_objects num_files num_errors runtime_minutes user report_date]
-      JobRun.where(job_type: 'discovery_report').each.with_index do |job_run, index|
-        puts "#{index + 1} of #{total}"
+      JobRun.where(job_type: 'discovery_report').each.with_index(1) do |job_run, i|
+        puts "#{i} of #{total}"
         if job_run.output_location && File.exist?(job_run.output_location)
           num_found += 1
           json_report = JSON.parse(File.read(job_run.output_location))


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #1011 - verified that this error message does show a 0 based index to the user, and the user error messages should be a 1-based index since that is what they expect.  Scanned the code and found no other cases where this is a problem (but did make one other change to be consistent with format/style).

## How was this change tested? 🤨

Localhost