### PR TITLE
Add redis to docker compose and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,22 +38,14 @@ cd pre-assembly
 bundle install
 ```
 
-#### Redis/Resque
+#### Development/Test
 
-The pre-assembly app uses Resque backed by Redis for job queueing.  In order to run the tests or run the
-webapp locally, you will need to have Redis running.  On MacOSX, use `homebrew` to install:
-
-```bash
-brew install redis
-```
-
-and start as needed (if not running as a background process):
+The pre-assembly app requires redis and postgres for local development and testing. In order to run the tests or run the
+webapp locally, you will need to have start these dependencies via `docker compose`:
 
 ```bash
-redis-server /usr/local/etc/redis.conf
+docker compose up -d
 ```
-
-See https://redis.io/ for other installation instructions and information.
 
 #### exiftool
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,5 +9,9 @@ services:
       - POSTGRES_PASSWORD=sekret
     volumes:
       - postgres-data:/var/lib/postgresql/data
+  redis:
+    image: redis
+    ports:
+      - 6379:6379
 volumes:
   postgres-data:


### PR DESCRIPTION
## Why was this change made? 🤔

Installing redis in order to manual run the server differs from our normal practice of starting external dependencies using docker compose. This moves that dependency into the `docker-compose.yml` file and updates the README to reflect these changes.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


