### PR TITLE
Put all jobs on the default queue

### DIFF
--- a/app/jobs/discovery_report_job.rb
+++ b/app/jobs/discovery_report_job.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class DiscoveryReportJob < ApplicationJob
-  queue_as :discovery_report
-
   # @param [JobRun] job_run
   # rubocop:disable Metrics/AbcSize
   def perform(job_run)

--- a/app/jobs/preassembly_job.rb
+++ b/app/jobs/preassembly_job.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class PreassemblyJob < ApplicationJob
-  queue_as :preassembly
-
   # @param [JobRun] job_run
   def perform(job_run)
     job_run.started


### PR DESCRIPTION


## Why was this change made? 🤔

Setting a queue is unnecessary because we don't segregate workers by queue. This makes it slightly simpler.

## How was this change tested? 🤨
CI

