### PR TITLE
remove remaining usage of "bundle" 

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ brew install exiftool
 ## Running tests
 
 ```bash
+docker compose up
 bundle exec rspec
 ```
 

--- a/app/lib/pre_assembly/digital_object.rb
+++ b/app/lib/pre_assembly/digital_object.rb
@@ -136,14 +136,14 @@ module PreAssembly
                                          content_md_creation_style: content_md_creation_style,
                                          reading_order: reading_order)
       else
-        build_from_bundle(objects: object_files.sort,
-                          bundle: content_md_creation.to_sym,
-                          content_md_creation_style: content_md_creation_style,
-                          reading_order: reading_order)
+        build_from_staging_location(objects: object_files.sort,
+                                    content_metadata_creation: content_md_creation.to_sym,
+                                    content_md_creation_style: content_md_creation_style,
+                                    reading_order: reading_order)
       end
     end
 
-    def build_from_bundle(objects:, bundle:, content_md_creation_style:, reading_order:)
+    def build_from_staging_location(objects:, content_metadata_creation:, content_md_creation_style:, reading_order:)
       all_paths = objects.flatten.map do |obj|
         raise "File '#{obj.path}' not found" unless obj.file_exists?
 
@@ -152,7 +152,7 @@ module PreAssembly
 
       common_path = Assembly::ObjectFile.common_path(all_paths) # find common paths to all files provided
 
-      filesets = FromStagingLocation::FileSetBuilder.build(bundle: bundle, objects: objects, style: content_md_creation_style)
+      filesets = FromStagingLocation::FileSetBuilder.build(content_metadata_creation: content_metadata_creation, objects: objects, style: content_md_creation_style)
       FromStagingLocation::StructuralBuilder.build(cocina_dro: cocina_object,
                                                    filesets: filesets,
                                                    common_path: common_path,

--- a/app/lib/pre_assembly/from_staging_location/file.rb
+++ b/app/lib/pre_assembly/from_staging_location/file.rb
@@ -24,13 +24,9 @@ module PreAssembly
         'application/json' => { preserve: 'yes', shelve: 'yes', publish: 'yes' }
       }.freeze
 
-      # @param [Symbol] bundle
       # @param [Assembly::ObjectFile] file
-      # @param style
-      def initialize(file:, bundle: nil, style: nil)
-        @bundle = bundle
+      def initialize(file:)
         @file = file
-        @style = style
       end
 
       delegate :sha1, :md5, :provider_md5, :provider_sha1, :mimetype, :filesize, :image?, to: :file

--- a/app/lib/pre_assembly/from_staging_location/file_set_builder.rb
+++ b/app/lib/pre_assembly/from_staging_location/file_set_builder.rb
@@ -4,34 +4,34 @@ module PreAssembly
   module FromStagingLocation
     # Creates a data structure of FileSets from a staging location
     class FileSetBuilder
-      # @param [Symbol] bundle one of: :default or :filename
+      # @param [Symbol] content_metadata_creation one of: :default or :filename
       # @param [Array<Assembly::ObjectFile>] objects
       # @param [Symbol] style one of: :simple_image, :file, :simple_book, :book_as_image, :book_with_pdf, :map, or :'3d'
-      def self.build(bundle:, objects:, style:)
-        new(bundle: bundle, objects: objects, style: style).build
+      def self.build(content_metadata_creation:, objects:, style:)
+        new(content_metadata_creation: content_metadata_creation, objects: objects, style: style).build
       end
 
-      def initialize(bundle:, objects:, style:)
-        @bundle = bundle
+      def initialize(content_metadata_creation:, objects:, style:)
+        @content_metadata_creation = content_metadata_creation
         @objects = objects
         @style = style
       end
 
       # @return [Array<FileSet>] a list of filesets in the object
       def build
-        case bundle
+        case content_metadata_creation
         when :default # one resource per object
           objects.collect { |obj| FileSet.new(resource_files: [obj], style: style) }
         when :filename # one resource per distinct filename (excluding extension)
           build_for_filename
         else
-          raise 'Invalid bundle method'
+          raise 'Invalid content_metadata_creation: must be :default or :filename'
         end
       end
 
       private
 
-      attr_reader :bundle, :objects, :style
+      attr_reader :content_metadata_creation, :objects, :style
 
       def build_for_filename
         # loop over distinct filenames, this determines how many resources we will have and

--- a/app/lib/pre_assembly/from_staging_location/structural_builder.rb
+++ b/app/lib/pre_assembly/from_staging_location/structural_builder.rb
@@ -8,11 +8,15 @@ module PreAssembly
       # @param [Array<Fileset>] filesets
       # @param [Cocina::Models::DRO] cocina_dro
       # @param [String] common_path
+      # @param [Symbol] content_md_creation_style content metadata creation styles supported by the assembly-objectfile gem
       # @param [String] reading_order
       # @param [Boolean] all_files_public
       def self.build(filesets:, cocina_dro:, common_path:, content_md_creation_style:, reading_order:, all_files_public:)
-        new(filesets: filesets, cocina_dro: cocina_dro, common_path: common_path,
-            content_md_creation_style: content_md_creation_style, reading_order: reading_order,
+        new(filesets: filesets,
+            cocina_dro: cocina_dro,
+            common_path: common_path,
+            content_md_creation_style: content_md_creation_style,
+            reading_order: reading_order,
             all_files_public: all_files_public).build
       end
 

--- a/spec/lib/pre_assembly/from_staging_location/structural_builder_spec.rb
+++ b/spec/lib/pre_assembly/from_staging_location/structural_builder_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe PreAssembly::FromStagingLocation::StructuralBuilder do
 
     let(:common_path) { 'spec/test_data/pdf_document/content/' }
     let(:objects) { [PreAssembly::ObjectFile.new("#{common_path}document.pdf", { file_attributes: { publish: 'yes', shelve: 'no', preserve: 'yes' } })] }
-    let(:filesets) { PreAssembly::FromStagingLocation::FileSetBuilder.build(bundle: :default, objects: objects, style: :document) }
+    let(:filesets) { PreAssembly::FromStagingLocation::FileSetBuilder.build(content_metadata_creation: :default, objects: objects, style: :document) }
     let(:cocina_dro) do
       Cocina::RSpec::Factories.build(:dro, collection_ids: ['druid:bb000kk0000']).new(access: dro_access)
     end

--- a/spec/services/object_file_finder_spec.rb
+++ b/spec/services/object_file_finder_spec.rb
@@ -56,30 +56,30 @@ RSpec.describe ObjectFileFinder do
     it 'returns an ObjectFile with expected path values' do
       tests = [
         # Stageable is a file:
-        # - immediately in bundle dir.
-        { stageable: 'BUNDLE/x.tif',
-          file_path: 'BUNDLE/x.tif',
+        # - immediately in staging dir.
+        { stageable: 'staging_dir/x.tif',
+          file_path: 'staging_dir/x.tif',
           exp_rel_path: 'x.tif' },
-        # - within subdir of bundle dir.
-        { stageable: 'BUNDLE/a/b/x.tif',
-          file_path: 'BUNDLE/a/b/x.tif',
+        # - within subdir of staging dir.
+        { stageable: 'staging_dir/a/b/x.tif',
+          file_path: 'staging_dir/a/b/x.tif',
           exp_rel_path: 'x.tif' },
         # Stageable is a directory:
-        # - immediately in bundle dir
-        { stageable: 'BUNDLE/a',
-          file_path: 'BUNDLE/a/x.tif',
+        # - immediately in staging dir
+        { stageable: 'staging_dir/a',
+          file_path: 'staging_dir/a/x.tif',
           exp_rel_path: 'a/x.tif' },
-        # - immediately in bundle dir, with file deeper
-        { stageable: 'BUNDLE/a',
-          file_path: 'BUNDLE/a/b/x.tif',
+        # - immediately in staging dir, with file deeper
+        { stageable: 'staging_dir/a',
+          file_path: 'staging_dir/a/b/x.tif',
           exp_rel_path: 'a/b/x.tif' },
-        # - within a subdir of bundle dir
-        { stageable: 'BUNDLE/a/b',
-          file_path: 'BUNDLE/a/b/x.tif',
+        # - within a subdir of staging dir
+        { stageable: 'staging_dir/a/b',
+          file_path: 'staging_dir/a/b/x.tif',
           exp_rel_path: 'b/x.tif' },
-        # - within a subdir of bundle dir, with file deeper
-        { stageable: 'BUNDLE/a/b',
-          file_path: 'BUNDLE/a/b/c/d/x.tif',
+        # - within a subdir of staging dir, with file deeper
+        { stageable: 'staging_dir/a/b',
+          file_path: 'staging_dir/a/b/c/d/x.tif',
           exp_rel_path: 'b/c/d/x.tif' }
       ]
       tests.each do |t|

--- a/spec/test_data/exemplar_templates/TEMPLATE.yaml
+++ b/spec/test_data/exemplar_templates/TEMPLATE.yaml
@@ -57,8 +57,8 @@ project_style:
 # Paths to the pre-assembly input and output.
 ####
 
-staging_location:  '/foo/bar/revs'  # Input location for the project content (i.e., the
-                             # "bundle" or "batch"). May contain images directly or may contain
+staging_location:  '/foo/bar/revs'  # Input location for the project content
+                             # May contain images directly or may contain
                              # folders, one per object, usually named by druid.
                              # A fully qualified path.
 


### PR DESCRIPTION
## Why was this change made? 🤔

"bundle" was a confusing name in this repo due to the use of the "bundler" gem.  This PR renames variables and such to be more meaningful.

There are a few other bonus improvements, like getting rid of unused keyword params.

## How was this change tested? 🤨

unit tests

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


