### PR TITLE
[refactor] Load manifest into a tree structure

### DIFF
--- a/app/lib/pre_assembly/from_file_manifest/structural_builder.rb
+++ b/app/lib/pre_assembly/from_file_manifest/structural_builder.rb
@@ -32,8 +32,8 @@ module PreAssembly
       end
 
       def build_file_sets
-        resources.keys.sort.map do |seq|
-          FromFileManifest::FileSetBuilder.build(resource: resources[seq],
+        resources[:file_sets].keys.sort.map do |seq|
+          FromFileManifest::FileSetBuilder.build(resource: resources[:file_sets][seq],
                                                  external_identifier: "#{object}_#{seq}",
                                                  cocina_dro: cocina_dro,
                                                  object: object,

--- a/app/services/object_file_validator.rb
+++ b/app/services/object_file_validator.rb
@@ -28,10 +28,10 @@ class ObjectFileValidator
     if using_file_manifest? # if we are using a file manifest, let's add how many files were found
       batch_id = File.basename(object.container)
       if batch_id && file_manifest.manifest[batch_id]
-        cm_files = file_manifest.manifest[batch_id].fetch(:files, [])
-        counts[:files_in_manifest] = cm_files.count
+        manifest_files = file_manifest.manifest[batch_id].fetch(:file_sets, []).flat_map { |_seq, val| val[:files] }
+        counts[:files_in_manifest] = manifest_files.count
         relative_paths = object.object_files.map(&:relative_path)
-        counts[:files_found] = (cm_files.pluck(:filename) & relative_paths).count
+        counts[:files_found] = (manifest_files.pluck(:filename) & relative_paths).count
         errors[:empty_manifest] = true unless counts[:files_in_manifest] > 0
         errors[:files_found_mismatch] = true unless counts[:files_in_manifest] == counts[:files_found]
       else

--- a/spec/lib/pre_assembly/from_file_manifest/structural_builder_spec.rb
+++ b/spec/lib/pre_assembly/from_file_manifest/structural_builder_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe PreAssembly::FromFileManifest::StructuralBuilder do
       let(:staging_location) { Rails.root.join 'spec/test_data/media_video_test' }
 
       let(:resources) do
+        { file_sets:
         { 1 =>
           { label: 'Video file 1',
             sequence: '1',
@@ -130,7 +131,7 @@ RSpec.describe PreAssembly::FromFileManifest::StructuralBuilder do
                         publish: 'no',
                         shelve: 'no',
                         preserve: 'yes',
-                        resource_type: 'file' }] } }
+                        resource_type: 'file' }] } } }
       end
 
       it 'adds all the files' do
@@ -161,6 +162,7 @@ RSpec.describe PreAssembly::FromFileManifest::StructuralBuilder do
       let(:staging_location) { Rails.root.join 'spec/test_data/book-file-manifest' }
 
       let(:resources) do
+        { file_sets:
         { 1 =>
             { label: 'page 1',
               sequence: '1',
@@ -262,7 +264,7 @@ RSpec.describe PreAssembly::FromFileManifest::StructuralBuilder do
                         publish: 'yes',
                         shelve: 'yes',
                         preserve: 'yes',
-                        resource_type: 'page' }] } }
+                        resource_type: 'page' }] } } }
       end
 
       it 'adds all the files' do


### PR DESCRIPTION

## Why was this change made? 🤔
This keeps us from having to do two passes over the data and eliminates a complex method.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


