### PR TITLE
log the full exception with name and message when job fails

### DIFF
--- a/app/jobs/discovery_report_job.rb
+++ b/app/jobs/discovery_report_job.rb
@@ -19,7 +19,7 @@ class DiscoveryReportJob < ApplicationJob
       job_run.completed
     end
   rescue StandardError => e # catch any error preventing the whole job from running (e.g. bad header in csv)
-    job_run.error_message = e.message
+    job_run.error_message = e.exception
     job_run.failed
   end
   # rubocop:enable Metrics/AbcSize

--- a/app/jobs/preassembly_job.rb
+++ b/app/jobs/preassembly_job.rb
@@ -16,7 +16,7 @@ class PreassemblyJob < ApplicationJob
       job_run.completed
     end
   rescue StandardError => e # catch any error preventing the whole job from running (e.g. bad header in csv)
-    job_run.error_message = e.message
+    job_run.error_message = e.exception
     job_run.failed
   end
 end

--- a/spec/jobs/discovery_report_job_spec.rb
+++ b/spec/jobs/discovery_report_job_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe DiscoveryReportJob, type: :job do
     end
 
     context 'when failed' do
-      let(:error_message) { 'something really unexpected happened' }
+      let(:error_message) { 'StandardError : something really unexpected happened' }
       # simulate an uncaught exception while running the job
 
       before { allow(job_run.to_discovery_report).to receive(:to_builder).and_raise(StandardError, error_message) }

--- a/spec/jobs/preassembly_job_spec.rb
+++ b/spec/jobs/preassembly_job_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe PreassemblyJob, type: :job do
     end
 
     context 'when failed' do
-      let(:error_message) { 'something really unexpected happened' }
+      let(:error_message) { 'StandardError : something really unexpected happened' }
       # simulate an uncaught exception while running the job
 
       before { allow(batch).to receive(:pre_assemble_objects).and_raise(StandardError, error_message) }


### PR DESCRIPTION
## Why was this change made? 🤔

When a job fails, let's log the full exception with name and message in the database for display to the user.

## How was this change tested? 🤨

Updated tests.