### PR TITLE
[refactor] Move manifest building out of the structural builder

### DIFF
--- a/app/lib/pre_assembly/from_file_manifest/structural_builder.rb
+++ b/app/lib/pre_assembly/from_file_manifest/structural_builder.rb
@@ -4,24 +4,19 @@ module PreAssembly
   module FromFileManifest
     # Updates the Cocina::DROStructural metadata with the new structure derived from a file manifest
     class StructuralBuilder
-      # rubocop:disable Metrics/ParameterLists
       # @param [String] reading_order
-      def self.build(cocina_dro:, resources:, object:, staging_location:, content_md_creation_style:, reading_order: 'left-to-right')
-        new(cocina_dro: cocina_dro, resources: resources, object: object, staging_location: staging_location,
+      def self.build(cocina_dro:, resources:, content_md_creation_style:, reading_order: 'left-to-right')
+        new(cocina_dro: cocina_dro, resources: resources,
             content_md_creation_style: content_md_creation_style, reading_order: reading_order).build
       end
 
-      def initialize(cocina_dro:, resources:, object:, staging_location:, content_md_creation_style:, reading_order:)
+      def initialize(cocina_dro:, resources:, content_md_creation_style:, reading_order:)
         @cocina_dro = cocina_dro
         @resources = resources
-        @object = object
-        @staging_location = staging_location
         @content_md_creation_style = content_md_creation_style
         @reading_order = reading_order
       end
-      # rubocop:enable Metrics/ParameterLists
-
-      attr_reader :content_md_creation_style, :resources, :cocina_dro, :object, :staging_location, :common_path, :reading_order
+      attr_reader :content_md_creation_style, :resources, :cocina_dro, :reading_order
 
       # generate the base of the Cocina Structural metadata for this new druid
       def build
@@ -33,11 +28,10 @@ module PreAssembly
 
       def build_file_sets
         resources[:file_sets].keys.sort.map do |seq|
+          external_identifier = "#{cocina_dro.externalIdentifier.delete_prefix('druid:')}_#{seq}"
           FromFileManifest::FileSetBuilder.build(resource: resources[:file_sets][seq],
-                                                 external_identifier: "#{object}_#{seq}",
-                                                 cocina_dro: cocina_dro,
-                                                 object: object,
-                                                 staging_location: staging_location)
+                                                 external_identifier: external_identifier,
+                                                 cocina_dro: cocina_dro)
         end
       end
     end

--- a/spec/features/preassembly_run/book_using_file_manifest_spec.rb
+++ b/spec/features/preassembly_run/book_using_file_manifest_spec.rb
@@ -63,8 +63,6 @@ RSpec.describe 'Pre-assemble Book Using File Manifest', type: :feature do
     expect(PreAssembly::FromFileManifest::StructuralBuilder).to have_received(:build)
       .with(cocina_dro: item,
             resources: Hash,
-            object: 'content',
-            staging_location: staging_location.to_s,
             reading_order: 'right-to-left',
             content_md_creation_style: :simple_book)
     expect(dsc_object).to have_received(:update).with(params: item)

--- a/spec/features/preassembly_run/media_audio_spec.rb
+++ b/spec/features/preassembly_run/media_audio_spec.rb
@@ -66,8 +66,6 @@ RSpec.describe 'Pre-assemble Media Audio object', type: :feature do
     expect(PreAssembly::FromFileManifest::StructuralBuilder).to have_received(:build)
       .with(cocina_dro: item,
             resources: Hash,
-            object: bare_druid,
-            staging_location: staging_location.to_s,
             reading_order: 'left-to-right',
             content_md_creation_style: :media)
     expect(dsc_object).to have_received(:update).with(params: item)

--- a/spec/features/preassembly_run/media_video_spec.rb
+++ b/spec/features/preassembly_run/media_video_spec.rb
@@ -66,8 +66,6 @@ RSpec.describe 'Pre-assemble Media Video object', type: :feature do
     expect(PreAssembly::FromFileManifest::StructuralBuilder).to have_received(:build)
       .with(cocina_dro: item,
             resources: Hash,
-            object: bare_druid,
-            staging_location: staging_location.to_s,
             reading_order: 'left-to-right',
             content_md_creation_style: :media)
     expect(dsc_object).to have_received(:update).with(params: item)

--- a/spec/lib/pre_assembly/file_manifest_spec.rb
+++ b/spec/lib/pre_assembly/file_manifest_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe PreAssembly::FileManifest do
           { contains: [
               {
                 type: 'https://cocina.sul.stanford.edu/models/resources/media',
-                externalIdentifier: 'aa111aa1111_1',
+                externalIdentifier: 'bc234fg5678_1',
                 label: 'Tape 1, Side A', version: 1,
                 structural: {
                   contains: [
@@ -52,7 +52,7 @@ RSpec.describe PreAssembly::FileManifest do
                 }
               }, {
                 type: 'https://cocina.sul.stanford.edu/models/resources/file',
-                externalIdentifier: 'aa111aa1111_2',
+                externalIdentifier: 'bc234fg5678_2',
                 label: 'Tape 1, Side B', version: 1,
                 structural: {
                   contains: [
@@ -80,7 +80,7 @@ RSpec.describe PreAssembly::FileManifest do
                 }
               }, {
                 type: 'https://cocina.sul.stanford.edu/models/resources/file',
-                externalIdentifier: 'aa111aa1111_3',
+                externalIdentifier: 'bc234fg5678_3',
                 label: 'Transcript', version: 1,
                 structural: {
                   contains: [
@@ -134,7 +134,7 @@ RSpec.describe PreAssembly::FileManifest do
           { contains: [
               {
                 type: 'https://cocina.sul.stanford.edu/models/resources/media',
-                externalIdentifier: 'aa111aa1111_1',
+                externalIdentifier: 'bc234fg5678_1',
                 label: 'Tape 1, Side A', version: 1,
                 structural: {
                   contains: [
@@ -165,7 +165,7 @@ RSpec.describe PreAssembly::FileManifest do
                 }
               }, {
                 type: 'https://cocina.sul.stanford.edu/models/resources/file',
-                externalIdentifier: 'aa111aa1111_2',
+                externalIdentifier: 'bc234fg5678_2',
                 label: 'Tape 1, Side B', version: 1,
                 structural: {
                   contains: [
@@ -196,7 +196,7 @@ RSpec.describe PreAssembly::FileManifest do
                 }
               }, {
                 type: 'https://cocina.sul.stanford.edu/models/resources/file',
-                externalIdentifier: 'aa111aa1111_3',
+                externalIdentifier: 'bc234fg5678_3',
                 label: 'Transcript', version: 1,
                 structural: {
                   contains: [

--- a/spec/lib/pre_assembly/from_file_manifest/structural_builder_spec.rb
+++ b/spec/lib/pre_assembly/from_file_manifest/structural_builder_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe PreAssembly::FromFileManifest::StructuralBuilder do
     subject(:structural) do
       described_class.build(cocina_dro: cocina_dro,
                             resources: resources,
-                            object: content_dir,
-                            staging_location: staging_location,
                             reading_order: 'left-to-right',
                             content_md_creation_style: :media)
     end
@@ -18,7 +16,6 @@ RSpec.describe PreAssembly::FromFileManifest::StructuralBuilder do
 
     context 'with media style' do
       let(:content_dir) { 'vd000bj0000' }
-      let(:staging_location) { Rails.root.join 'spec/test_data/media_video_test' }
 
       let(:resources) do
         { file_sets:
@@ -34,7 +31,8 @@ RSpec.describe PreAssembly::FromFileManifest::StructuralBuilder do
                       publish: 'yes',
                       shelve: 'yes',
                       preserve: 'yes',
-                      resource_type: 'video' },
+                      resource_type: 'video',
+                      md5_digest: 'ee4e90be549c5614ac6282a5b80a506b' },
                     { filename: 'vd000bj0000_video_1.mpeg',
                       label: 'Video file 1',
                       sequence: '1',
@@ -150,7 +148,6 @@ RSpec.describe PreAssembly::FromFileManifest::StructuralBuilder do
 
     context 'with simple_book style' do
       let(:content_dir) { 'content' }
-      let(:staging_location) { Rails.root.join 'spec/test_data/book-file-manifest' }
 
       let(:resources) do
         { file_sets:


### PR DESCRIPTION


## Why was this change made? 🤔

Move it up to the FileManifest.  This will allow us to use the cocina model as the intermediate representation rather than have a hash based representation.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


