### PR TITLE
Don't enqueue a job until the transaction is committed

### DIFF
--- a/app/models/job_run.rb
+++ b/app/models/job_run.rb
@@ -8,7 +8,7 @@ class JobRun < ApplicationRecord
   validates :job_type, presence: true
   validates :state, presence: true
   after_initialize :default_enums
-  after_create :enqueue!
+  after_create_commit :enqueue!
 
   delegate :progress_log_file, to: :batch_context
 


### PR DESCRIPTION


## Why was this change made? 🤔

Otherwise the worker can start, but it can't load the JobRun record
Fixes #1064 

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


