### PR TITLE
update-prepare-content script to deal with BOM encoding issues

### DIFF
--- a/bin/prepare_content
+++ b/bin/prepare_content
@@ -74,10 +74,10 @@ unless File.exist?(csv_out) # if we don't already have a log file, write out the
 end
 
 # read in existing log file
-log_file_data = CSV.parse(IO.read(csv_out), headers: true).map { |row| row.to_hash.with_indifferent_access }
+log_file_data = CSV.open(csv_out, 'rb:bom|utf-8', headers: true).map { |row| row.to_hash.with_indifferent_access }
 
 # read input manifest
-csv_data = CSV.parse(IO.read(csv_in), headers: true).map { |row| row.to_hash.with_indifferent_access }
+csv_data = CSV.open(csv_in, 'rb:bom|utf-8', headers: true).map { |row| row.to_hash.with_indifferent_access }
 
 start_time = Time.now
 puts ''


### PR DESCRIPTION
## Why was this change made? 🤔

Allow prepare-content script to deal with BOM encoding.  Similar fix to what was done here: https://github.com/sul-dlss/argo/commit/95bff1dc7980ba563fd568ed5ad2496308017571

Based on an error report from Meagan Trott, which upon investigation turned out to be a CSV file with this encoding pattern.


## How was this change tested? 🤨

Ran on localhost with the "bad" CSV and it worked.