### PR TITLE
hide staging symlink option in pre-assembly; defaults to false

### DIFF
--- a/app/views/batch_contexts/_new_bc_form.erb
+++ b/app/views/batch_contexts/_new_bc_form.erb
@@ -28,7 +28,8 @@
 
 
     <%= form.input :staging_location %>
-    <%= form.input :staging_style_symlink %>
+    <%# the 'staging_style_symlink` is hidden, since we do not currently want users to access it (it may cause problems with some accessioning steps)%>
+    <%= form.hidden_field :staging_style_symlink, value: false %>
     <%= form.input :content_metadata_creation, collection:
         [
             ["Default", "default"],


### PR DESCRIPTION
## Why was this change made? 🤔

After talking to @andrewjbtw , the staging symlink option may be unnecessary/undesirable.  Before removing entirely until we are really sure, we can simply hide it and set to false as default.

## How was this change tested? 🤨

Localhost