### PR TITLE
use pry, not pry-rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'nokogiri'
 gem 'okcomputer'
 gem 'pg' # postgres database
 gem 'propshaft' # The modern asset pipeline for Rails [https://github.com/rails/propshaft]
-gem 'pry-rails' # useful for rails console
+gem 'pry' # make it possible to use pry for IRB
 gem 'rails', '~> 7.0'
 gem 'rake'
 gem 'sidekiq', '~> 6.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -311,8 +311,6 @@ GEM
     pry-byebug (3.10.1)
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
-    pry-rails (0.3.9)
-      pry (>= 0.10.4)
     public_suffix (5.0.0)
     puma (5.6.5)
       nio4r (~> 2.0)
@@ -479,8 +477,8 @@ DEPENDENCIES
   okcomputer
   pg
   propshaft
+  pry
   pry-byebug
-  pry-rails
   puma (~> 5.6)
   rails (~> 7.0)
   rails-controller-testing


### PR DESCRIPTION
## Why was this change made? 🤔

`pry-rails` is no longer maintained;  some of us still prefer `pry`, tho.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


