### PR TITLE
Rename content_metadata_creation to processing_configuration

### DIFF
--- a/app/controllers/batch_contexts_controller.rb
+++ b/app/controllers/batch_contexts_controller.rb
@@ -30,7 +30,7 @@ class BatchContextsController < ApplicationController
   def batch_contexts_params
     params.require(:batch_context)
           .permit(:project_name, :content_structure, :staging_style_symlink,
-                  :content_metadata_creation, :staging_location, :all_files_public,
+                  :processing_configuration, :staging_location, :all_files_public,
                   :using_file_manifest, job_runs_attributes: [:job_type])
           .merge(user: current_user)
   end

--- a/app/lib/pre_assembly/batch.rb
+++ b/app/lib/pre_assembly/batch.rb
@@ -15,7 +15,7 @@ module PreAssembly
                   :objects_had_errors
 
     delegate :staging_location,
-             :content_md_creation,
+             :processing_configuration,
              :content_structure,
              :object_manifest_rows,
              :staging_location_with_path,

--- a/app/lib/pre_assembly/digital_object.rb
+++ b/app/lib/pre_assembly/digital_object.rb
@@ -9,7 +9,7 @@ module PreAssembly
                 :stager, :label, :druid, :source_id, :container
 
     delegate :staging_location,
-             :content_md_creation,
+             :processing_configuration,
              :content_structure,
              :project_name,
              :file_manifest,
@@ -142,14 +142,14 @@ module PreAssembly
                                          reading_order:)
       else
         build_from_staging_location(objects: object_files.sort,
-                                    content_metadata_creation: content_md_creation.to_sym,
+                                    processing_configuration:,
                                     content_md_creation_style:,
                                     reading_order:)
       end
     end
 
-    def build_from_staging_location(objects:, content_metadata_creation:, content_md_creation_style:, reading_order:)
-      filesets = FromStagingLocation::FileSetBuilder.build(content_metadata_creation:, objects:, style: content_md_creation_style)
+    def build_from_staging_location(objects:, processing_configuration:, content_md_creation_style:, reading_order:)
+      filesets = FromStagingLocation::FileSetBuilder.build(processing_configuration:, objects:, style: content_md_creation_style)
       FromStagingLocation::StructuralBuilder.build(cocina_dro: cocina_object,
                                                    filesets:,
                                                    all_files_public: batch.batch_context.all_files_public?,

--- a/app/lib/pre_assembly/from_staging_location/file_set_builder.rb
+++ b/app/lib/pre_assembly/from_staging_location/file_set_builder.rb
@@ -4,35 +4,34 @@ module PreAssembly
   module FromStagingLocation
     # Creates a data structure of FileSets from a staging location
     class FileSetBuilder
-      # @param [Symbol] content_metadata_creation one of: :default or :filename
-      #   this variable would be better named manifest_type, but we are using the name content_metadata_creation in the UI
+      # @param [Symbol] processing_configuration one of: :default or :filename
       # @param [Array<Assembly::ObjectFile>] objects
       # @param [Symbol] style one of: :simple_image, :file, :simple_book, :book_as_image, :book_with_pdf, :map, or :'3d'
-      def self.build(content_metadata_creation:, objects:, style:)
-        new(content_metadata_creation:, objects:, style:).build
+      def self.build(processing_configuration:, objects:, style:)
+        new(processing_configuration:, objects:, style:).build
       end
 
-      def initialize(content_metadata_creation:, objects:, style:)
-        @content_metadata_creation = content_metadata_creation
+      def initialize(processing_configuration:, objects:, style:)
+        @processing_configuration = processing_configuration.to_sym
         @objects = objects
         @style = style
       end
 
       # @return [Array<FileSet>] a list of filesets in the object
       def build
-        case content_metadata_creation
+        case processing_configuration
         when :default # one resource per object
           objects.collect { |obj| FileSet.new(resource_files: [obj], style:) }
         when :filename # one resource per distinct filename (excluding extension)
           build_for_filename
         else
-          raise 'Invalid content_metadata_creation: must be :default or :filename'
+          raise 'Invalid processing_configuration: must be :default or :filename'
         end
       end
 
       private
 
-      attr_reader :content_metadata_creation, :objects, :style
+      attr_reader :processing_configuration, :objects, :style
 
       def build_for_filename
         # loop over distinct filenames, this determines how many resources we will have and

--- a/app/models/batch_context.rb
+++ b/app/models/batch_context.rb
@@ -19,7 +19,7 @@ class BatchContext < ApplicationRecord
   before_save :output_dir_exists!, if: proc { persisted? }
   before_create :output_dir_no_exists!
 
-  validates :staging_location, :content_metadata_creation, :content_structure, presence: true
+  validates :staging_location, :processing_configuration, :content_structure, presence: true
   validates :project_name, presence: true, format: { with: /\A[\w-]+\z/,
                                                      message: 'only allows A-Z, a-z, 0-9, hyphen and underscore' }
   validates :staging_style_symlink, :using_file_manifest, inclusion: { in: [true, false] }
@@ -40,8 +40,7 @@ class BatchContext < ApplicationRecord
     'simple_book_rtl' => 9
   }
 
-  # this would be better named manifest_type, but we are using the name content_metadata_creation in the UI
-  enum content_metadata_creation: {
+  enum processing_configuration: {
     'default' => 0,
     'filename' => 1,
     'media_cm_style' => 2 # Deprecated
@@ -61,11 +60,6 @@ class BatchContext < ApplicationRecord
   def file_manifest
     PreAssembly::FileManifest.new(csv_filename: file_manifest_path,
                                   staging_location:)
-  end
-
-  # this method would be better named manifest_type, but we are using the name content_metadata_creation in the UI
-  def content_md_creation
-    content_metadata_creation
   end
 
   def project_style
@@ -115,7 +109,7 @@ class BatchContext < ApplicationRecord
 
   def default_enums
     self[:content_structure] ||= 0
-    self[:content_metadata_creation] ||= 0
+    self[:processing_configuration] ||= 0
   end
 
   def normalize_dir(dir)

--- a/app/services/discovery_report.rb
+++ b/app/services/discovery_report.rb
@@ -8,7 +8,7 @@ class DiscoveryReport
   attr_reader :batch, :summary
   attr_accessor :error_message, :objects_had_errors
 
-  delegate :staging_location, :content_md_creation, :project_style, :file_manifest, to: :batch
+  delegate :staging_location, :project_style, :file_manifest, to: :batch
 
   # @param [PreAssembly::Batch] batch
   def initialize(batch)

--- a/app/views/batch_contexts/_batch_context.html.erb
+++ b/app/views/batch_contexts/_batch_context.html.erb
@@ -34,8 +34,8 @@
       <i class="fa-regular fa-circle-xmark"></i>
     <% end %>
   </dd>
-  <dt class="col-sm-3">Content Metadata Creation</dt>
-  <dd class="col-sm-9"><%= batch_context.content_metadata_creation %></dd>
+  <dt class="col-sm-3">Processing configuration</dt>
+  <dd class="col-sm-9"><%= batch_context.processing_configuration %></dd>
   <dt class="col-sm-3">Using File Manifest?</dt>
   <dd class="col-sm-9">
     <% if batch_context.using_file_manifest %>

--- a/app/views/batch_contexts/_new_bc_form.erb
+++ b/app/views/batch_contexts/_new_bc_form.erb
@@ -30,10 +30,10 @@
     <%= form.input :staging_location %>
     <%# the 'staging_style_symlink` is hidden, since we do not currently want users to access it (it may cause problems with some accessioning steps)%>
     <%= form.hidden_field :staging_style_symlink, value: false %>
-    <%= form.input :content_metadata_creation, collection:
+    <%= form.input :processing_configuration, collection:
         [
             ["Default", "default"],
-            ["Filename", "filename"]
+            ["Group by filename", "filename"]
         ]
     %>
 

--- a/db/migrate/20230821221826_rename_content_metadata_creation.rb
+++ b/db/migrate/20230821221826_rename_content_metadata_creation.rb
@@ -1,0 +1,5 @@
+class RenameContentMetadataCreation < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :batch_contexts, :content_metadata_creation, :processing_configuration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_22_173421) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_21_221826) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,7 +19,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_22_173421) do
     t.integer "content_structure", null: false
     t.string "staging_location", null: false
     t.boolean "staging_style_symlink", default: false, null: false
-    t.integer "content_metadata_creation", null: false
+    t.integer "processing_configuration", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false

--- a/spec/controllers/batch_contexts_controller_spec.rb
+++ b/spec/controllers/batch_contexts_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe BatchContextsController do
         {
           project_name: 'Multimedia',
           content_structure: 'simple_image',
-          content_metadata_creation: 'default',
+          processing_configuration: 'default',
           staging_location: 'spec/fixtures/multimedia',
           job_runs_attributes: { '0' => { job_type: 'preassembly' } }
         }
@@ -63,7 +63,7 @@ RSpec.describe BatchContextsController do
           bc = assigns(:batch_context)
           expect(bc.project_name).to eq 'Multimedia'
           expect(bc.content_structure).to eq 'simple_image'
-          expect(bc.content_metadata_creation).to eq 'default'
+          expect(bc.processing_configuration).to eq 'default'
           expect(bc.staging_location).to eq 'spec/fixtures/multimedia'
         end
 
@@ -76,7 +76,7 @@ RSpec.describe BatchContextsController do
       end
 
       context 'Invalid Parameters' do
-        let(:bc_params) { { project_name: '', content_structure: '', content_metadata_creation: '', staging_location: '' } }
+        let(:bc_params) { { project_name: '', content_structure: '', processing_configuration: '', staging_location: '' } }
 
         it 'do not create objects' do
           params[:batch_context][:project_name] = nil

--- a/spec/factories/batch_contexts.rb
+++ b/spec/factories/batch_contexts.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :batch_context do
     staging_location { 'spec/fixtures/multimedia' }
-    content_metadata_creation { 'default' }
+    processing_configuration { 'default' }
     content_structure { 'simple_image' }
     project_name { 'Test_Project' }
     staging_style_symlink { false }
@@ -18,14 +18,14 @@ FactoryBot.define do
 
     trait :flat_dir_images do
       staging_location { 'spec/fixtures/flat_dir_images' }
-      content_metadata_creation { 'default' }
+      processing_configuration { 'default' }
       content_structure { 'simple_image' }
       project_name { 'Flat_Dir_Images' }
     end
 
     trait :folder_manifest do
       staging_location { 'spec/fixtures/obj_dirs_images' }
-      content_metadata_creation { 'default' }
+      processing_configuration { 'default' }
       content_structure { 'simple_image' }
       project_name { 'FolderManifest' }
     end

--- a/spec/features/discovery_report/file_manifest_book_spec.rb
+++ b/spec/features/discovery_report/file_manifest_book_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Discovery Report from file_manifest.csv' do
     fill_in 'Project name', with: project_name
     select 'Discovery Report', from: 'Job type'
     fill_in 'Staging location', with: staging_location
-    select 'Default', from: 'Content metadata creation'
+    select 'Default', from: 'Processing configuration'
     check 'batch_context_using_file_manifest'
 
     click_button 'Submit'

--- a/spec/features/preassembly_run/book_using_file_manifest_spec.rb
+++ b/spec/features/preassembly_run/book_using_file_manifest_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Pre-assemble Book Using File Manifest' do
     select 'Pre Assembly Run', from: 'Job type'
     select 'Book (rtl)', from: 'Content structure'
     fill_in 'Staging location', with: staging_location
-    select 'Default', from: 'Content metadata creation'
+    select 'Default', from: 'Processing configuration'
     check 'batch_context_using_file_manifest'
 
     click_button 'Submit'

--- a/spec/features/preassembly_run/media_audio_spec.rb
+++ b/spec/features/preassembly_run/media_audio_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'Pre-assemble Media Audio object' do
     select 'Pre Assembly Run', from: 'Job type'
     select 'Media', from: 'Content structure'
     fill_in 'Staging location', with: staging_location
-    select 'Default', from: 'Content metadata creation'
+    select 'Default', from: 'Processing configuration'
     check 'batch_context_using_file_manifest'
 
     click_button 'Submit'

--- a/spec/features/preassembly_run/media_video_spec.rb
+++ b/spec/features/preassembly_run/media_video_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'Pre-assemble Media Video object' do
     select 'Pre Assembly Run', from: 'Job type'
     select 'Media', from: 'Content structure'
     fill_in 'Staging location', with: staging_location
-    select 'Default', from: 'Content metadata creation'
+    select 'Default', from: 'Processing configuration'
     check 'batch_context_using_file_manifest'
 
     click_button 'Submit'

--- a/spec/fixtures/exemplar_templates/TEMPLATE.yaml
+++ b/spec/fixtures/exemplar_templates/TEMPLATE.yaml
@@ -76,7 +76,7 @@ staging_style:    'copy'     # the staging style, can be "copy" or "symlink", de
 ####
 
 # The method used to group resources together when generating content metadata.
-content_md_creation:
+processing_configuration:
   style:       'default'                # Used by most projects, creates one resource per file.
                'filename'                 # Collects files together into a single resource based on filename -- files with the same name but different extensions will become
                                           # part of a single resource node.

--- a/spec/fixtures/exemplar_templates/reg_example.yaml
+++ b/spec/fixtures/exemplar_templates/reg_example.yaml
@@ -11,5 +11,5 @@ project_name:      'Gould'
 
 progress_log_file: '/dor/preassembly/gould_log.yaml'
 
-content_md_creation:
+processing_configuration:
   style:       'default'

--- a/spec/fixtures/project_config_files/flat_dir_images.yaml
+++ b/spec/fixtures/project_config_files/flat_dir_images.yaml
@@ -7,5 +7,5 @@ project_style:
 
 staging_location: 'spec/fixtures/flat_dir_images'
 
-content_md_creation:
+processing_configuration:
   style: 'default'

--- a/spec/fixtures/project_config_files/folder_manifest.yaml
+++ b/spec/fixtures/project_config_files/folder_manifest.yaml
@@ -7,5 +7,5 @@ project_style:
 
 staging_location: 'spec/fixtures/obj_dirs_images'
 
-content_md_creation:
+processing_configuration:
   style: 'default'

--- a/spec/fixtures/project_config_files/hierarchical_files.yaml
+++ b/spec/fixtures/project_config_files/hierarchical_files.yaml
@@ -7,5 +7,5 @@ project_style:
 
 staging_location: 'spec/fixtures/hierarchical-files'
 
-content_md_creation:
+processing_configuration:
   style: 'default'

--- a/spec/fixtures/project_config_files/images_jp2_tif.yaml
+++ b/spec/fixtures/project_config_files/images_jp2_tif.yaml
@@ -7,5 +7,5 @@ project_style:
 
 staging_location: 'spec/fixtures/images_jp2_tif'
 
-content_md_creation:
+processing_configuration:
   style: 'default'

--- a/spec/fixtures/project_config_files/media_missing.yaml
+++ b/spec/fixtures/project_config_files/media_missing.yaml
@@ -9,7 +9,7 @@ project_style:
 
 staging_location: 'spec/fixtures/media_missing'
 
-content_md_creation:
+processing_configuration:
   style: 'media'
   file_manifest: 'file_manifest.csv'
 

--- a/spec/fixtures/project_config_files/media_stage_symlink.yaml
+++ b/spec/fixtures/project_config_files/media_stage_symlink.yaml
@@ -7,7 +7,7 @@ staging_location: 'spec/fixtures/multimedia'
 
 staging_style: 'symlink'
 
-content_md_creation:
+processing_configuration:
   style: 'media'
 
 stageable_discovery:

--- a/spec/fixtures/project_config_files/media_staging_style_copy.yaml
+++ b/spec/fixtures/project_config_files/media_staging_style_copy.yaml
@@ -7,7 +7,7 @@ staging_location: 'spec/fixtures/multimedia'
 
 staging_style: 'copy'
 
-content_md_creation:
+processing_configuration:
   style: 'media'
   file_manifest: 'file_manifest.csv'
 

--- a/spec/fixtures/project_config_files/multimedia.yaml
+++ b/spec/fixtures/project_config_files/multimedia.yaml
@@ -9,6 +9,6 @@ project_style:
 
 staging_location: 'spec/fixtures/multimedia'
 
-content_md_creation:
+processing_configuration:
   style: 'media'
   file_manifest: 'file_manifest_with_thumb.csv'

--- a/spec/fixtures/project_config_files/obj_dirs_images.yaml
+++ b/spec/fixtures/project_config_files/obj_dirs_images.yaml
@@ -7,5 +7,5 @@ project_style:
 
 staging_location: 'spec/fixtures/obj_dirs_images'
 
-content_md_creation:
+processing_configuration:
   style: 'none'

--- a/spec/lib/pre_assembly/digital_object_spec.rb
+++ b/spec/lib/pre_assembly/digital_object_spec.rb
@@ -522,7 +522,7 @@ RSpec.describe PreAssembly::DigitalObject do
       end
 
       before do
-        allow(bc).to receive_messages(content_structure: 'simple_book', content_md_creation: 'filename')
+        allow(bc).to receive_messages(content_structure: 'simple_book', processing_configuration: 'filename')
         add_object_files(extension: 'tif')
         add_object_files(extension: 'jp2')
         allow(SecureRandom).to receive(:uuid).and_return('1', '2', '3', '4')

--- a/spec/lib/pre_assembly/file_manifest_spec.rb
+++ b/spec/lib/pre_assembly/file_manifest_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe PreAssembly::FileManifest do
         {
           project_name: 'ProjectBar',
           staging_location:,
-          content_metadata_creation: :default,
+          processing_configuration: :default,
           content_structure: 'media',
           using_file_manifest: true
         }
@@ -118,7 +118,7 @@ RSpec.describe PreAssembly::FileManifest do
         {
           project_name: 'ProjectBaz',
           staging_location:,
-          content_metadata_creation: :default,
+          processing_configuration: :default,
           content_structure: :simple_image,
           using_file_manifest: true
         }

--- a/spec/lib/pre_assembly/from_staging_location/structural_builder_spec.rb
+++ b/spec/lib/pre_assembly/from_staging_location/structural_builder_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe PreAssembly::FromStagingLocation::StructuralBuilder do
                             content_md_creation_style: :document)
     end
 
-    let(:filesets) { PreAssembly::FromStagingLocation::FileSetBuilder.build(content_metadata_creation: :default, objects:, style: :document) }
+    let(:filesets) { PreAssembly::FromStagingLocation::FileSetBuilder.build(processing_configuration: :default, objects:, style: :document) }
     let(:cocina_dro) do
       Cocina::RSpec::Factories.build(:dro, collection_ids: ['druid:bb000kk0000']).new(access: dro_access)
     end

--- a/spec/models/batch_context_spec.rb
+++ b/spec/models/batch_context_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe BatchContext do
 
     it { is_expected.to validate_presence_of(:content_structure) }
     it { is_expected.to validate_presence_of(:staging_location) }
-    it { is_expected.to validate_presence_of(:content_metadata_creation) }
+    it { is_expected.to validate_presence_of(:processing_configuration) }
     it { is_expected.to validate_presence_of(:project_name) }
 
     describe 'project_name' do
@@ -71,7 +71,7 @@ RSpec.describe BatchContext do
   end
 
   it do
-    is_expected.to define_enum_for(:content_metadata_creation).with_values(
+    is_expected.to define_enum_for(:processing_configuration).with_values(
       'default' => 0,
       'filename' => 1,
       'media_cm_style' => 2
@@ -83,7 +83,7 @@ RSpec.describe BatchContext do
   it 'enums default to their default values' do
     bc = described_class.new
     expect(bc.content_structure).to eq 'simple_image'
-    expect(bc.content_metadata_creation).to eq 'default'
+    expect(bc.processing_configuration).to eq 'default'
   end
 
   it 'staging_location has trailing slash removed' do

--- a/spec/services/discovery_report_spec.rb
+++ b/spec/services/discovery_report_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe DiscoveryReport do
         content_structure:,
         staging_location: 'spec/fixtures/images_jp2_tif',
         staging_style_symlink: false,
-        content_metadata_creation: 0,
+        processing_configuration: 0,
         user: build(:user, sunet_id: 'jdoe')
       }
     end

--- a/spec/support/batch_setup.rb
+++ b/spec/support/batch_setup.rb
@@ -12,14 +12,14 @@ end
 
 def batch_context_from_hash(proj)
   hash = hash_from_proj(proj)
-  cmc = hash['content_md_creation']['style']
+  cmc = hash['processing_configuration']['style']
   cmc += '_cm_style' if cmc == 'media'
   build(
     :batch_context,
     project_name: hash['project_name'],
     content_structure: hash['project_style']['content_structure'],
     staging_location: hash['staging_location'],
-    content_metadata_creation: cmc,
+    processing_configuration: cmc,
     using_file_manifest: hash['using_file_manifest'],
     user: build(:user, sunet_id: 'Jdoe')
   )


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #1180 - rename "content_metadata_creation" to "processing_configuration" in the UI and in the code, including renaming of a database column and all related methods and attributes.  Also change the display value of one of the possible values (but not the underlying value stored in the database, so changes needed there).

Given the large number of code changes, need to validate this on stage by:

- [x] run pre-assembly integration test - required changes: https://github.com/sul-dlss/infrastructure-integration-test/pull/614
- [x] have Andrew check it out

# How was this change tested? 🤨

Updated specs, integration tests