### PR TITLE
selecting media content structure requires a file manifest

### DIFF
--- a/app/models/batch_context.rb
+++ b/app/models/batch_context.rb
@@ -24,6 +24,8 @@ class BatchContext < ApplicationRecord
                                                      message: 'only allows A-Z, a-z, 0-9, hyphen and underscore' }
   validates :staging_style_symlink, :using_file_manifest, inclusion: { in: [true, false] }
 
+  validate :verify_file_manifest_selected_for_media
+
   validate :verify_staging_location
   validate :verify_staging_location_path
 
@@ -139,6 +141,12 @@ class BatchContext < ApplicationRecord
       throw(:abort)
     end
     FileUtils.mkdir_p(output_dir)
+  end
+
+  def verify_file_manifest_selected_for_media
+    return unless content_structure == 'media' && !using_file_manifest
+
+    errors.add(:content_structure, 'requires a file manifest.  Please select the checkbox and ensure a file manifest is present.')
   end
 
   # rubocop:disable Metrics/AbcSize

--- a/spec/controllers/batch_contexts_controller_spec.rb
+++ b/spec/controllers/batch_contexts_controller_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe BatchContextsController do
       end
 
       context 'Invalid Parameters' do
-        let(:bc_params) { { project_name: '', content_structure: '', processing_configuration: '', staging_location: '' } }
+        let(:bc_params) { { project_name: '', content_structure: 'media', processing_configuration: '', staging_location: '' } }
 
         it 'do not create objects' do
           params[:batch_context][:project_name] = nil

--- a/spec/controllers/batch_contexts_controller_spec.rb
+++ b/spec/controllers/batch_contexts_controller_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe BatchContextsController do
       end
 
       context 'Invalid Parameters' do
-        let(:bc_params) { { project_name: '', content_structure: 'media', processing_configuration: '', staging_location: '' } }
+        let(:bc_params) { { project_name: '', content_structure: '', processing_configuration: '', staging_location: '' } }
 
         it 'do not create objects' do
           params[:batch_context][:project_name] = nil

--- a/spec/models/batch_context_spec.rb
+++ b/spec/models/batch_context_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe BatchContext do
       expect { bc.user = nil }.to change(bc, :valid?).to(false)
     end
 
+    it 'is not valid if user does not select a file manifest' do
+      expect { bc.using_file_manifest = nil }.to change(bc, :valid?).to(false)
+    end
+
     it 'is not valid unless staging_location exists on filesystem' do
       expect { bc.staging_location = 'does/not/exist' }.to change(bc, :valid?).to(false)
     end

--- a/spec/models/batch_context_spec.rb
+++ b/spec/models/batch_context_spec.rb
@@ -20,10 +20,6 @@ RSpec.describe BatchContext do
       expect { bc.user = nil }.to change(bc, :valid?).to(false)
     end
 
-    it 'is not valid if user does not select a file manifest' do
-      expect { bc.using_file_manifest = nil }.to change(bc, :valid?).to(false)
-    end
-
     it 'is not valid unless staging_location exists on filesystem' do
       expect { bc.staging_location = 'does/not/exist' }.to change(bc, :valid?).to(false)
     end
@@ -32,6 +28,40 @@ RSpec.describe BatchContext do
     it { is_expected.to validate_presence_of(:staging_location) }
     it { is_expected.to validate_presence_of(:processing_configuration) }
     it { is_expected.to validate_presence_of(:project_name) }
+
+    context 'file_manifest required for media' do
+      context 'when using_file_manifest is not selected' do
+        let(:attr_hash) do
+          {
+            project_name: 'File_manifest_media',
+            staging_location: 'spec/fixtures/media_audio_test',
+            content_structure: 'media',
+            using_file_manifest: false
+          }
+        end
+
+        it 'is not valid' do
+          expect(bc.valid?).to be false
+          expect(bc.errors.size).to eq 1
+          expect(bc.errors.first.attribute).to eq :content_structure
+        end
+      end
+
+      context 'when using_file_manifest is selected' do
+        let(:attr_hash) do
+          {
+            project_name: 'File_manifest_media',
+            staging_location: 'spec/fixtures/media_audio_test',
+            content_structure: 'media',
+            using_file_manifest: true
+          }
+        end
+
+        it 'is valid' do
+          expect(bc.valid?).to be true
+        end
+      end
+    end
 
     describe 'project_name' do
       it 'is not valid with chars other than alphanum, hyphen and underscore' do


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #1158 - if user selects media content type, they must include a file manifest

Validate on form submission, so it is not possible to proceed unless the user selects the checkbox (which will then also validate the file exists).  This is a simple server side only approach that does not require any javascript libraries or complications to auto-check the box if the user selects media.

<img width="778" alt="Screen Shot 2023-08-24 at 5 05 17 PM" src="https://github.com/sul-dlss/pre-assembly/assets/47137/88b32be4-ff74-4472-a6b0-37101d73ad65">


# How was this change tested? 🤨

Localhost and new unit test
