### PR TITLE
Adds support for targeted file updates.

### DIFF
--- a/app/lib/pre_assembly/file_manifest.rb
+++ b/app/lib/pre_assembly/file_manifest.rb
@@ -48,7 +48,8 @@ module PreAssembly
       current_directory = Dir.pwd # this must be done before resources_hash is built
       structure = FromFileManifest::StructuralBuilder.build(cocina_dro:,
                                                             resources: item_structure,
-                                                            reading_order:)
+                                                            reading_order:,
+                                                            staging_location:)
 
       FileUtils.cd(current_directory)
       structure

--- a/app/lib/pre_assembly/from_file_manifest/file_set_builder.rb
+++ b/app/lib/pre_assembly/from_file_manifest/file_set_builder.rb
@@ -5,21 +5,23 @@ module PreAssembly
     # Creates a hash representing the Cocina::FileSets from a file manifest
     class FileSetBuilder
       # @param [Cocina::Models::DRO] cocina_dro
-      def self.build(resource:, cocina_dro:, external_identifier:)
+      def self.build(resource:, cocina_dro:, external_identifier:, staging_location:)
         new(
           resource:,
           cocina_dro:,
-          external_identifier:
+          external_identifier:,
+          staging_location:
         ).build
       end
 
-      def initialize(resource:, cocina_dro:, external_identifier:)
+      def initialize(resource:, cocina_dro:, external_identifier:, staging_location:)
         @resource = resource
         @cocina_dro = cocina_dro
         @external_identifier = external_identifier
+        @staging_location = staging_location
       end
 
-      attr_reader :resource, :cocina_dro, :external_identifier
+      attr_reader :resource, :cocina_dro, :external_identifier, :staging_location
 
       def build
         {
@@ -49,9 +51,24 @@ module PreAssembly
       end
 
       def file_builder(file_attributes:)
-        Cocina::Models::File.new(
-          file_attributes.merge(version: cocina_dro.version, access: file_access(file_attributes))
-        )
+        attrs = file_attributes
+                .merge(version: cocina_dro.version, access: file_access(file_attributes))
+                .merge(existing_cocina_file_attributes(filename: file_attributes[:filename], mimetype_present: file_attributes[:hasMimeType].present?))
+        Cocina::Models::File.new(attrs)
+      end
+
+      def existing_cocina_file_attributes(filename:, mimetype_present:)
+        return {} if file_exists?(filename)
+        return {} unless (existing_cocina_file = existing_cocina_files[filename])
+
+        fields = :externalIdentifier, :hasMessageDigests, :size, :presentation
+        fields << :hasMimeType unless mimetype_present
+
+        existing_cocina_file.to_h.slice(*fields)
+      end
+
+      def file_exists?(filename)
+        File.exist?(File.join(staging_location, cocina_dro.externalIdentifier.delete_prefix('druid:'), filename))
       end
 
       def file_access(file_attributes)
@@ -60,6 +77,12 @@ module PreAssembly
         file_access = cocina_dro.access.to_h.slice(:view, :download, :location, :controlledDigitalLending)
         file_access[:view] = 'dark' if file_access[:view] == 'citation-only'
         file_access
+      end
+
+      def existing_cocina_files
+        @existing_cocina_files = cocina_dro.structural.contains.flat_map do |file_set|
+          file_set.structural.contains.map { |file| [file.filename, file] }
+        end.to_h
       end
     end
   end

--- a/app/lib/pre_assembly/from_file_manifest/structural_builder.rb
+++ b/app/lib/pre_assembly/from_file_manifest/structural_builder.rb
@@ -5,16 +5,18 @@ module PreAssembly
     # Updates the Cocina::DROStructural metadata with the new structure derived from a file manifest
     class StructuralBuilder
       # @param [String,nil] reading_order
-      def self.build(cocina_dro:, resources:, reading_order: nil)
-        new(cocina_dro:, resources:, reading_order:).build
+      def self.build(cocina_dro:, resources:, staging_location:, reading_order: nil)
+        new(cocina_dro:, resources:, staging_location:, reading_order:).build
       end
 
-      def initialize(cocina_dro:, resources:, reading_order: nil)
+      def initialize(cocina_dro:, resources:, staging_location:, reading_order: nil)
         @cocina_dro = cocina_dro
         @resources = resources
         @reading_order = reading_order
+        @staging_location = staging_location
       end
-      attr_reader :resources, :cocina_dro, :reading_order
+
+      attr_reader :resources, :cocina_dro, :reading_order, :staging_location
 
       # generate the base of the Cocina Structural metadata for this new druid
       # @return [Cocina::Models::DROStructural] the structural metadata
@@ -30,7 +32,8 @@ module PreAssembly
           external_identifier = "#{cocina_dro.externalIdentifier.delete_prefix('druid:')}_#{seq}"
           FromFileManifest::FileSetBuilder.build(resource: resources[:file_sets][seq],
                                                  external_identifier:,
-                                                 cocina_dro:)
+                                                 cocina_dro:,
+                                                 staging_location:)
         end
       end
     end

--- a/spec/features/preassembly_run/book_using_file_manifest_spec.rb
+++ b/spec/features/preassembly_run/book_using_file_manifest_spec.rb
@@ -65,7 +65,8 @@ RSpec.describe 'Pre-assemble Book Using File Manifest' do
     expect(PreAssembly::FromFileManifest::StructuralBuilder).to have_received(:build)
       .with(cocina_dro: item,
             resources: Hash,
-            reading_order: 'right-to-left')
+            reading_order: 'right-to-left',
+            staging_location: staging_location.to_s)
     expect(dsc_object).to have_received(:update).with(params: item)
   end
 end

--- a/spec/features/preassembly_run/hierarchial_files_with_manifest_spec.rb
+++ b/spec/features/preassembly_run/hierarchial_files_with_manifest_spec.rb
@@ -129,7 +129,8 @@ RSpec.describe 'Pre-assemble Image object' do
       expect(PreAssembly::FromFileManifest::StructuralBuilder).to have_received(:build)
         .with(cocina_dro: item,
               resources:,
-              reading_order: nil)
+              reading_order: nil,
+              staging_location: staging_location.to_s)
       expect(dsc_object).to have_received(:update).with(params: item)
     end
   end

--- a/spec/features/preassembly_run/media_audio_spec.rb
+++ b/spec/features/preassembly_run/media_audio_spec.rb
@@ -68,7 +68,8 @@ RSpec.describe 'Pre-assemble Media Audio object' do
     expect(PreAssembly::FromFileManifest::StructuralBuilder).to have_received(:build)
       .with(cocina_dro: item,
             resources: Hash,
-            reading_order: nil)
+            reading_order: nil,
+            staging_location: staging_location.to_s)
     expect(dsc_object).to have_received(:update).with(params: item)
   end
 end

--- a/spec/features/preassembly_run/media_video_spec.rb
+++ b/spec/features/preassembly_run/media_video_spec.rb
@@ -68,7 +68,8 @@ RSpec.describe 'Pre-assemble Media Video object' do
     expect(PreAssembly::FromFileManifest::StructuralBuilder).to have_received(:build)
       .with(cocina_dro: item,
             resources: Hash,
-            reading_order: nil)
+            reading_order: nil,
+            staging_location: staging_location.to_s)
     expect(dsc_object).to have_received(:update).with(params: item)
   end
 end

--- a/spec/lib/pre_assembly/from_file_manifest/structural_builder_spec.rb
+++ b/spec/lib/pre_assembly/from_file_manifest/structural_builder_spec.rb
@@ -3,15 +3,17 @@
 RSpec.describe PreAssembly::FromFileManifest::StructuralBuilder do
   describe '#build' do
     subject(:structural) do
-      described_class.build(cocina_dro:, resources:)
+      described_class.build(cocina_dro:, resources:, staging_location:)
     end
 
     let(:dro_access) { { view: 'world' } }
+    let(:dro_structural) { { contains: [], isMemberOf: ['druid:bb000kk0000'] } }
     let(:cocina_dro) do
-      Cocina::RSpec::Factories.build(:dro, collection_ids: ['druid:bb000kk0000']).new(access: dro_access)
+      Cocina::RSpec::Factories.build(:dro, id: 'druid:vd000bj0000').new(access: dro_access, structural: dro_structural)
     end
 
     context 'with media style' do
+      let(:staging_location) { Rails.root.join('spec/fixtures/media_video_test').to_s }
       let(:content_dir) { 'vd000bj0000' }
 
       let(:resources) do
@@ -113,9 +115,104 @@ RSpec.describe PreAssembly::FromFileManifest::StructuralBuilder do
         # It retains the collection
         expect(structural.isMemberOf).to eq ['druid:bb000kk0000']
       end
+
+      context 'when file manifest has additions, deletions, and updates' do
+        let(:resources) do
+          { file_sets: { 1 =>
+            { label: 'Video file 1',
+              sequence: 1,
+              resource_type: 'video',
+              files: [{ type: 'https://cocina.sul.stanford.edu/models/file',
+                        externalIdentifier: 'https://cocina.sul.stanford.edu/file/f3e1c208-a79a-49f6-9f26-784cf80ad445',
+                        # Not in the cocina structural, meaning this file was added.
+                        filename: 'vd000bj0000_video_1.mp4',
+                        label: 'vd000bj0000_video_1.mp4',
+                        administrative: { sdrPreserve: true, publish: true, shelve: true },
+                        hasMessageDigests: [{ type: 'md5', digest: 'ee4e90be549c5614ac6282a5b80a506b' }] },
+                      { type: 'https://cocina.sul.stanford.edu/models/file',
+                        externalIdentifier: 'https://cocina.sul.stanford.edu/file/2e4fa62a-c4b5-410a-a64c-fb3fb543aebd',
+                        # In cocina structural but not on disk, meaning this file is unchanged.
+                        filename: 'x-vd000bj0000_video_1.mpeg',
+                        label: 'vd000bj0000_video_1.mpeg',
+                        administrative: { sdrPreserve: true, publish: false, shelve: false },
+                        hasMessageDigests: [{ type: 'md5', digest: 'bed85c6ffc2f8070599a7fb682852f30' }] },
+                      { type: 'https://cocina.sul.stanford.edu/models/file',
+                        externalIdentifier: 'https://cocina.sul.stanford.edu/file/e32b449a-847f-4765-8f08-d06c8dd3b09f',
+                        # Both in cocina structural and on disk, meaning this file was updated.
+                        filename: 'vd000bj0000_video_1_thumb.jp2',
+                        label: 'vd000bj0000_video_1_thumb.jp2',
+                        administrative: { sdrPreserve: true, publish: true, shelve: true },
+                        hasMessageDigests: [{ type: 'md5', digest: '4b0e92aec76da9ac98567b8e6848e922' }] }] } } }
+        end
+
+        let(:dro_structural) do
+          { contains: [{ type: 'https://cocina.sul.stanford.edu/models/resources/video',
+                         externalIdentifier: 'bc234fg5678_1',
+                         label: 'Video file 1',
+                         version: 1,
+                         structural: { contains: [{ type: 'https://cocina.sul.stanford.edu/models/file',
+                                                    externalIdentifier: 'https://cocina.sul.stanford.edu/file/f3e1c208-a79a-49f6-9f26-784cf80ad445',
+                                                    label: 'vd000bj0000_video_1.mp4',
+                                                    # Not in the file manifest, meaning this file was deleted.
+                                                    filename: 'x-vd000bj0000_video_1.mp4',
+                                                    version: 1,
+                                                    hasMessageDigests: [{ type: 'md5', digest: 'ee4e90be549c5614ac6282a5b80a506b' }],
+                                                    access: { view: 'world', download: 'none', controlledDigitalLending: false },
+                                                    administrative: { publish: true, sdrPreserve: true, shelve: true } },
+                                                  { type: 'https://cocina.sul.stanford.edu/models/file',
+                                                    externalIdentifier: 'https://cocina.sul.stanford.edu/file/2e4fa62a-c4b5-410a-a64c-fb3fb543aebd',
+                                                    label: 'vd000bj0000_video_1.mpeg',
+                                                    # Exists in file manifest, but not on disk. Note that the md5 is changed to make sure it is maintained.
+                                                    filename: 'x-vd000bj0000_video_1.mpeg',
+                                                    version: 1,
+                                                    hasMessageDigests: [{ type: 'md5', digest: 'x-bed85c6ffc2f8070599a7fb682852f30' }],
+                                                    # Mimetype, size, and presentation added to make sure it is maintained.
+                                                    hasMimeType: 'image/jp2',
+                                                    size: 1234,
+                                                    presentation: { height: 123, width: 456 },
+                                                    access: { view: 'world', download: 'none', controlledDigitalLending: false },
+                                                    administrative: { publish: false, sdrPreserve: true, shelve: false } },
+                                                  { type: 'https://cocina.sul.stanford.edu/models/file',
+                                                    externalIdentifier: 'https://cocina.sul.stanford.edu/file/e32b449a-847f-4765-8f08-d06c8dd3b09f',
+                                                    label: 'vd000bj0000_video_1_thumb.jp2',
+                                                    # Exists in file manifest and on disk, meaning it is updated. Note that the md5 is changed to make sure it is not maintained.
+                                                    filename: 'vd000bj0000_video_1_thumb.jp2',
+                                                    version: 1,
+                                                    hasMessageDigests: [{ type: 'md5', digest: 'x-4b0e92aec76da9ac98567b8e6848e922' }],
+                                                    # Mimetype, size, and presentation added to make sure it is not maintained.
+                                                    hasMimeType: 'image/jp2',
+                                                    size: 1234,
+                                                    presentation: { height: 123, width: 456 },
+                                                    access: { view: 'world', download: 'none', controlledDigitalLending: false },
+                                                    administrative: { publish: true, sdrPreserve: true, shelve: true } }] } }],
+            hasMemberOrders: [],
+            isMemberOf: ['druid:bb000kk0000'] }
+        end
+
+        it 'generates the structural with changes' do
+          file_sets = structural.contains
+          expect(file_sets.size).to eq 1
+          files = file_sets.flat_map { |file_set| file_set.structural.contains }
+          expect(files.map(&:filename)).to eq ['vd000bj0000_video_1.mp4',
+                                               'x-vd000bj0000_video_1.mpeg',
+                                               'vd000bj0000_video_1_thumb.jp2']
+          unchanged_file = files[1]
+          expect(unchanged_file.hasMimeType).to eq 'image/jp2'
+          expect(unchanged_file.size).to eq 1234
+          expect(unchanged_file.presentation.to_h).to eq(height: 123, width: 456)
+          expect(unchanged_file.hasMessageDigests.first.digest).to eq 'x-bed85c6ffc2f8070599a7fb682852f30'
+
+          updated_file = files[2]
+          expect(updated_file.hasMimeType).to be_nil
+          expect(updated_file.size).to be_nil
+          expect(updated_file.presentation).to be_nil
+          expect(updated_file.hasMessageDigests.first.digest).to eq '4b0e92aec76da9ac98567b8e6848e922'
+        end
+      end
     end
 
     context 'with simple_book style' do
+      let(:staging_location) { Rails.root.join('spec/fixtures/book-file-manifest').to_s }
       let(:content_dir) { 'content' }
 
       let(:resources) do


### PR DESCRIPTION
closes #1240

# Why was this change made? 🤔
To avoid having to stage all files to re-accession.


# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit, infra integration

# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



