### PR TITLE
Initialize remote byebug for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ its sessions. To override that behavior and specify an alternate user, you can m
 environment variable at startup, like so:
 
 ```bash
-REMOTE_USER=ima_user bin/dev
+REMOTE_DEBUGGER=byebug REMOTE_USER=ima_user bin/dev # omit REMOTE_DEBUGGER if you don't need a debugger
+bundle exec byebug -R localhost:8989 # run in separate terminal window
 ```
 
 Because the application looks for user info in an environment variable, and because local dev environments don't have

--- a/config/initializers/byebug.rb
+++ b/config/initializers/byebug.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+if Rails.env.development? && ENV.fetch('REMOTE_DEBUGGER', nil) == 'byebug'
+  require 'byebug/core'
+
+  debugger_host = ENV.fetch('DEBUGGER_HOST', 'localhost')
+  debugger_port = ENV.fetch('DEBUGGER_PORT', 8989).to_i
+
+  begin
+    Byebug.start_server(debugger_host, debugger_port)
+  rescue Errno::EADDRINUSE
+    Rails.logger.error("Debugger already running on #{debugger_host}:#{debugger_port}! Change `DEBUGGER_HOST` and/or `DEBUGGER_PORT` and try again.")
+  end
+end


### PR DESCRIPTION
# Why was this change made? 🤔

Initializes the remote byebug server port to follow the pattern used in other reports (i.e. argo)

