### PR TITLE
better differentiation of JobRun.state values

### DIFF
--- a/app/jobs/discovery_report_job.rb
+++ b/app/jobs/discovery_report_job.rb
@@ -13,9 +13,9 @@ class DiscoveryReportJob < ApplicationJob
     job_run.save!
     if report.objects_had_errors # individual objects processed had errors
       job_run.error_message = report.error_message
-      job_run.completed_with_errors
+      job_run.discovery_report_completed_with_errors
     else
-      job_run.completed
+      job_run.discovery_report_completed
     end
   rescue StandardError => e # catch any error preventing the whole job from running (e.g. bad header in csv)
     job_run.error_message = e.exception

--- a/app/jobs/preassembly_job.rb
+++ b/app/jobs/preassembly_job.rb
@@ -9,9 +9,9 @@ class PreassemblyJob < ApplicationJob
     batch.run_pre_assembly
     if batch.objects_had_errors # individual objects processed had errors
       job_run.error_message = batch.error_message
-      job_run.completed_with_errors
+      job_run.preassembly_completed_with_errors
     else
-      job_run.completed
+      job_run.preassembly_completed
     end
   rescue StandardError => e # catch any error preventing the whole job from running (e.g. bad header in csv)
     job_run.error_message = e.exception

--- a/app/lib/pre_assembly/batch.rb
+++ b/app/lib/pre_assembly/batch.rb
@@ -154,7 +154,7 @@ module PreAssembly
         else
           Accession.find_or_create_by!(druid: dobj.druid.id, version: progress.fetch(:version), job_run:)
         end
-        log "Completed #{dobj.druid}"
+        log "Preassembly completed #{dobj.druid}"
         File.open(progress_log_file, 'a') { |f| f.puts progress.to_yaml }
       end
     end

--- a/app/models/job_run.rb
+++ b/app/models/job_run.rb
@@ -29,12 +29,25 @@ class JobRun < ApplicationRecord
     end
 
     # signifies the job ran through, but at least one object had an error of some kind (e.g. network blip)
-    event :completed_with_errors do
-      transition running: :complete_with_errors
+    event :discovery_report_completed_with_errors do
+      transition running: :discovery_report_complete_with_errors
     end
 
-    event :completed do
-      transition running: :complete
+    event :discovery_report_completed do
+      transition running: :discovery_report_complete
+    end
+
+    # signifies the job ran through, but at least one object had an error of some kind (e.g. network blip)
+    event :preassembly_completed_with_errors do
+      transition running: :preassembly_complete_with_errors
+    end
+
+    event :preassembly_completed do
+      transition running: :preassembly_complete
+    end
+
+    event :accessioning_completed do
+      transition preassembly_complete: :accessioning_complete
     end
 
     after_transition do |job_run, transition|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,10 +36,12 @@ en:
         state:
           states:
             running: 'Running'
-            complete: 'Completed'
+            discovery_report_complete: 'Discovery report completed'
+            preassembly_complete: 'Preassembly completed'
             failed: 'Failed'
             waiting: 'Queued'
-            complete_with_errors: 'Completed (with errors)'
+            discovery_report_complete_with_errors: 'Discovery report completed (with errors)'
+            preassembly_complete_with_errors: 'Preassembly completed (with errors)'
     attributes:
       batch_context:
         all_files_public: "Preserve, Shelve, Publish Settings"

--- a/db/migrate/20230909033128_add_state_nuance_to_job_runs.rb
+++ b/db/migrate/20230909033128_add_state_nuance_to_job_runs.rb
@@ -1,0 +1,32 @@
+class AddStateNuanceToJobRuns < ActiveRecord::Migration[7.0]
+  # JobRun#job_type enum: 'discovery_report' is 0, 'preassembly' is 1
+  def up
+    execute <<-SQL
+      UPDATE job_runs
+      SET state = (CASE job_type WHEN 0 THEN 'discovery_report_complete_with_errors'
+                                 WHEN 1 THEN 'preassembly_complete_with_errors'
+                                 ELSE state
+                   END)
+      WHERE state = 'complete_with_errors';
+
+      UPDATE job_runs
+      SET state = (CASE job_type WHEN 0 THEN 'discovery_report_complete'
+                                 WHEN 1 THEN 'preassembly_complete'
+                                 ELSE state
+                   END)
+      WHERE state = 'complete';
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      UPDATE job_runs
+      SET state = 'complete_with_errors'
+      WHERE state in ('discovery_report_complete_with_errors', 'preassembly_complete_with_errors');
+
+      UPDATE job_runs
+      SET state = 'complete'
+      WHERE state in ('discovery_report_complete', 'preassembly_complete');
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_05_160434) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_09_033128) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/spec/features/discovery_report/completed_with_errors_spec.rb
+++ b/spec/features/discovery_report/completed_with_errors_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Discovery Report completes with errors' do
     # go to job details page, wait for preassembly to finish
     first('td  > a').click
     expect(page).to have_content project_name
-    expect(page).to have_content 'Completed (with errors)'
+    expect(page).to have_content 'Discovery report completed (with errors)'
     expect(page).to have_content 'Errors'
     expect(page).to have_content '1 objects had errors in the discovery report'
     expect(page).to have_link('Download').twice

--- a/spec/features/preassembly_run/no_files_spec.rb
+++ b/spec/features/preassembly_run/no_files_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Run preassembly on object with no files' do
     end
   end
 
-  it 'has status "Completed" and creates log file showing "success"' do
+  it 'has status "Preassembly completed" and creates log file showing "success"' do
     visit '/'
     expect(page).to have_selector('h3', text: 'Complete the form below')
 
@@ -50,7 +50,7 @@ RSpec.describe 'Run preassembly on object with no files' do
     # go to job details page, wait for preassembly to finish
     first('td  > a').click
     expect(page).to have_content project_name
-    expect(page).to have_content 'Completed'
+    expect(page).to have_content 'Preassembly completed'
     expect(page).to have_link('Download').once
 
     result_file = Rails.root.join(Settings.job_output_parent_dir, user_id, project_name, "#{project_name}_progress.yml")

--- a/spec/jobs/discovery_report_job_spec.rb
+++ b/spec/jobs/discovery_report_job_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe DiscoveryReportJob do
       it 'writes JSON file and saves job_run.output_location' do
         expect { job.perform(job_run) }.to change { File.exist?(outfile) }.to(true)
         expect(job_run.reload.output_location).to eq(outfile)
-        expect(job_run).to be_complete
+        expect(job_run).to be_discovery_report_complete
       end
     end
 
@@ -49,7 +49,7 @@ RSpec.describe DiscoveryReportJob do
 
       it 'calls to_discovery_report and ends in a completed with error state, and saves error message to the database' do
         job.perform(job_run)
-        expect(job_run).to be_complete_with_errors
+        expect(job_run).to be_discovery_report_complete_with_errors
         expect(job_run.error_message).to eq error_message
       end
     end

--- a/spec/jobs/preassembly_job_spec.rb
+++ b/spec/jobs/preassembly_job_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe PreassemblyJob do
       it 'calls run_pre_assembly and ends in an complete state' do
         expect(batch).to receive(:run_pre_assembly)
         job.perform(job_run)
-        expect(job_run).to be_complete
+        expect(job_run).to be_preassembly_complete
         expect(job_run.error_message).to be_nil
       end
     end
@@ -54,7 +54,7 @@ RSpec.describe PreassemblyJob do
       it 'calls run_pre_assembly and ends in a completed with error state, and saves error message to the database' do
         expect(batch).to receive(:run_pre_assembly)
         job.perform(job_run)
-        expect(job_run).to be_complete_with_errors
+        expect(job_run).to be_preassembly_complete_with_errors
         expect(job_run.error_message).to eq error_message
       end
     end

--- a/spec/mailers/job_mailer_spec.rb
+++ b/spec/mailers/job_mailer_spec.rb
@@ -19,10 +19,10 @@ RSpec.describe JobMailer do
   end
 
   describe 'body' do
-    before { job_run.state = 'complete' }
+    before { job_run.state = 'discovery_report_complete' }
 
     it 'renders the body' do
-      expect(job_notification.body.encoded).to include("Your Discovery report job ##{job_run.id} finished with status 'Completed'")
+      expect(job_notification.body.encoded).to include("Your Discovery report job ##{job_run.id} finished with status 'Discovery report completed'")
         .and include("http://localhost:3000/job_runs/#{job_run.id}")
     end
   end

--- a/spec/models/job_run_spec.rb
+++ b/spec/models/job_run_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe JobRun do
       expect(JobMailer).to receive(:with).with(job_run:).and_return(mock_mailer)
       expect(mock_mailer).to receive(:completion_email).and_return(mock_delivery)
       expect(mock_delivery).to receive(:deliver_later)
-      job_run.completed
+      job_run.preassembly_completed
     end
 
     it 'sends a notification email when job_run fails' do
@@ -58,7 +58,7 @@ RSpec.describe JobRun do
       expect(JobMailer).to receive(:with).with(job_run:).and_return(mock_mailer)
       expect(mock_mailer).to receive(:completion_email).and_return(mock_delivery)
       expect(mock_delivery).to receive(:deliver_later)
-      job_run.completed_with_errors
+      job_run.preassembly_completed_with_errors
     end
   end
 

--- a/spec/views/job_runs/show.html.erb_spec.rb
+++ b/spec/views/job_runs/show.html.erb_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'job_runs/show.html.erb' do
 
     it 'with a completed job, presents a download link to the report and the log file' do
       job_run.started
-      job_run.completed
+      job_run.discovery_report_completed
       render template: 'job_runs/show'
       expect(rendered).to include("<a href=\"/job_runs/#{job_run.id}/download_log\">Download</a>")
       expect(rendered).to include("<a href=\"/job_runs/#{job_run.id}/download_report\">Download</a>")
@@ -27,7 +27,7 @@ RSpec.describe 'job_runs/show.html.erb' do
 
     it 'with a completed with errors job, presents a download link to the report and the log file' do
       job_run.started
-      job_run.completed_with_errors
+      job_run.discovery_report_completed_with_errors
       render template: 'job_runs/show'
       expect(rendered).to include("<a href=\"/job_runs/#{job_run.id}/download_log\">Download</a>")
       expect(rendered).to include("<a href=\"/job_runs/#{job_run.id}/download_report\">Download</a>")
@@ -62,7 +62,7 @@ RSpec.describe 'job_runs/show.html.erb' do
 
     it 'with a completed job, presents a download link to only the log file' do
       job_run.started
-      job_run.completed
+      job_run.discovery_report_completed
       render template: 'job_runs/show'
       expect(rendered).to include("<a href=\"/job_runs/#{job_run.id}/download_log\">Download</a>")
       expect(rendered).not_to include("<a href=\"/job_runs/#{job_run.id}/download_report\">Download</a>")


### PR DESCRIPTION
* splits `:complete` into `:discovery_report_complete` and `:preassembly_complete`, to differentiate from `:accessioning_complete` (which pre-assembly will start using to track and notify about the eventual completion of accessioning launched by each preassembly `JobRun`)
* for parity with those new states, splits `:complete_with_errors` into `:discovery_report_complete_with_errors` and `:preassembly_complete_with_errors`
* migrates existing `job_runs.state` values using combo of `state` and `job_type`
* provides a reverse migration that goes back to the old state values

# Why was this change made? 🤔

fixes https://github.com/sul-dlss/pre-assembly/issues/1198

# How was this change tested? 🤨

i dumped a copy of the stage database and then loaded it up on my local preassembly PG instance:

from preassembly stage, after `ksu`ing to root (file ends up in the postgres user's home dir):
```
# su - postgres -c "pg_dump -Fc preassembly  > ~/preassembly_job_run_state_testing_snapshot_$(date --iso-8601=seconds).sql"
```

on my local instance, using a copy of the `.sql` dump created above, after doing a `rails db:drop db:create` to get an empty database to which to restore:
```
% pg_restore -U postgres -d preassembly_development -h localhost preassembly_job_run_state_testing_snapshot_2023-09-08T17:42:19-07:00.sql
```

`pg_restore` threw some errors about not being able to change table and constraint owners to the preassembly user, e.g.:

```
pg_restore: error: could not execute query: ERROR:  role "preassembly" does not exist
Command was: ALTER TABLE public.accessions OWNER TO preassembly;
```

but none were fatal.

then i queried the counts of the various states before the migration:
```
irb(main):012:0> JobRun.where(state: ['complete', 'complete_with_errors']).group('job_type', 'state').pluck('job_type', 'state', 'count
(1)')
  JobRun Pluck (4.4ms)  SELECT "job_runs"."job_type", "job_runs"."state", count(1) FROM "job_runs" WHERE "job_runs"."state" IN ($1, $2) GROUP BY "job_runs"."job_type", "job_runs"."state"  [["state", "complete"], ["state", "complete_with_errors"]]
=>                                                                
[["discovery_report", "complete", 350],                           
 ["preassembly", "complete_with_errors", 43],                     
 ["preassembly", "complete", 2532],                               
 ["discovery_report", "complete_with_errors", 30]]                
irb(main):013:0> 
irb(main):014:0> JobRun.where(state: ['complete', 'complete_with_errors']).group(:state).pluck('state', 'count(state)')
  JobRun Pluck (1.9ms)  SELECT "job_runs"."state", count(state) FROM "job_runs" WHERE "job_runs"."state" IN ($1, $2) GROUP BY "job_runs"."state"  [["state", "complete"], ["state", "complete_with_errors"]]                                                                  
=> [["complete_with_errors", 73], ["complete", 2882]]                                                                                  
```

ran the migration:
```
% RAILS_ENV=development bin/rails db:migrate                        job-run-completed-state-nuance
== 20230909033128 AddStateNuanceToJobRuns: migrating ==========================
-- execute("      UPDATE job_runs\n      SET state = (CASE job_type WHEN 0 THEN 'discovery_report_complete_with_errors'\n                                 WHEN 1 THEN 'preassembly_complete_with_errors'\n                                 ELSE state\n                   END)\n      WHERE state = 'complete_with_errors';\n\n      UPDATE job_runs\n      SET state = (CASE job_type WHEN 0 THEN 'discovery_report_complete'\n                                 WHEN 1 THEN 'preassembly_complete'\n                                 ELSE state\n                   END)\n      WHERE state = 'complete';\n")
   -> 0.0243s
== 20230909033128 AddStateNuanceToJobRuns: migrated (0.0244s) =================
```

ran the same queries again to make sure the post-migration counts looked reasonable:
```
irb(main):003:0> JobRun.where.not(state: ['waiting', 'running', 'failed']).group('job_type', 'state').pluck('job_type', 'state', 'count
(1)')
  JobRun Pluck (2.9ms)  SELECT "job_runs"."job_type", "job_runs"."state", count(1) FROM "job_runs" WHERE "job_runs"."state" NOT IN ($1, $2, $3) GROUP BY "job_runs"."job_type", "job_runs"."state"  [["state", "waiting"], ["state", "running"], ["state", "failed"]]
=>                                                                                          
[["preassembly", "preassembly_complete_with_errors", 43],                                   
 ["discovery_report", "discovery_report_complete_with_errors", 30],                         
 ["preassembly", "preassembly_complete", 2532],                                             
 ["discovery_report", "discovery_report_complete", 350]]                                    
irb(main):004:0> 
irb(main):005:0> JobRun.where.not(state: ['waiting', 'running', 'failed']).group(:state).pluck('state', 'count(state)')
  JobRun Pluck (2.8ms)  SELECT "job_runs"."state", count(state) FROM "job_runs" WHERE "job_runs"."state" NOT IN ($1, $2, $3) GROUP BY "job_runs"."state"  [["state", "waiting"], ["state", "running"], ["state", "failed"]]        
=>                                                                                          
[["discovery_report_complete", 350],                                                        
 ["preassembly_complete_with_errors", 43],                                                  
 ["preassembly_complete", 2532],                                  
 ["discovery_report_complete_with_errors", 30]]
```


i also tested rollback locally:
```
% bin/rails db:rollback                                             job-run-completed-state-nuance
== 20230909033128 AddStateNuanceToJobRuns: reverting ==========================
-- execute("      UPDATE job_runs\n      SET state = 'complete_with_errors'\n      WHERE state in ('discovery_report_complete_with_errors', 'preassembly_complete_with_errors');\n\n      UPDATE job_runs\n      SET state = 'complete'\n      WHERE state in ('discovery_report_complete', 'preassembly_complete');\n")
   -> 0.0229s
== 20230909033128 AddStateNuanceToJobRuns: reverted (0.0230s) =================
```

```
% bin/rails c                                                       job-run-completed-state-nuance
Loading development environment (Rails 7.0.7.2)
irb(main):001:0> JobRun.where.not(state: ['waiting', 'running', 'failed']).group('job_type', 'state').pluck('job_type', 'state', 'count
(1)')
  JobRun Pluck (2.8ms)  SELECT "job_runs"."job_type", "job_runs"."state", count(1) FROM "job_runs" WHERE "job_runs"."state" NOT IN ($1, $2, $3) GROUP BY "job_runs"."job_type", "job_runs"."state"  [["state", "waiting"], ["state", "running"], ["state", "failed"]]
=> 
[["discovery_report", "complete", 350],
 ["preassembly", "complete_with_errors", 43],
 ["preassembly", "complete", 2532],
 ["discovery_report", "complete_with_errors", 30]]
irb(main):002:0> 
irb(main):003:0> JobRun.where.not(state: ['waiting', 'running', 'failed']).group(:state).pluck('state', 'count(state)')
  JobRun Pluck (2.2ms)  SELECT "job_runs"."state", count(state) FROM "job_runs" WHERE "job_runs"."state" NOT IN ($1, $2, $3) GROUP BY "job_runs"."state"  [["state", "waiting"], ["state", "running"], ["state", "failed"]]
=> [["complete_with_errors", 73], ["complete", 2882]]
```

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡

No UI changes other than text in localization file