### PR TITLE
Group by filename with OCR

### DIFF
--- a/app/lib/pre_assembly/from_staging_location/file.rb
+++ b/app/lib/pre_assembly/from_staging_location/file.rb
@@ -24,20 +24,39 @@ module PreAssembly
         'application/json' => { preserve: 'yes', shelve: 'yes', publish: 'yes' }
       }.freeze
 
+      ATTRIBUTES_FOR_TYPE_WITH_OCR = {
+        'image/tif' => { preserve: 'yes', shelve: 'no', publish: 'no' },
+        'image/tiff' => { preserve: 'yes', shelve: 'no', publish: 'no' },
+        'image/jp2' => { preserve: 'yes', shelve: 'no', publish: 'no' },
+        'image/jpeg' => { preserve: 'yes', shelve: 'no', publish: 'no' },
+        'image/png' => { preserve: 'yes', shelve: 'no', publish: 'no' },
+        'application/pdf' => { preserve: 'yes', shelve: 'yes', publish: 'yes' },
+        'plain/text' => { preserve: 'yes', shelve: 'yes', publish: 'yes' },
+        'text/plain' => { preserve: 'yes', shelve: 'yes', publish: 'yes' },
+        'application/xml' => { preserve: 'yes', shelve: 'yes', publish: 'yes', role: 'transcription' }
+      }.freeze
+
       # @param [Assembly::ObjectFile] file
-      def initialize(file:)
+      def initialize(file:, processing_configuration:)
         @file = file
+        @processing_configuration = processing_configuration
       end
 
       delegate :sha1, :md5, :provider_md5, :mimetype, :filesize, :relative_path, to: :file
 
       def file_attributes
-        file.file_attributes || ATTRIBUTES_FOR_TYPE[mimetype] || ATTRIBUTES_FOR_TYPE['default']
+        file.file_attributes || file_attributes_for_mimetype(mimetype)
       end
 
       private
 
-      attr_reader :file
+      attr_reader :file, :processing_configuration
+
+      def file_attributes_for_mimetype(mimetype)
+        return ATTRIBUTES_FOR_TYPE_WITH_OCR[mimetype] if processing_configuration == :filename_with_ocr && ATTRIBUTES_FOR_TYPE_WITH_OCR.key?(mimetype)
+
+        ATTRIBUTES_FOR_TYPE[mimetype] || ATTRIBUTES_FOR_TYPE['default']
+      end
     end
   end
 end

--- a/app/lib/pre_assembly/from_staging_location/file_set.rb
+++ b/app/lib/pre_assembly/from_staging_location/file_set.rb
@@ -8,9 +8,10 @@ module PreAssembly
 
       # @param [Array<Assembly::ObjectFile>] resource_files
       # @param [Symbol] style one of: :simple_image, :file, :simple_book, :book_as_image, :book_with_pdf, :map, or :'3d'
-      def initialize(resource_files:, style:)
+      def initialize(resource_files:, style:, processing_configuration:)
         @resource_files = resource_files
         @style = style
+        @processing_configuration = processing_configuration
       end
 
       # otherwise look at the style to determine the resource_type_description
@@ -28,7 +29,7 @@ module PreAssembly
 
       private
 
-      attr_reader :resource_files, :style
+      attr_reader :resource_files, :style, :processing_configuration
 
       # rubocop:disable Metrics/AbcSize
       # rubocop:disable Metrics/CyclomaticComplexity

--- a/app/lib/pre_assembly/from_staging_location/file_set.rb
+++ b/app/lib/pre_assembly/from_staging_location/file_set.rb
@@ -24,7 +24,7 @@ module PreAssembly
       end
 
       def files
-        resource_files.map { |file| File.new(file:) }
+        resource_files.map { |file| File.new(file:, processing_configuration:) }
       end
 
       private

--- a/app/lib/pre_assembly/from_staging_location/file_set_builder.rb
+++ b/app/lib/pre_assembly/from_staging_location/file_set_builder.rb
@@ -21,7 +21,7 @@ module PreAssembly
       def build
         case processing_configuration
         when :default # one resource per object
-          objects.collect { |obj| FileSet.new(resource_files: [obj], style:) }
+          objects.collect { |obj| FileSet.new(resource_files: [obj], style:, processing_configuration:) }
         when :filename # one resource per distinct filename (excluding extension)
           build_for_filename
         else
@@ -39,7 +39,8 @@ module PreAssembly
         distinct_filenames = objects.collect(&:filename_without_ext).uniq # find all the unique filenames in the set of objects, leaving off extensions and base paths
         distinct_filenames.map do |distinct_filename|
           FileSet.new(resource_files: objects.collect { |obj| obj if obj.filename_without_ext == distinct_filename }.compact,
-                      style:)
+                      style:,
+                      processing_configuration:)
         end
       end
     end

--- a/app/lib/pre_assembly/from_staging_location/file_set_builder.rb
+++ b/app/lib/pre_assembly/from_staging_location/file_set_builder.rb
@@ -22,7 +22,7 @@ module PreAssembly
         case processing_configuration
         when :default # one resource per object
           objects.collect { |obj| FileSet.new(resource_files: [obj], style:, processing_configuration:) }
-        when :filename # one resource per distinct filename (excluding extension)
+        when :filename, :filename_with_ocr # one resource per distinct filename (excluding extension)
           build_for_filename
         else
           raise 'Invalid processing_configuration: must be :default or :filename'

--- a/app/lib/pre_assembly/from_staging_location/structural_builder.rb
+++ b/app/lib/pre_assembly/from_staging_location/structural_builder.rb
@@ -105,7 +105,11 @@ module PreAssembly
         publish  = file[:publish] == 'yes'
         preserve = file[:preserve] == 'yes'
         shelve   = file[:shelve] == 'yes'
-        { sdrPreserve: preserve, publish:, shelve: }
+        role     = file[:role]
+
+        return { sdrPreserve: preserve, publish:, shelve: } unless role
+
+        { sdrPreserve: preserve, publish:, shelve:, role: }
       end
 
       def message_digests(fileset_file)

--- a/app/lib/pre_assembly/from_staging_location/structural_builder.rb
+++ b/app/lib/pre_assembly/from_staging_location/structural_builder.rb
@@ -49,6 +49,8 @@ module PreAssembly
               administrative: administrative(fileset_file),
               access: file_access
             }
+            file_attributes[:use] = fileset_file.file_attributes[:role] if role?(fileset_file)
+
             Cocina::Models::File.new(file_attributes)
           end
 
@@ -105,11 +107,11 @@ module PreAssembly
         publish  = file[:publish] == 'yes'
         preserve = file[:preserve] == 'yes'
         shelve   = file[:shelve] == 'yes'
-        role     = file[:role]
+        { sdrPreserve: preserve, publish:, shelve: }
+      end
 
-        return { sdrPreserve: preserve, publish:, shelve: } unless role
-
-        { sdrPreserve: preserve, publish:, shelve:, role: }
+      def role?(fileset_file)
+        fileset_file.file_attributes.key? :role
       end
 
       def message_digests(fileset_file)

--- a/app/models/batch_context.rb
+++ b/app/models/batch_context.rb
@@ -46,7 +46,8 @@ class BatchContext < ApplicationRecord
   enum processing_configuration: {
     'default' => 0,
     'filename' => 1,
-    'media_cm_style' => 2 # Deprecated
+    'media_cm_style' => 2, # Deprecated
+    'filename_with_ocr' => 3
   }
 
   accepts_nested_attributes_for :job_runs

--- a/app/views/batch_contexts/_new_bc_form.erb
+++ b/app/views/batch_contexts/_new_bc_form.erb
@@ -34,7 +34,7 @@
         [
             ["Default", "default"],
             ["Group by filename", "filename"],
-            ["Group by filename (with OCR)", "filename_with_ocr"]
+            ["Group by filename (with pre-existing OCR)", "filename_with_ocr"]
         ]
     %>
 

--- a/app/views/batch_contexts/_new_bc_form.erb
+++ b/app/views/batch_contexts/_new_bc_form.erb
@@ -33,7 +33,8 @@
     <%= form.input :processing_configuration, collection:
         [
             ["Default", "default"],
-            ["Group by filename", "filename"]
+            ["Group by filename", "filename"],
+            ["Group by filename (with OCR)", "filename_with_ocr"]
         ]
     %>
 

--- a/spec/lib/pre_assembly/from_staging_location/structural_builder_spec.rb
+++ b/spec/lib/pre_assembly/from_staging_location/structural_builder_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe PreAssembly::FromStagingLocation::StructuralBuilder do
                             all_files_public:)
     end
 
-    let(:filesets) { PreAssembly::FromStagingLocation::FileSetBuilder.build(processing_configuration: :default, objects:, style: :document) }
+    let(:filesets) { PreAssembly::FromStagingLocation::FileSetBuilder.build(processing_configuration:, objects:, style: :document) }
+    let(:processing_configuration) { :default }
     let(:cocina_dro) do
       Cocina::RSpec::Factories.build(:dro, collection_ids: ['druid:bb000kk0000']).new(access: dro_access)
     end
@@ -71,6 +72,28 @@ RSpec.describe PreAssembly::FromStagingLocation::StructuralBuilder do
 
           # it stores administrative settings corresponding to the access
           expect(files.map { |file| file.administrative.to_h }).to all(eq({ publish: false, shelve: false, sdrPreserve: true }))
+
+          # It retains the collection
+          expect(structural.isMemberOf).to eq ['druid:bb000kk0000']
+        end
+      end
+
+      context 'with OCR files included' do
+        let(:processing_configuration) { :filename_with_ocr }
+        let(:objects) { [PreAssembly::ObjectFile.new("#{base_path}document.pdf", { relative_path: 'document.pdf' })] }
+        let(:dro_access) { { view: 'world', download: 'world' } }
+        let(:all_files_public) { false }
+
+        it 'adds all the files' do
+          file_sets = structural.contains
+          expect(file_sets.size).to eq 1
+          files = file_sets.flat_map { |file_set| file_set.structural.contains }
+          expect(files.map(&:filename)).to eq ['document.pdf']
+          expected_access = { view: 'world', download: 'world', controlledDigitalLending: false }
+          expect(files.map(&:access).map(&:to_h)).to all(eq(expected_access))
+
+          # it stores administrative settings corresponding to the access
+          expect(files.map { |file| file.administrative.to_h }).to all(eq({ publish: true, shelve: true, sdrPreserve: true }))
 
           # It retains the collection
           expect(structural.isMemberOf).to eq ['druid:bb000kk0000']

--- a/spec/models/batch_context_spec.rb
+++ b/spec/models/batch_context_spec.rb
@@ -108,7 +108,8 @@ RSpec.describe BatchContext do
     is_expected.to define_enum_for(:processing_configuration).with_values(
       'default' => 0,
       'filename' => 1,
-      'media_cm_style' => 2
+      'media_cm_style' => 2,
+      'filename_with_ocr' => 3
     )
   end
 


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #1187 

This adds the processing configuration option for `filename_with_ocr`.


Held for testing by @andrewjbtw 

# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



