### PR TITLE
Label on checkbox

### DIFF
--- a/app/views/batch_contexts/_new_bc_form.erb
+++ b/app/views/batch_contexts/_new_bc_form.erb
@@ -37,7 +37,7 @@
         ]
     %>
 
-    <p><%= form.check_box :using_file_manifest%> I have a file manifest</p>
+    <%= form.input :using_file_manifest, as: :boolean, label: 'I have a file manifest'%>
 
     <%= form.input :all_files_public,
                    as: :radio_buttons,

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -72,7 +72,7 @@ SimpleForm.setup do |config|
   # Defaults to :nested for bootstrap config.
   #   inline: input + label
   #   nested: label > input
-  config.boolean_style = :nested
+  config.boolean_style = :inline
 
   # Default class for buttons
   config.button_class = 'btn'


### PR DESCRIPTION
# Why was this change made? 🤔
Fixes #1257 to add a label field for the `I have a file manifest checkbox`

Resulting HTML generated:

```
<fieldset class="form-group boolean optional batch_context_using_file_manifest">
  <div class="form-check"><input name="batch_context[using_file_manifest]" type="hidden" value="0" autocomplete="off" />
    <input class="form-check-input boolean optional" type="checkbox" value="1" name="batch_context[using_file_manifest]" id="batch_context_using_file_manifest" />
    <label class="form-check-label boolean optional" for="batch_context_using_file_manifest">I have a file manifest</label>. </div>
</fieldset>
```

Doesn't look like it negatively affects radio buttons on the form. 
![Screenshot 2023-09-15 at 10 32 47 AM](https://github.com/sul-dlss/pre-assembly/assets/1619369/9f95959a-36b3-45ee-bad5-483cd37cd9ab)


# How was this change tested? 🤨
AXE DevTools confirms issue has gone away. Mac VoiceOver reads label.

# Does your change introduce accessibility violations? 🩺
None further, see above. 