### PR TITLE
move inline display of progress log file from job run page to batch context (project) page

### DIFF
--- a/app/models/batch_context.rb
+++ b/app/models/batch_context.rb
@@ -63,6 +63,10 @@ class BatchContext < ApplicationRecord
     @progress_log_file ||= File.join(output_dir, "#{project_name}_progress.yml")
   end
 
+  def progress_log_file_exists?
+    progress_log_file && File.exist?(progress_log_file)
+  end
+
   def staging_location_with_path(rel_path)
     File.join(staging_location, rel_path)
   end

--- a/app/models/job_run.rb
+++ b/app/models/job_run.rb
@@ -11,7 +11,7 @@ class JobRun < ApplicationRecord
   after_initialize :default_enums
   after_create_commit :enqueue!
 
-  delegate :progress_log_file, to: :batch_context
+  delegate :progress_log_file, :progress_log_file_exists?, to: :batch_context
 
   enum job_type: {
     'discovery_report' => 0,
@@ -76,10 +76,6 @@ class JobRun < ApplicationRecord
   # indicates if the discovery report job is ready for display and is available (some jobs may fail, leaving no report)
   def report_ready?
     job_type == 'discovery_report' && !in_progress? && output_location && File.exist?(output_location)
-  end
-
-  def progress_log_file_exists?
-    progress_log_file && File.exist?(progress_log_file)
   end
 
   def send_notification

--- a/app/views/batch_contexts/_batch_context.html.erb
+++ b/app/views/batch_contexts/_batch_context.html.erb
@@ -45,3 +45,7 @@
     </table>
   </div>
 <% end %>
+
+<% if batch_context.progress_log_file_exists? %>
+    <turbo-frame id="progress-log-frame" src="<%= progress_log_job_run_path(batch_context.job_runs.last) %>"></turbo-frame>
+<% end %>

--- a/app/views/job_runs/show.html.erb
+++ b/app/views/job_runs/show.html.erb
@@ -16,9 +16,6 @@
   <% if @job_run.report_ready? %>
       <turbo-frame id="discovery-report-frame" src="<%= discovery_report_summary_job_run_path(@job_run) %>"></turbo-frame>
   <% end %>
-  <% if @job_run.progress_log_file_exists? %>
-      <turbo-frame id="progress-log-frame" src="<%= progress_log_job_run_path(@job_run) %>"></turbo-frame>
-  <% end %>
   <div class="row mt-5">
      <div class="col-8">
         <p><%= link_to 'Return to homepage', root_path, class: 'nav-link' %></p>


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #1266 - do not show progress log file on individual job run pages as it can be confusing (a single batch context shares the same progress log file across multiple job runs).  Instead, show it on the batch context page.

It is still available from download from either page (just as before).

# How was this change tested? 🤨

Localhost and CI