### PR TITLE
make footer styling look more like Argo and H2

### DIFF
--- a/app/assets/stylesheets/sulFooter.scss
+++ b/app/assets/stylesheets/sulFooter.scss
@@ -7,6 +7,14 @@ body {
 
 #pre-footer {
   background-color: $pre-footer-background;
+
+  a {
+    text-decoration: none;
+  }
+
+  a:hover {
+    text-decoration: underline;
+  }
 }
 
 .su-global-footer {
@@ -14,6 +22,11 @@ body {
   color: $footer-color;
   a {
     color: $footer-color;
+    text-decoration: none;
+  }
+
+  a:hover {
+    text-decoration: underline;
   }
 
   .su-global-footer__menu--policy {


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #1275 - remove underlines from links in footer, show them on hover (just like we do in H2 and similar to Argo, which is where we took default styling from...except Argo does not show underlined links anywhere, so it disables globally)

**BEFORE**

![Screen Shot 2023-09-18 at 4 40 49 PM](https://github.com/sul-dlss/pre-assembly/assets/47137/21faca7a-b679-4128-af49-c7268f1251e0)

**AFTER**

(hovering over My Account)

![Screen Shot 2023-09-18 at 4 40 31 PM](https://github.com/sul-dlss/pre-assembly/assets/47137/422ed9cf-39cc-4abb-8c96-c6ea362398b4)


# How was this change tested? 🤨

Localhost