### PR TITLE
Tweak to job run complete job to avoid race condition.

### DIFF
--- a/app/jobs/job_run_complete_job.rb
+++ b/app/jobs/job_run_complete_job.rb
@@ -3,6 +3,7 @@
 # Updates a JobRun if all Accessions are complete
 class JobRunCompleteJob < ApplicationJob
   def perform(job_run)
+    return if job_run.running?
     return if job_run.accessioning_complete?
     return if job_run.accessions.exists?(state: :in_progress)
 

--- a/app/jobs/preassembly_job.rb
+++ b/app/jobs/preassembly_job.rb
@@ -13,7 +13,8 @@ class PreassemblyJob < ApplicationJob
     else
       job_run.completed
     end
-    # To avoid a possible race condition, run JobrunCompleteJob.
+    # To avoid a possible race condition (all accessioning complete before job run is marked completed),
+    # run JobrunCompleteJob.
     JobRunCompleteJob.perform_later(job_run)
   rescue StandardError => e # catch any error preventing the whole job from running (e.g. bad header in csv)
     job_run.error_message = e.exception

--- a/spec/jobs/job_run_complete_job_spec.rb
+++ b/spec/jobs/job_run_complete_job_spec.rb
@@ -46,4 +46,13 @@ RSpec.describe JobRunCompleteJob do
       expect { job.perform(job_run) }.not_to(change { job_run.reload.state })
     end
   end
+
+  context 'when started but preassembly not completed' do
+    let(:accessions) { [completed_accession, failed_accession] }
+    let(:state) { 'running' }
+
+    it 'does not change the state' do
+      expect { job.perform(job_run) }.not_to(change { job_run.reload.state })
+    end
+  end
 end


### PR DESCRIPTION
# Why was this change made? 🤔
To avoid a race condition where accessions complete before the job run is marked complete.


# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



