### PR TITLE
show structural changes from discovery report

### DIFF
--- a/app/controllers/job_runs_controller.rb
+++ b/app/controllers/job_runs_controller.rb
@@ -8,7 +8,6 @@ class JobRunsController < ApplicationController
 
   def show
     @job_run = JobRun.find(params[:id])
-    @structural_has_changed = structural_changed?
   end
 
   def create
@@ -47,6 +46,7 @@ class JobRunsController < ApplicationController
     @job_run = JobRun.find(params[:id])
     if @job_run.report_ready?
       @discovery_report = JSON.parse(File.read(@job_run.output_location))
+      @structural_has_changed = structural_changed?
     else
       flash.now[:warning] = 'There is no discovery report. Please check back later.'
       render 'show'


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #1283 - the move from a partial to a turbo frame left out this change, which is needed to show the structural differences in the discovery report when they exist

# How was this change tested? 🤨

Localhost