### PR TITLE
Add globus staging location and adjust destination path

### DIFF
--- a/app/models/globus_destination.rb
+++ b/app/models/globus_destination.rb
@@ -10,12 +10,17 @@ class GlobusDestination < ApplicationRecord
     "https://app.globus.org/file-manager?&destination_id=#{Settings.globus.endpoint_id}&destination_path=#{destination_path}"
   end
 
-  # directory within globus including user directory in the format /globus/sunet/datetime
+  # directory within globus including user directory in the format /sunet/datetime
   def destination_path
-    "#{Settings.globus.directory}/#{user.sunet_id}/#{created_at.strftime('%Y%m%d%H%M%S')}"
+    "/#{user.sunet_id}/#{created_at.strftime('%Y%m%d%H%M%S')}"
   end
 
-  # parse the path from a globus URL e.g. https://app.globus.org/file-manager?&destination_id=f3e29605-7ba5-45f5-8900-f1234566&destination_path=/globus/edsu/20230907044801
+  # path on preassembly filesystem to staged files
+  def staging_location
+    "#{Settings.globus.directory}#{destination_path}"
+  end
+
+  # parse the path from a globus URL e.g. https://app.globus.org/file-manager?&destination_id=f3e29605-7ba5-45f5-8900-f1234566&destination_path=/edsu/20230907044801
   def parse_path(uri)
     params = CGI.parse(URI.parse(uri).query)
     params['destination_path'].first

--- a/spec/models/globus_destination_spec.rb
+++ b/spec/models/globus_destination_spec.rb
@@ -14,21 +14,27 @@ RSpec.describe GlobusDestination do
 
   describe '#url' do
     it 'returns a globus url with the destination path' do
-      expect(globus_destination.url).to eq 'https://app.globus.org/file-manager?&destination_id=some-endpoint-uuid&destination_path=/globus/ima_user/20230921125959'
+      expect(globus_destination.url).to eq 'https://app.globus.org/file-manager?&destination_id=some-endpoint-uuid&destination_path=/ima_user/20230921125959'
     end
   end
 
   describe '#destination_path' do
     it 'returns the destination globus directory' do
-      expect(globus_destination.destination_path).to eq '/globus/ima_user/20230921125959'
+      expect(globus_destination.destination_path).to eq '/ima_user/20230921125959'
+    end
+  end
+
+  describe '#staging_location' do
+    it 'returns the globus staging location' do
+      expect(globus_destination.staging_location).to eq '/globus/ima_user/20230921125959'
     end
   end
 
   describe '#parse_path' do
-    let(:url) { 'https://app.globus.org/file-manager?&destination_id=some-endpoint-uuid&destination_path=/globus/ima_user/20230921125959' }
+    let(:url) { 'https://app.globus.org/file-manager?&destination_id=some-endpoint-uuid&destination_path=/ima_user/20230921125959' }
 
     it 'finds the destination_path' do
-      expect(globus_destination.parse_path(url)).to eq '/globus/ima_user/20230921125959'
+      expect(globus_destination.parse_path(url)).to eq '/ima_user/20230921125959'
     end
   end
 end


### PR DESCRIPTION
# Why was this change made? 🤔
Refs #1188. Adjusts the path in globus to not include the directory where globus is mounted. Adds staging_location method.

# How was this change tested? 🤨
Unit.