### PR TITLE
remove link to project from job runs list page

### DIFF
--- a/app/views/job_runs/_job_runs.html.erb
+++ b/app/views/job_runs/_job_runs.html.erb
@@ -1,9 +1,6 @@
 <% @job_runs.each do |job_run| %>
     <tr>
     <td><%= link_to "#{job_prefix}#{job_run.id}", job_run, data: { turbo_frame: "_top" } %></td>
-    <% if show_project %>
-        <td><%= link_to job_run.batch_context.project_name, batch_context_path(job_run.batch_context), data: { turbo_frame: "_top" } %></td>
-    <% end %>
     <td><%= job_run.job_type.humanize %></td>
     <td><%= job_run.batch_context.user.sunet_id %></td>
     <td><%= job_run.human_state_name %></td>

--- a/app/views/job_runs/index.html.erb
+++ b/app/views/job_runs/index.html.erb
@@ -6,7 +6,6 @@
     <thead>
       <tr class="table-secondary">
         <th scope="col">ID</th>
-        <th scope="col">Project</th>
         <th scope="col">Type</th>
         <th scope="col">Creator</th>
         <th scope="col">Status</th>
@@ -14,7 +13,7 @@
       </tr>
     </thead>
     <tbody>
-      <%= render 'job_runs', job_prefix: 'Job #', show_project: true %>
+      <%= render 'job_runs', job_prefix: 'Job #' %>
    </tbody>
   </table>
 

--- a/app/views/job_runs/recent_history.html.erb
+++ b/app/views/job_runs/recent_history.html.erb
@@ -12,7 +12,7 @@
           </th>
         </thead>
       <tbody id="job-history-table">
-        <%= render 'job_runs', job_prefix: '', show_project: false %>
+        <%= render 'job_runs', job_prefix: '' %>
        </tbody>
     </table>
   </div>


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #1298 - remove the links to the project from the list of job runs, it's too busy

# How was this change tested? 🤨

Localhost