### PR TITLE
Allow discovery report to handle unregistered items.

### DIFF
--- a/app/services/structural_files_differ.rb
+++ b/app/services/structural_files_differ.rb
@@ -10,6 +10,7 @@ class StructuralFilesDiffer
   # @param [String] staging_location - the location where the files for the batch are staged
   # @param [String] druid - the druid of the object, which corresponds to the directory name in the staging location
   # @return [Hash] hash containing arrays of added, deleted, and updated files
+  # @raise [Dor::Services::Client::NotFoundResponse] if the item has not been registered
   def self.diff(existing_structural:, new_structural:, staging_location:, druid:)
     new(existing_structural:,
         new_structural:,

--- a/spec/services/discovery_report_spec.rb
+++ b/spec/services/discovery_report_spec.rb
@@ -168,5 +168,29 @@ RSpec.describe DiscoveryReport do
         expect(report.summary).to include(objects_with_error: 0, total_size: 382_224)
       end
     end
+
+    context 'with item that is not registered' do
+      let(:content_structure) { 'simple_image' }
+
+      before do
+        allow(client_object).to receive(:find).and_raise(RuntimeError)
+      end
+
+      it 'to_builder gives expected output for one dobj omitting structural diff' do
+        report_json = JSON.parse(report.to_builder.target!)
+        expect(report_json['rows'].first.with_indifferent_access).to match(
+          druid: 'druid:jy812bp9403',
+          errors: {
+            wrong_content_structure: true,
+            dor_connection_error: true
+          },
+          counts: {
+            total_size: 127_401,
+            mimetypes: { 'image/tiff' => 2, 'image/jp2' => 1 },
+            filename_no_extension: 0
+          }
+        )
+      end
+    end
   end
 end

--- a/spec/services/object_file_validator_spec.rb
+++ b/spec/services/object_file_validator_spec.rb
@@ -16,10 +16,6 @@ RSpec.describe ObjectFileValidator do
 
     let(:object) { batch.un_pre_assembled_objects.first }
 
-    before do
-      allow(validator).to receive(:registration_check).and_return({}) # pretend everything is in Dor
-    end
-
     it 'converts a DigtialObject to structured data (Hash)' do
       expect(validator.validate.as_json).to match a_hash_including(
         counts: a_hash_including(total_size: 0),
@@ -58,6 +54,16 @@ RSpec.describe ObjectFileValidator do
 
       it 'adds missing_media_container_name_or_manifest error' do
         expect(json).to match a_hash_including(errors: a_hash_including(missing_media_container_name_or_manifest: true))
+      end
+    end
+
+    context 'dor services client does not find itm' do
+      before do
+        allow(dor_services_client_object).to receive(:find).and_raise(Dor::Services::Client::NotFoundResponse)
+      end
+
+      it 'adds item_not_registered error' do
+        expect(json).to match a_hash_including(errors: a_hash_including(item_not_registered: true))
       end
     end
   end


### PR DESCRIPTION
closes #1303

# Why was this change made? 🤔
The structure diffing assumed the object could be retrieved from dor-services-app.


# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit, stage

# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



