### PR TITLE
capitalize state name for display

### DIFF
--- a/app/views/job_mailer/completion_email.text.erb
+++ b/app/views/job_mailer/completion_email.text.erb
@@ -1,2 +1,2 @@
-Your <%= @job_run.job_type.humanize %> job #<%= @job_run.id %> finished with status '<%= @job_run.human_state_name %>'.
+Your <%= @job_run.job_type.humanize %> job #<%= @job_run.id %> finished with status '<%= @job_run.human_state_name.capitalize %>'.
 You can view the job details and log file at: <%= job_run_url(@job_run); %>

--- a/app/views/job_runs/_details.html.erb
+++ b/app/views/job_runs/_details.html.erb
@@ -19,7 +19,7 @@
         </tr>
         <tr>
             <td>State</td>
-            <td><%= @job_run.human_state_name %></td>
+            <td><%= @job_run.human_state_name.capitalize %></td>
         </tr>
         <% unless @job_run.error_message.blank? %>
             <tr>

--- a/app/views/job_runs/_job_runs.html.erb
+++ b/app/views/job_runs/_job_runs.html.erb
@@ -3,7 +3,7 @@
     <td><%= link_to "#{job_prefix}#{job_run.id}", job_run, data: { turbo_frame: "_top" } %></td>
     <td><%= job_run.job_type.humanize %></td>
     <td><%= job_run.batch_context.user.sunet_id %></td>
-    <td><%= job_run.human_state_name %></td>
+    <td><%= job_run.human_state_name.capitalize %></td>
     <td><%= job_run.created_at.in_time_zone('Pacific Time (US & Canada)').to_formatted_s(:long) %></td>
     </tr>
 <% end %>


### PR DESCRIPTION
# Why was this change made? 🤔

Make all state names appear the same.  Not sure why `.human_state_name` seemed to capitalize some, but not others.  This just makes them all start with a capital letter.

![Screen Shot 2023-09-25 at 10 56 39 AM](https://github.com/sul-dlss/pre-assembly/assets/47137/c3e92ea7-4034-41b1-9c31-c682fbd0c4a9)


# How was this change tested? 🤨

Localhost

