### PR TITLE
Remove error as separate job run state.

### DIFF
--- a/app/jobs/discovery_report_job.rb
+++ b/app/jobs/discovery_report_job.rb
@@ -11,12 +11,8 @@ class DiscoveryReportJob < ApplicationJob
     file = File.open(report.output_path, 'w') { |f| f << JSON.pretty_generate(JSON.parse(report.to_builder.target!)) }
     job_run.output_location = file.path
     job_run.save!
-    if report.objects_had_errors # individual objects processed had errors
-      job_run.error_message = report.error_message
-      job_run.completed_with_errors
-    else
-      job_run.completed
-    end
+    job_run.error_message = report.objects_had_errors ? report.error_message : nil
+    job_run.completed
   rescue StandardError => e # catch any error preventing the whole job from running (e.g. bad header in csv)
     job_run.error_message = e.exception
     job_run.failed

--- a/app/jobs/preassembly_job.rb
+++ b/app/jobs/preassembly_job.rb
@@ -7,12 +7,8 @@ class PreassemblyJob < ApplicationJob
     batch = job_run.batch
     # .run_pre_assembly iterates over all objects and runs preassembly on each
     batch.run_pre_assembly
-    if batch.objects_had_errors # individual objects processed had errors
-      job_run.error_message = batch.error_message
-      job_run.completed_with_errors
-    else
-      job_run.completed
-    end
+    job_run.error_message = batch.objects_had_errors ? batch.error_message : nil
+    job_run.completed
     # To avoid a possible race condition (all accessioning complete before job run is marked completed),
     # run JobrunCompleteJob.
     JobRunCompleteJob.perform_later(job_run)

--- a/db/migrate/20230925202808_update_job_run_state.rb
+++ b/db/migrate/20230925202808_update_job_run_state.rb
@@ -1,0 +1,25 @@
+class UpdateJobRunState < ActiveRecord::Migration[7.0]
+  def up
+    execute <<-SQL
+      UPDATE job_runs
+      SET state = 'discovery_report_complete'
+      WHERE state = 'discovery_report_complete_with_errors';
+
+      UPDATE job_runs
+      SET state = 'preassembly_complete'
+      WHERE state = 'preassembly_complete_with_errors';
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      UPDATE job_runs
+      SET state = 'discovery_report_complete_with_errors'
+      WHERE state = 'discovery_report_complete' AND error_message IS NOT NULL;
+
+      UPDATE job_runs
+      SET state = 'preassembly_complete_with_errors'
+      WHERE state = preassembly_complete' AND error_message IS NOT NULL;
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_20_123240) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_25_202808) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/spec/features/discovery_report/completed_with_errors_spec.rb
+++ b/spec/features/discovery_report/completed_with_errors_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Discovery Report completes with errors', :js do
     # go to job details page, wait for preassembly to finish
     first('td  > a').click
     expect(page).to have_content project_name
-    expect(page).to have_content 'Discovery report completed (with errors)'
+    expect(page).to have_content 'Discovery report completed (with preassembly errors)'
     expect(page).to have_content 'Errors'
     expect(page).to have_content '1 objects had errors in the discovery report'
     expect(page).to have_link('Download').twice

--- a/spec/jobs/discovery_report_job_spec.rb
+++ b/spec/jobs/discovery_report_job_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe DiscoveryReportJob do
         expect { job.perform(job_run) }.to change { File.exist?(outfile) }.to(true)
         expect(job_run.reload.output_location).to eq(outfile)
         expect(job_run).to be_discovery_report_complete
+        expect(job_run.with_preassembly_errors?).to be false
       end
     end
 
@@ -37,6 +38,7 @@ RSpec.describe DiscoveryReportJob do
         job.perform(job_run)
         expect(job_run).to be_failed
         expect(job_run.error_message).to eq error_message
+        expect(job_run.with_preassembly_errors?).to be true
       end
     end
 
@@ -49,8 +51,9 @@ RSpec.describe DiscoveryReportJob do
 
       it 'calls to_discovery_report and ends in a completed with error state, and saves error message to the database' do
         job.perform(job_run)
-        expect(job_run).to be_discovery_report_complete_with_errors
+        expect(job_run).to be_discovery_report_complete
         expect(job_run.error_message).to eq error_message
+        expect(job_run.with_preassembly_errors?).to be true
       end
     end
   end

--- a/spec/jobs/preassembly_job_spec.rb
+++ b/spec/jobs/preassembly_job_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe PreassemblyJob do
         job.perform(job_run)
         expect(job_run).to be_preassembly_complete
         expect(job_run.error_message).to be_nil
+        expect(job_run.with_preassembly_errors?).to be false
         expect(JobRunCompleteJob).to have_received(:perform_later).with(job_run)
       end
     end
@@ -43,6 +44,7 @@ RSpec.describe PreassemblyJob do
         job.perform(job_run)
         expect(job_run).to be_failed
         expect(job_run.error_message).to eq error_message
+        expect(job_run.with_preassembly_errors?).to be true
       end
     end
 
@@ -56,8 +58,9 @@ RSpec.describe PreassemblyJob do
       it 'calls run_pre_assembly and ends in a completed with error state, and saves error message to the database' do
         expect(batch).to receive(:run_pre_assembly)
         job.perform(job_run)
-        expect(job_run).to be_preassembly_complete_with_errors
+        expect(job_run).to be_preassembly_complete
         expect(job_run.error_message).to eq error_message
+        expect(job_run.with_preassembly_errors?).to be true
         expect(JobRunCompleteJob).to have_received(:perform_later).with(job_run)
       end
     end

--- a/spec/models/job_run_spec.rb
+++ b/spec/models/job_run_spec.rb
@@ -49,7 +49,8 @@ RSpec.describe JobRun do
       expect(JobMailer).to receive(:with).with(job_run:).and_return(mock_mailer)
       expect(mock_mailer).to receive(:completion_email).and_return(mock_delivery)
       expect(mock_delivery).to receive(:deliver_later)
-      job_run.completed_with_errors
+      job_run.error_message = 'something went wrong'
+      job_run.completed
     end
   end
 

--- a/spec/views/job_runs/show.html.erb_spec.rb
+++ b/spec/views/job_runs/show.html.erb_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe 'job_runs/show.html.erb' do
 
     it 'with a completed with errors job, presents a download link to the report and the log file' do
       job_run.started
-      job_run.completed_with_errors
+      job_run.error_message = 'Oops, that was bad.'
+      job_run.completed
       render template: 'job_runs/show'
       expect(rendered).to include("<a href=\"/job_runs/#{job_run.id}/download_log\">Download</a>")
       expect(rendered).to include("<a href=\"/job_runs/#{job_run.id}/download_report\">Download</a>")


### PR DESCRIPTION
closes #1301

# Why was this change made? 🤔
Make error state less confusing to users. This approach separates the presence of errors from the state.


# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit, Andrew

# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



