### PR TITLE
skip over druids that do not have any file differences

### DIFF
--- a/app/views/job_runs/_structural_updates_summary.html.erb
+++ b/app/views/job_runs/_structural_updates_summary.html.erb
@@ -10,14 +10,15 @@
     </thead>
     <tbody>
     <% druids.each do |druid| %>
+        <% next unless druid['file_diffs'] %>
         <% %w[added_files deleted_files updated_files].each do |status| %>
-        <% druid['file_diffs'][status]&.each do |filename| %>
-            <tr>
-            <td><%= druid['druid'] %></td>
-            <td><%= filename %></td>
-            <td><%= status.sub('_files', '').capitalize %></td>
-            </tr>
-        <% end %>
+          <% druid['file_diffs'][status]&.each do |filename| %>
+              <tr>
+              <td><%= druid['druid'] %></td>
+              <td><%= filename %></td>
+              <td><%= status.sub('_files', '').capitalize %></td>
+              </tr>
+          <% end %>
         <% end %>
     <% end %>
     </tbody>


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #1310 - if a discovery report has file differences but one druid does not have any, you would get an exception like below, which causes the view to not render at all in the turbo frame.  This fixes it by skipping over any druids in the report that do not have a file diffs section in the JSON.

```
  | Completed 500 Internal Server Error in 205ms (ActiveRecord: 4.5ms | Allocations: 7934)
15:25:30 web.1  |
15:25:30 web.1  |
15:25:30 web.1  |
15:25:30 web.1  | ActionView::Template::Error (undefined method `[]' for nil:NilClass):
15:25:30 web.1  |     11:     <tbody>
15:25:30 web.1  |     12:     <% druids.each do |druid| %>
15:25:30 web.1  |     13:         <% %w[added_files deleted_files updated_files].each do |status| %>
15:25:30 web.1  |     14:         <% druid['file_diffs'][status]&.each do |filename| %>
15:25:30 web.1  |     15:             <tr>
15:25:30 web.1  |     16:             <td><%= druid['druid'] %></td>
15:25:30 web.1  |     17:             <td><%= filename %></td>
15:25:30 web.1  |
15:25:30 web.1  | app/views/job_runs/_structural_updates_summary.html.erb:14
15:25:30 web.1  | app/views/job_runs/_structural_updates_summary.html.erb:13:in `each'
15:25:30 web.1  | app/views/job_runs/_structural_updates_summary.html.erb:13
15:25:30 web.1  | app/views/job_runs/_structural_updates_summary.html.erb:12:in `each'
15:25:30 web.1  | app/views/job_runs/_structural_updates_summary.html.erb:12
15:25:30 web.1  | app/views/job_runs/discovery_report_summary.html.erb:38
```
# How was this change tested? 🤨

Localhost (by taking the problematic report from stage, verifying the problem, and fixing it).