### PR TITLE
[HOLD] Transition job run to preassembly_complete_with_errors when all associated accessions failed

### DIFF
--- a/app/jobs/job_run_complete_job.rb
+++ b/app/jobs/job_run_complete_job.rb
@@ -3,9 +3,10 @@
 # Updates a JobRun if all Accessions are complete
 class JobRunCompleteJob < ApplicationJob
   def perform(job_run)
-    return if job_run.running?
-    return if job_run.accessioning_complete?
-    return if job_run.accessions.exists?(state: :in_progress)
+    return if job_run.running? ||
+              job_run.accessioning_complete? ||
+              job_run.accessions.empty? ||
+              job_run.accessions.exists?(state: :in_progress)
 
     job_run.accessioning_completed
   end

--- a/spec/jobs/job_run_complete_job_spec.rb
+++ b/spec/jobs/job_run_complete_job_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe JobRunCompleteJob do
     let(:accessions) { [completed_accession, failed_accession] }
     let(:state) { 'preassembly_complete' }
 
-    it 'transitions the job run to completed' do
+    it 'transitions the job run to accessioning_complete' do
       expect { job.perform(job_run) }.to change { job_run.reload.state }.from(state).to('accessioning_complete')
     end
   end
@@ -24,7 +24,7 @@ RSpec.describe JobRunCompleteJob do
     let(:accessions) { [completed_accession, failed_accession] }
     let(:state) { 'preassembly_complete_with_errors' }
 
-    it 'transitions the job run to completed' do
+    it 'transitions the job run to accessioning_complete' do
       expect { job.perform(job_run) }.to change { job_run.reload.state }.from(state).to('accessioning_complete')
     end
   end
@@ -50,6 +50,15 @@ RSpec.describe JobRunCompleteJob do
   context 'when started but preassembly not completed' do
     let(:accessions) { [completed_accession, failed_accession] }
     let(:state) { 'running' }
+
+    it 'does not change the state' do
+      expect { job.perform(job_run) }.not_to(change { job_run.reload.state })
+    end
+  end
+
+  context 'when no accessions exist' do
+    let(:accessions) { [] }
+    let(:state) { 'preassembly_complete' }
 
     it 'does not change the state' do
       expect { job.perform(job_run) }.not_to(change { job_run.reload.state })


### PR DESCRIPTION
# Why was this change made?

Fixes #1309

# How was this change tested?

- [x] CI
- [ ] QA/stage

# Does your change introduce accessibility violations?

No.
