### PR TITLE
Reformat projects show page to match job runs show

### DIFF
--- a/app/views/batch_contexts/_actions.html.erb
+++ b/app/views/batch_contexts/_actions.html.erb
@@ -1,14 +1,18 @@
-<div class="col-2">
-    <%= form_for(JobRun.new) do |form| %>
-    <%= form.hidden_field :batch_context_id, value: batch_context.id %>
-    <%= form.hidden_field :job_type, value: 'discovery_report' %>
-    <%= form.submit 'New Discovery Report', class: 'btn btn-outline' %>
-    <% end %>
-</div>
-<div class="col-2 text-end">
-    <%= form_for(JobRun.new) do |form| %>
-    <%= form.hidden_field :batch_context_id, value: batch_context.id %>
-    <%= form.hidden_field :job_type, value: 'preassembly' %>
-    <%= form.submit 'Run Preassembly', class: 'btn btn-sul-dlss' %>
-    <% end %>
+<div class="row justify-content-end">
+  <div class="hstack">
+    <div class="col-9 text-end">
+        <%= form_for(JobRun.new) do |form| %>
+        <%= form.hidden_field :batch_context_id, value: batch_context.id %>
+        <%= form.hidden_field :job_type, value: 'discovery_report' %>
+        <%= form.submit 'New Discovery Report', class: 'btn btn-outline' %>
+        <% end %>
+    </div>
+    <div class="col-3 text-end">
+        <%= form_for(JobRun.new) do |form| %>
+        <%= form.hidden_field :batch_context_id, value: batch_context.id %>
+        <%= form.hidden_field :job_type, value: 'preassembly' %>
+        <%= form.submit 'Run Preassembly', class: 'btn btn-sul-dlss' %>
+        <% end %>
+    </div>
+  </div>
 </div>

--- a/app/views/batch_contexts/_details.html.erb
+++ b/app/views/batch_contexts/_details.html.erb
@@ -1,0 +1,17 @@
+ <table class="table table-bordered">
+    <thead>
+        <tr class="table-secondary">
+            <th colspan="2">Details</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Created by</td>
+            <td><%= batch_context.user.sunet_id %></td>
+        </tr>
+        <tr>
+            <td>Created at</td>
+            <td><%= batch_context.created_at %></td>
+        </tr>
+    </tbody>
+</table>

--- a/app/views/batch_contexts/_jobs_summary.html.erb
+++ b/app/views/batch_contexts/_jobs_summary.html.erb
@@ -1,0 +1,23 @@
+    <div class="row mt-4">
+      <h5>Jobs summary</h5>
+      <table class="table">
+        <thead>
+          <tr>
+            <th>JobRun ID</th>
+            <th>Type</th>
+            <th>Created</th>
+            <th>State</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% job_runs.each do |job_run|%>
+            <tr>
+              <td><%= link_to(job_run.id, job_run) %></td>
+              <td><%= job_run.job_type.humanize %></td>
+              <td><%= job_run.created_at %></td>
+              <td><%= job_run.state.humanize %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>

--- a/app/views/batch_contexts/_settings.html.erb
+++ b/app/views/batch_contexts/_settings.html.erb
@@ -1,0 +1,25 @@
+ <table class="table table-bordered">
+    <thead>
+        <tr class="table-secondary">
+            <th colspan="2">Settings</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Content Structure</td>
+            <td><%= batch_context.content_structure %></td>
+        </tr>
+        <tr>
+            <td>Staging Location</td>
+            <td><%= batch_context.staging_location %></td>
+        </tr>
+        <tr>
+            <td>Processing configuration</td>
+            <td><%= batch_context.processing_configuration %></td>
+        </tr>
+        <tr>
+            <td>Using File Manifest</td>
+            <td><%= batch_context.using_file_manifest ? 'yes' : 'no' %></td>
+        </tr>
+    </tbody>
+</table>

--- a/app/views/batch_contexts/show.html.erb
+++ b/app/views/batch_contexts/show.html.erb
@@ -1,50 +1,22 @@
 <div class="container mt-5">
   <div class="row">
-    <div class="col">
-      <h1><%= @batch_context.project_name %> by <%= @batch_context.user.email %></h1>
+    <div class="col-6">
+      <h1>Project: <%= @batch_context.project_name %></h1>
     </div>
-  </div>
-  <div class="row p-1 pl-5">
-    <div class="hstack gap-2">
+    <div class="col-6 justify-content-end">
       <%= render partial: 'actions', locals: { batch_context: @batch_context } %>
     </div>
   </div>
-  <dl class="dl row">
-    <dt class="col-sm-3">Content Structure</dt>
-    <dd class="col-sm-9"><%= @batch_context.content_structure %></dd>
-    <dt class="col-sm-3">Staging Location</dt>
-    <dd class="col-sm-9"><%= @batch_context.staging_location %></dd>
-    <dt class="col-sm-3">Processing configuration</dt>
-    <dd class="col-sm-9"><%= @batch_context.processing_configuration %></dd>
-    <dt class="col-sm-3">Using File Manifest</dt>
-    <dd class="col-sm-9"><%= @batch_context.using_file_manifest ? 'yes' : 'no' %></dd>
-    <dt class="col-sm-3">Created At</dt>
-    <dd class="col-sm-9"><%= @batch_context.created_at %></dd>
-  </dl>
-  <% if @batch_context.job_runs.present? %>
-    <div class="row mt-4">
-      <h5>Jobs summary</h5>
-      <table class="table">
-        <thead>
-          <tr>
-            <th>JobRun ID</th>
-            <th>Type</th>
-            <th>Created</th>
-            <th>State</th>
-          </tr>
-        </thead>
-        <tbody>
-          <% @batch_context.job_runs.each do |job_run|%>
-            <tr>
-              <td><%= link_to(job_run.id, job_run) %></td>
-              <td><%= job_run.job_type.humanize %></td>
-              <td><%= job_run.created_at %></td>
-              <td><%= job_run.state.humanize %></td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
+  <div class="row p-1 pl-5">
+    <div class="col-6">
+      <%= render partial: 'settings', locals: { batch_context: @batch_context } %>
     </div>
+    <div class="col-6">
+      <%= render partial: 'details', locals: { batch_context: @batch_context } %>
+    </div>
+  </div>
+  <% if @batch_context.job_runs.present? %>
+    <%= render partial: 'jobs_summary', locals: { job_runs: @batch_context.job_runs } %>
   <% end %>
 
   <% if @batch_context.progress_log_file_exists? %>

--- a/spec/views/batch_contexts/show.html.erb_spec.rb
+++ b/spec/views/batch_contexts/show.html.erb_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'batch_contexts/show.html.erb' do
 
   it 'diplays BatchContext info' do
     render template: 'batch_contexts/show'
-    expect(rendered).to include("#{bc.project_name} by #{bc.user.email}")
+    expect(rendered).to include("Project: #{bc.project_name}")
     expect(rendered).to include('no')
   end
 


### PR DESCRIPTION
# Why was this change made? 🤔

Closes #1325 

This just changes the layout of the existing data.

Before:

![Screenshot 2023-09-29 at 1 07 46 PM](https://github.com/sul-dlss/pre-assembly/assets/2294288/dbdc7823-63c5-42d9-b495-f1bdaee02dcf)

After:

![Screenshot 2023-09-29 at 1 35 15 PM](https://github.com/sul-dlss/pre-assembly/assets/2294288/bd413bb7-f984-42ff-bc01-847f87bb0af6)


# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



