### PR TITLE
move structural updates summary to bottom of job run detail page

### DIFF
--- a/app/views/job_runs/discovery_report_summary.html.erb
+++ b/app/views/job_runs/discovery_report_summary.html.erb
@@ -35,8 +35,6 @@
         </tbody>
       </table>
 
-      <%= render partial: 'structural_updates_summary', locals: { druids: @discovery_report['rows'] } if @structural_has_changed %>
-
       <% if @discovery_report['summary']['objects_with_error'].any? %>
         <table class="table">
           <caption>Errors Summary</caption>
@@ -69,6 +67,8 @@
         </tbody>
         </table>
       <% end %>
+
+      <%= render partial: 'structural_updates_summary', locals: { druids: @discovery_report['rows'] } if @structural_has_changed %>
     </div>
   </div>
 </turbo-frame>


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #1334 - swap order of sections on job run page

![Screen Shot 2023-10-02 at 4 27 20 PM](https://github.com/sul-dlss/pre-assembly/assets/47137/5cd9dda9-17c7-472e-b677-e6ca4d097aa6)


# How was this change tested? 🤨

Localhost