### PR TITLE
change subject lines of completion emails

### DIFF
--- a/app/mailers/job_mailer.rb
+++ b/app/mailers/job_mailer.rb
@@ -6,9 +6,15 @@ class JobMailer < ApplicationMailer
   def completion_email
     @job_run = params[:job_run]
     @user = @job_run.batch_context.user
+
+    # This email is sent when either (1) a discovery report completes, or (2) a preassembly job ends with errors
+    # If the preassembly job completes with no errors (and items are accessioning), a separate email is instead sent
+    # when accessioning is complete.
+    @subject = "[#{@job_run.batch_context.project_name}] Your #{@job_run.job_type.humanize} job "
+    @subject += @job_run.job_type == 'preassembly' ? 'encountered an error' : 'completed'
     mail(
       to: @user.email,
-      subject: "[#{@job_run.batch_context.project_name}] Your #{@job_run.job_type.humanize} job completed"
+      subject: @subject
     )
   end
 
@@ -19,7 +25,7 @@ class JobMailer < ApplicationMailer
     @failed_accessions = @job_run.accessions.where(state: 'failed')
     mail(
       to: @user.email,
-      subject: "[#{@job_run.batch_context.project_name}] Accessioning completed"
+      subject: "[#{@job_run.batch_context.project_name}] Job completed"
     )
   end
 end

--- a/spec/mailers/job_mailer_spec.rb
+++ b/spec/mailers/job_mailer_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe JobMailer do
       let(:job_run) { create(:job_run, :preassembly, state: 'preassembly_complete') }
 
       it 'renders the headers' do
-        expect(job_notification.subject).to eq('[Test_Project] Your Preassembly job completed')
+        expect(job_notification.subject).to eq('[Test_Project] Your Preassembly job encountered an error')
       end
     end
   end
@@ -43,7 +43,7 @@ RSpec.describe JobMailer do
     end
 
     it 'renders the headers' do
-      expect(job_notification.subject).to eq('[Test_Project] Accessioning completed')
+      expect(job_notification.subject).to eq('[Test_Project] Job completed')
       expect(job_notification.to).to eq([job_run.batch_context.user.email])
       expect(job_notification.from).to eq(['no-reply-preassembly-job@stanford.edu'])
     end


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #1335 and fixes #1336 - change the subject line of emails sent when jobs complete

# How was this change tested? 🤨

CI