### PR TITLE
Display Globus errors

### DIFF
--- a/app/controllers/globus_controller.rb
+++ b/app/controllers/globus_controller.rb
@@ -9,13 +9,18 @@ class GlobusController < ApplicationController
 
   def create
     @user = current_user
-    @dest = GlobusDestination.create(user: @user)
-    create_globus_endpoint
-
-    render status: :created, json: {
-      url: @dest.url,
-      location: @dest.staging_location
-    }
+    if @user.globus_destinations.where(deleted_at: nil).count >= 99
+      render status: :bad_request, json: {
+        error: 'You have too many Globus shares. Please contact sdr-contact@lists.stanford.edu for help.'
+      }
+    else
+      @dest = GlobusDestination.create(user: @user)
+      create_globus_endpoint
+      render status: :created, json: {
+        url: @dest.url,
+        location: @dest.staging_location
+      }
+    end
   end
 
   private

--- a/app/javascript/controllers/globus_controller.js
+++ b/app/javascript/controllers/globus_controller.js
@@ -9,13 +9,15 @@ export default class extends Controller {
 
     const response = await fetch('/globus', {method: 'post'})
 
-    if (response.ok) {
+    if (response.status == 201) {
       const dest = await response.json()
       this.setFinishedRequest(dest)
       this.setDestination(dest)
+    } else if (response.status == 400) {
+      const resp = await response.json()
+      this.setRequestError(resp.error)
     } else {
-      console.log('Unable to create Globus Destination:', response)
-      throw new Error('Unable to create Globus Destination')
+      this.setRequestError('Unexpected Globus Error!')
     }
   }
 
@@ -23,7 +25,7 @@ export default class extends Controller {
     // update the Staging location with the Globus URL
     this.stagingLocationTarget.value = dest.url
 
-    // open a new tab witht the Globus Viewer URL in it
+    // open a new tab with the Globus Viewer URL in it
     window.open(dest.url)
   }
 
@@ -38,5 +40,13 @@ export default class extends Controller {
     link.href = dest.url
     link.text = 'Your Globus Link'
     this.requestGlobusLinkTarget.replaceWith(link)
+  }
+
+  setRequestError(msg) {
+    const span = document.createElement('span')
+    span.id = 'globus-error'
+    span.classList.add('text-danger')
+    span.innerText = msg
+    this.requestGlobusLinkTarget.replaceWith(span)
   }
 }

--- a/spec/features/batch_context/globus_spec.rb
+++ b/spec/features/batch_context/globus_spec.rb
@@ -41,4 +41,27 @@ RSpec.describe 'Use Globus staging location', :js do
     expect(BatchContext.count).to eq(1)
     expect(BatchContext.all[0].globus_destination).to eq(globus_dest)
   end
+
+  it 'disallows creation when there are >= 99 active GlobusDestinations' do
+    99.times do
+      GlobusDestination.create(user:, deleted_at: nil)
+    end
+
+    # make sure they can't create any more
+    visit '/'
+    click_button 'Request Globus Link'
+    expect(find_by_id('globus-error')).to have_content('You have too many Globus shares. Please contact sdr-contact@lists.stanford.edu for help.')
+    expect(GlobusDestination.count).to eq(99)
+  end
+
+  it 'allows creation when there are >= 99 inactive GlobusDestinations' do
+    101.times do
+      GlobusDestination.create(user:, deleted_at: DateTime.now)
+    end
+
+    # make sure they can still create
+    visit '/'
+    click_button 'Request Globus Link'
+    expect(GlobusDestination.count).to eq(102)
+  end
 end


### PR DESCRIPTION
# Why was this change made? 🤔

Adjust the globus controller to check how many globus destinations a
user has already prior to creating another one. If they have 99 or more
the controller returns an JSON error message with 400 status code.

The Stimulus controller checks the response and replaces the Create
Globus Link button with the error message if it's a 400. If it's another
type of error (potentially a 500 error with no JSON body) it uses the
generic message 'Unexpected Globus Error'.

closes #1340

# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



