### PR TITLE
show globus links on batch_context show and index pages

### DIFF
--- a/app/models/batch_context.rb
+++ b/app/models/batch_context.rb
@@ -97,6 +97,12 @@ class BatchContext < ApplicationRecord
     staging_location_with_path(FILE_MANIFEST_FILE_NAME)
   end
 
+  def active_globus_url
+    return nil unless globus_destination.present? && globus_destination.deleted_at.blank?
+
+    globus_destination.url
+  end
+
   private
 
   def object_manifest_path

--- a/app/views/batch_contexts/_settings.html.erb
+++ b/app/views/batch_contexts/_settings.html.erb
@@ -11,7 +11,12 @@
         </tr>
         <tr>
             <td>Staging Location</td>
-            <td><%= batch_context.staging_location %></td>
+            <td>
+                <%= batch_context.staging_location %>
+                <% if batch_context.globus_destination %>
+                    <br /><%= link_to batch_context.globus_destination.url, batch_context.globus_destination.url %>
+                <% end %>
+            </td>
         </tr>
         <tr>
             <td>Processing configuration</td>

--- a/app/views/batch_contexts/_settings.html.erb
+++ b/app/views/batch_contexts/_settings.html.erb
@@ -13,8 +13,8 @@
             <td>Staging Location</td>
             <td>
                 <%= batch_context.staging_location %>
-                <% if batch_context.globus_destination %>
-                    <br /><%= link_to batch_context.globus_destination.url, batch_context.globus_destination.url %>
+                <% if batch_context.active_globus_url %>
+                    <br /><%= link_to batch_context.active_globus_url, batch_context.active_globus_url %>
                 <% end %>
             </td>
         </tr>

--- a/app/views/batch_contexts/index.html.erb
+++ b/app/views/batch_contexts/index.html.erb
@@ -24,8 +24,8 @@
           <td><%= batch_context.content_structure %></td>
           <td>
             <%= batch_context.staging_location %>
-            <% if batch_context.globus_destination %>
-              <br /><%= link_to 'globus link', batch_context.globus_destination.url %>
+            <% if batch_context.active_globus_url %>
+              <br /><%= link_to 'globus link', batch_context.active_globus_url %>
             <% end %>
           </td>
           <td><%= batch_context.processing_configuration %></td>

--- a/app/views/batch_contexts/index.html.erb
+++ b/app/views/batch_contexts/index.html.erb
@@ -22,7 +22,12 @@
           <td><%= link_to batch_context.project_name, batch_context %></td>
           <td><%= batch_context.user.email %></td>
           <td><%= batch_context.content_structure %></td>
-          <td><%= batch_context.staging_location %></td>
+          <td>
+            <%= batch_context.staging_location %>
+            <% if batch_context.globus_destination %>
+              <br /><%= link_to 'globus link', batch_context.globus_destination.url %>
+            <% end %>
+          </td>
           <td><%= batch_context.processing_configuration %></td>
           <td><%= batch_context.using_file_manifest ? 'yes' : 'no' %></td>
           <td><%= batch_context.job_runs.count %></td>

--- a/spec/factories/batch_contexts.rb
+++ b/spec/factories/batch_contexts.rb
@@ -37,5 +37,9 @@ FactoryBot.define do
     trait :using_file_manifest do
       with_file_manifest { true }
     end
+
+    trait :with_globus_destination do
+      globus_destination
+    end
   end
 end

--- a/spec/factories/batch_contexts.rb
+++ b/spec/factories/batch_contexts.rb
@@ -41,5 +41,9 @@ FactoryBot.define do
     trait :with_globus_destination do
       globus_destination
     end
+
+    trait :with_deleted_globus_destination do
+      globus_destination { association :globus_destination, :deleted }
+    end
   end
 end

--- a/spec/factories/globus_destination.rb
+++ b/spec/factories/globus_destination.rb
@@ -8,5 +8,9 @@ FactoryBot.define do
     trait :with_batch_context do
       batch_context
     end
+
+    trait :deleted do
+      deleted_at { Time.zone.now }
+    end
   end
 end

--- a/spec/models/batch_context_spec.rb
+++ b/spec/models/batch_context_spec.rb
@@ -131,9 +131,33 @@ RSpec.describe BatchContext do
     end
   end
 
-  describe 'output_dir' do
+  describe '#output_dir' do
     it 'returns "Settings.job_output_parent_dir/user_id/project_name"' do
       expect(bc.output_dir).to eq "#{Settings.job_output_parent_dir}/#{bc.user.email}/#{bc.project_name}"
+    end
+  end
+
+  describe '#active_globus_url' do
+    context 'when no globus_destination' do
+      it 'is nil' do
+        expect(bc.active_globus_url).to be_nil
+      end
+    end
+
+    context 'when active globus_destination' do
+      let(:bc) { build(:batch_context_with_deleted_output_dir, :with_globus_destination) }
+
+      it 'returns the url' do
+        expect(bc.active_globus_url).to eq bc.globus_destination.url
+      end
+    end
+
+    context 'when deleted globus_destination' do
+      let(:bc) { build(:batch_context_with_deleted_output_dir, :with_deleted_globus_destination) }
+
+      it 'is nil' do
+        expect(bc.active_globus_url).to be_nil
+      end
     end
   end
 

--- a/spec/views/batch_contexts/index.html.erb_spec.rb
+++ b/spec/views/batch_contexts/index.html.erb_spec.rb
@@ -2,15 +2,27 @@
 
 RSpec.describe 'batch_contexts/index.html.erb' do
   let!(:batch_contexts) { create_list(:batch_context_with_deleted_output_dir, 2) }
-  let!(:batch_context_with_globus) { create(:batch_context_with_deleted_output_dir, :with_globus_destination) }
-  let(:globus_url) { "https://app.globus.org/file-manager?&amp;destination_id=endpoint_uuid&amp;destination_path=#{batch_context_with_globus.globus_destination.destination_path}" }
 
-  it 'displays a list of batch_contexts' do
-    assign(:batch_contexts, BatchContext.all.page(1))
-    render template: 'batch_contexts/index'
-    expect(rendered).to include(batch_contexts[0].project_name)
-    expect(rendered).to include(batch_contexts[1].project_name)
-    expect(rendered).to include(batch_context_with_globus.project_name)
-    expect(rendered).to include("<a href=\"#{globus_url}\">globus link</a>")
+  context 'with active globus destination' do
+    let!(:batch_context_with_globus) { create(:batch_context_with_deleted_output_dir, :with_globus_destination) }
+
+    it 'displays a list of batch_contexts with a globus link' do
+      assign(:batch_contexts, BatchContext.all.page(1))
+      render template: 'batch_contexts/index'
+      expect(rendered).to include(batch_contexts[0].project_name)
+      expect(rendered).to include(batch_contexts[1].project_name)
+      expect(rendered).to include(batch_context_with_globus.project_name)
+      expect(rendered).to include("<a href=\"#{batch_context_with_globus.globus_destination.url.gsub('&', '&amp;')}\">globus link</a>")
+    end
+  end
+
+  context 'with no active globus destination' do
+    it 'displays a list of batch_contexts without globus link' do
+      assign(:batch_contexts, BatchContext.all.page(1))
+      render template: 'batch_contexts/index'
+      expect(rendered).to include(batch_contexts[0].project_name)
+      expect(rendered).to include(batch_contexts[1].project_name)
+      expect(rendered).not_to include('globus link')
+    end
   end
 end

--- a/spec/views/batch_contexts/index.html.erb_spec.rb
+++ b/spec/views/batch_contexts/index.html.erb_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.describe 'batch_contexts/index.html.erb' do
+  let!(:batch_contexts) { create_list(:batch_context_with_deleted_output_dir, 2) }
+  let!(:batch_context_with_globus) { create(:batch_context_with_deleted_output_dir, :with_globus_destination) }
+  let(:globus_url) { "https://app.globus.org/file-manager?&amp;destination_id=endpoint_uuid&amp;destination_path=#{batch_context_with_globus.globus_destination.destination_path}" }
+
+  it 'displays a list of batch_contexts' do
+    assign(:batch_contexts, BatchContext.all.page(1))
+    render template: 'batch_contexts/index'
+    expect(rendered).to include(batch_contexts[0].project_name)
+    expect(rendered).to include(batch_contexts[1].project_name)
+    expect(rendered).to include(batch_context_with_globus.project_name)
+    expect(rendered).to include("<a href=\"#{globus_url}\">globus link</a>")
+  end
+end

--- a/spec/views/batch_contexts/show.html.erb_spec.rb
+++ b/spec/views/batch_contexts/show.html.erb_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'batch_contexts/show.html.erb' do
     render template: 'batch_contexts/show'
     expect(rendered).to include("Project: #{bc.project_name}")
     expect(rendered).to include('no')
-    expect(rendered).to include("https://app.globus.org/file-manager?&amp;destination_id=endpoint_uuid&amp;destination_path=#{bc.globus_destination.destination_path}")
+    expect(rendered).to include("<a href=\"#{bc.globus_destination.url.gsub('&', '&amp;')}\">")
   end
 
   it 'has buttons for new Jobs' do
@@ -32,6 +32,15 @@ RSpec.describe 'batch_contexts/show.html.erb' do
       expect(rendered).to include("<a href=\"/job_runs/#{job_run.id}\">#{job_run.id}</a>")
       expect(rendered).to include('<td>Discovery report</td>')
       expect(rendered).to include('<td>Waiting</td>')
+    end
+  end
+
+  context 'when globus link deleted' do
+    let(:bc) { create(:batch_context_with_deleted_output_dir, :with_deleted_globus_destination) }
+
+    it 'does not render globus link' do
+      render template: 'batch_contexts/show'
+      expect(rendered).not_to include("<a href=\"#{bc.globus_destination.url.gsub('&', '&amp;')}\">")
     end
   end
 end

--- a/spec/views/batch_contexts/show.html.erb_spec.rb
+++ b/spec/views/batch_contexts/show.html.erb_spec.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
 RSpec.describe 'batch_contexts/show.html.erb' do
-  let(:bc) { create(:batch_context_with_deleted_output_dir) }
+  let(:bc) { create(:batch_context_with_deleted_output_dir, :with_globus_destination) }
 
   before { assign(:batch_context, bc) }
 
-  it 'diplays BatchContext info' do
+  it 'displays BatchContext info' do
     render template: 'batch_contexts/show'
     expect(rendered).to include("Project: #{bc.project_name}")
     expect(rendered).to include('no')
+    expect(rendered).to include("https://app.globus.org/file-manager?&amp;destination_id=endpoint_uuid&amp;destination_path=#{bc.globus_destination.destination_path}")
   end
 
   it 'has buttons for new Jobs' do


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #1276 - display the globus URL in batch_context show and index pages.

Note that the index page would get cluttered with long URLs shown in browser, so I switched to showing "globus link" in that case (see below).  Also note that this doesn't affect the Job Run page (which also shows some batch context details)... we could add it there too, or in fact, just consolidate the partials so they are always the same.  This is done in #1347 (which would then add the globus link to the settings part of the job runs detail too automatically).

![Screen Shot 2023-10-04 at 4 14 20 PM](https://github.com/sul-dlss/pre-assembly/assets/47137/b878c015-0d3d-4559-aa61-9e018d5da16d)

![Screen Shot 2023-10-04 at 4 14 23 PM](https://github.com/sul-dlss/pre-assembly/assets/47137/9474569a-0f10-4de2-bee6-663fb130e70d)

# How was this change tested? 🤨

Localhost and new tests