### PR TITLE
Switch to delivering mail now.

### DIFF
--- a/app/models/job_run.rb
+++ b/app/models/job_run.rb
@@ -120,10 +120,10 @@ class JobRun < ApplicationRecord
     # Only send if preassembly and has errors.
     return if preassembly? && !with_preassembly_errors?
 
-    JobMailer.with(job_run: self).completion_email.deliver_later
+    JobMailer.with(job_run: self).completion_email.deliver_now
   end
 
   def send_accessioning_notification
-    JobMailer.with(job_run: self).accession_completion_email.deliver_later
+    JobMailer.with(job_run: self).accession_completion_email.deliver_now
   end
 end

--- a/spec/models/job_run_spec.rb
+++ b/spec/models/job_run_spec.rb
@@ -34,21 +34,21 @@ RSpec.describe JobRun do
     it 'sends a notification email when job_run completes' do
       expect(JobMailer).to receive(:with).with(job_run:).and_return(mock_mailer)
       expect(mock_mailer).to receive(:completion_email).and_return(mock_delivery)
-      expect(mock_delivery).to receive(:deliver_later)
+      expect(mock_delivery).to receive(:deliver_now)
       job_run.completed
     end
 
     it 'sends a notification email when job_run fails' do
       expect(JobMailer).to receive(:with).with(job_run:).and_return(mock_mailer)
       expect(mock_mailer).to receive(:completion_email).and_return(mock_delivery)
-      expect(mock_delivery).to receive(:deliver_later)
+      expect(mock_delivery).to receive(:deliver_now)
       job_run.failed
     end
 
     it 'sends a notification email when job_run completes with errors' do
       expect(JobMailer).to receive(:with).with(job_run:).and_return(mock_mailer)
       expect(mock_mailer).to receive(:completion_email).and_return(mock_delivery)
-      expect(mock_delivery).to receive(:deliver_later)
+      expect(mock_delivery).to receive(:deliver_now)
       job_run.error_message = 'something went wrong'
       job_run.completed
     end
@@ -62,7 +62,7 @@ RSpec.describe JobRun do
     it 'sends a notification email when accessioning completes' do
       expect(JobMailer).to receive(:with).with(job_run:).and_return(mock_mailer)
       expect(mock_mailer).to receive(:accession_completion_email).and_return(mock_delivery)
-      expect(mock_delivery).to receive(:deliver_later)
+      expect(mock_delivery).to receive(:deliver_now)
       job_run.accessioning_completed
     end
   end


### PR DESCRIPTION
closes #1345

# Why was this change made? 🤔
To avoid probable race condition in which email was being created before job run object was persisted.


# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



