### PR TITLE
Use globus endpoint id to extract path from URL

### DIFF
--- a/app/models/globus_destination.rb
+++ b/app/models/globus_destination.rb
@@ -6,13 +6,11 @@ class GlobusDestination < ApplicationRecord
   belongs_to :user
   after_initialize :set_directory
 
-  # A helper to look up the GlobusDestination object using a Globus URL
+  # A helper to look up the GlobusDestination object using a Globus URL.
+  # @param url [String] a Globus URL
+  # @return [GlobusDestination, nil] the GlobusDestination found or nil
   def self.find_with_globus_url(url)
-    uri = URI.parse(url)
-    return unless uri.query
-
-    params = CGI.parse(uri.query)
-    path = params['destination_path'].first
+    path = extract_path(url)
     return unless path
 
     _, sunet_id, directory = path.split('/')
@@ -20,22 +18,43 @@ class GlobusDestination < ApplicationRecord
     GlobusDestination.find_by(user:, directory:)
   end
 
-  # creates a URL for globus, including the path to the user's destination directory
+  # Extract the path from either destination_path or origin_path depending on
+  # whether origin_id or destination_id has the configured globus-endpoint-id.
+  # This allows users to paste in a Globus viewer URL that they may have been
+  # emailed which flips around the destination_path to the origin_path, and also
+  # will find when they may have flipped the origin/destination in the viewer.
+  # @param url [String] a Globus URL
+  # @return [String, nil] the path value, or nil if not found
+  def self.extract_path(url)
+    uri = URI.parse(url)
+    return unless uri.query
+
+    params = CGI.parse(uri.query)
+    endpoint_param = if params['origin_id']&.first == Settings.globus.endpoint_id
+                       'origin_path'
+                     else
+                       'destination_path'
+                     end
+
+    params[endpoint_param]&.first
+  end
+
+  # Creates a URL for globus, including the path to the user's destination directory
   def url
     "https://app.globus.org/file-manager?&destination_id=#{Settings.globus.endpoint_id}&destination_path=#{destination_path}"
   end
 
-  # directory within globus including user directory in the format /sunet/datetime
+  # Get the directory within globus including user directory in the format /sunet/datetime
   def destination_path
     "/#{user.sunet_id}/#{directory}"
   end
 
-  # path on preassembly filesystem to staged files
+  # Get the path on preassembly filesystem to staged files
   def staging_location
     "#{Settings.globus.directory}#{destination_path}"
   end
 
-  # when not explicitly set the directory name is generated from the current time
+  # Set the default directory name using current time (when not already set)
   def set_directory
     self.directory = DateTime.now.strftime('%Y-%m-%d-%H-%M-%S-%L') unless directory
   end

--- a/spec/models/globus_destination_spec.rb
+++ b/spec/models/globus_destination_spec.rb
@@ -38,6 +38,8 @@ RSpec.describe GlobusDestination do
   end
 
   describe '#find_with_globus_url' do
+    subject(:globus_destination) { build(:globus_destination, user:, directory: '2023-09-21-12-59-59-123') }
+
     let(:found) { described_class.find_with_globus_url(url) }
 
     before do
@@ -45,12 +47,28 @@ RSpec.describe GlobusDestination do
       globus_destination.save
     end
 
-    context 'with correct Globus URL' do
+    context 'with our globus viewer url' do
       let(:url) { globus_destination.url }
 
       it 'finds object' do
         expect(found).not_to be_nil
         expect(found.user.sunet_id).to eq('ima_user')
+      end
+    end
+
+    context 'with the url globus sends in email' do
+      let(:url) { 'https://app.globus.org/file-manager?&origin_id=some-endpoint-uuid&origin_path=/ima_user/2023-09-21-12-59-59-123/&add_identity=d28a330f-9d3c-4832-950c-492fb7771a9e' }
+
+      it 'finds object' do
+        expect(found).not_to be_nil
+      end
+    end
+
+    context 'with a emailed globus url after navigation' do
+      let(:url) { 'https://app.globus.org/file-manager?&origin_id=some-endpoint-uuid&origin_path=/ima_user/2023-09-21-12-59-59-123/&destination_id=my-laptop&destination_path=/my/dir&add_identity=d28a330f-9d3c-4832-950c-492fb7771a9e' }
+
+      it 'finds object' do
+        expect(found).not_to be_nil
       end
     end
 


### PR DESCRIPTION
# Why was this change made? 🤔

Depending on how the user arrives at Globus (either from Preassembly, or from the Globus email, or navigating directly themselves) the Globus path embedded in the URL could be in either the `destination_path` or
`origin_path` parameters.

This commit adds the ability to use the Globus Destination ID configured in app settings to infer where to look for the Globus path.

Fixes #1333

# How was this change tested? 🤨

- [x] unit tests
- [x] integration tests

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



