### PR TITLE
Remove trailing whitespace when copying location

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -81,3 +81,12 @@
     margin-bottom: 0.5rem;
     margin-top: 0;
   }
+
+  .copy-button {
+    margin-left: 10px;
+  }
+
+  .copy-nowrap {
+    white-space: nowrap;
+    overflow: hidden;
+  }

--- a/app/javascript/controllers/copy_controller.js
+++ b/app/javascript/controllers/copy_controller.js
@@ -1,0 +1,20 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = {
+    clip: String
+  }
+
+  copy(event) {
+    navigator.clipboard.writeText(this.clipValue)
+    event.preventDefault()
+
+    const popover = new bootstrap.Popover(event.target, {
+      content: 'Copied.',
+      placement: 'top',
+      trigger: 'manual'
+    })
+    popover.show()
+    setTimeout(function() { popover.dispose() }, 1500)
+  }
+}

--- a/app/views/batch_contexts/_settings.html.erb
+++ b/app/views/batch_contexts/_settings.html.erb
@@ -11,12 +11,7 @@
         </tr>
         <tr>
             <td>Staging Location</td>
-            <td>
-                <%= batch_context.staging_location %>
-                <% if batch_context.active_globus_url %>
-                    <br /><%= link_to batch_context.active_globus_url, batch_context.active_globus_url %>
-                <% end %>
-            </td>
+            <td><%= batch_context.staging_location -%><% if batch_context.active_globus_url %><br /><%= link_to batch_context.active_globus_url, batch_context.active_globus_url %><% end %></td>
         </tr>
         <tr>
             <td>Processing configuration</td>

--- a/app/views/batch_contexts/_settings.html.erb
+++ b/app/views/batch_contexts/_settings.html.erb
@@ -11,7 +11,12 @@
         </tr>
         <tr>
             <td>Staging Location</td>
-            <td><%= batch_context.staging_location -%><% if batch_context.active_globus_url %><br /><%= link_to batch_context.active_globus_url, batch_context.active_globus_url %><% end %></td>
+            <td><div class="copy-nowrap"><%= batch_context.staging_location %>
+                <a class="copy-button" data-controller="copy" data-copy-clip-value="<%= batch_context.staging_location %>" data-action="copy#copy" aria-label="Copy staging location" href=""><span class="fas fa-copy"></span></a></div>
+                <% if batch_context.active_globus_url %>
+                    <%= link_to 'Globus', batch_context.active_globus_url, target: 'blank' %>
+                <% end %>
+            </td>
         </tr>
         <tr>
             <td>Processing configuration</td>

--- a/spec/views/batch_contexts/show.html.erb_spec.rb
+++ b/spec/views/batch_contexts/show.html.erb_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'batch_contexts/show.html.erb' do
     render template: 'batch_contexts/show'
     expect(rendered).to include("Project: #{bc.project_name}")
     expect(rendered).to include('no')
-    expect(rendered).to include("<a href=\"#{bc.globus_destination.url.gsub('&', '&amp;')}\">")
+    expect(rendered).to include('Globus')
   end
 
   it 'has buttons for new Jobs' do
@@ -40,7 +40,7 @@ RSpec.describe 'batch_contexts/show.html.erb' do
 
     it 'does not render globus link' do
       render template: 'batch_contexts/show'
-      expect(rendered).not_to include("<a href=\"#{bc.globus_destination.url.gsub('&', '&amp;')}\">")
+      expect(rendered).not_to include('Globus')
     end
   end
 end


### PR DESCRIPTION
# Why was this change made? 🤔
Mostly resolves #1352. Whitespace will no longer get added to copied staging location text with the exception of Chrome when there is also a Globus URL.

<img width="627" alt="Screenshot 2023-10-06 at 11 32 51 AM" src="https://github.com/sul-dlss/pre-assembly/assets/1619369/80d7aab6-db6f-4984-afc3-61e6a913cda9">

# How was this change tested? 🤨
Local deploy

# Does your change introduce accessibility violations? 🩺
VoiceOver doesn't indicate any content reading changes.


