### PR TITLE
add cleanup job for globus destinations

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -13,6 +13,7 @@ require 'capistrano/passenger'
 require 'capistrano/rails'
 require 'capistrano/rvm' # need this for ubuntu
 require 'dlss/capistrano'
+require 'whenever/capistrano'
 
 # Loads custom tasks from `lib/capistrano/tasks' if you have any defined.
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'sneakers', '~> 2.11' # rabbitMQ background processing
 gem 'state_machines-activerecord'
 gem 'stimulus-rails'
 gem 'turbo-rails', '~> 1.1'
+gem 'whenever', require: false
 
 # Stanford gems
 gem 'assembly-objectfile', '~> 2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    chronic (0.10.2)
     cocina-models (0.91.2)
       activesupport
       deprecation
@@ -526,6 +527,8 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.12)
@@ -583,6 +586,7 @@ DEPENDENCIES
   state_machines-activerecord
   stimulus-rails
   turbo-rails (~> 1.1)
+  whenever
 
 BUNDLED WITH
    2.4.13

--- a/app/models/globus_destination.rb
+++ b/app/models/globus_destination.rb
@@ -9,7 +9,7 @@ class GlobusDestination < ApplicationRecord
   scope :active, -> { where(deleted_at: nil) }
   scope :older_than, ->(time) { where('created_at < ?', time) }
 
-  # A helper method to find Globus Destinations to cleanup
+  # A helper method to find potential Globus Destinations to cleanup (will also depend on accessioning status)
   def self.find_stale
     active.older_than(1.week.ago)
   end

--- a/app/models/globus_destination.rb
+++ b/app/models/globus_destination.rb
@@ -6,6 +6,14 @@ class GlobusDestination < ApplicationRecord
   belongs_to :user
   after_initialize :set_directory
 
+  scope :active, -> { where(deleted_at: nil) }
+  scope :older_than, ->(time) { where('created_at < ?', time) }
+
+  # A helper method to find Globus Destinations to cleanup
+  def self.find_stale
+    active.older_than(1.week.ago)
+  end
+
   # A helper to look up the GlobusDestination object using a Globus URL.
   # @param url [String] a Globus URL
   # @return [GlobusDestination, nil] the GlobusDestination found or nil
@@ -15,7 +23,7 @@ class GlobusDestination < ApplicationRecord
 
     _, sunet_id, directory = path.split('/')
     user = User.find_by(sunet_id:)
-    GlobusDestination.find_by(user:, directory:)
+    find_by(user:, directory:)
   end
 
   # Extract the path from either destination_path or origin_path depending on

--- a/app/services/globus_cleanup.rb
+++ b/app/services/globus_cleanup.rb
@@ -4,7 +4,7 @@
 # Run regularly via cron, scheduled with whenever gem
 class GlobusCleanup
   def self.run
-    GlobusDestination.find_stale do |dest|
+    GlobusDestination.find_stale.each do |dest|
       next unless dest.batch_context.job_runs.any?(&:accessioning_complete?)
 
       cleanup_destination(dest)
@@ -14,10 +14,10 @@ class GlobusCleanup
     end
   end
 
-  # Delete the given globus destination
+  # Delete the given globus destination access rule and mark as deleted locally
   def self.cleanup_destination(dest)
-    GlobusClient.delete_access_rule(path: dest.destination_path, user_id: "#{dest.batch_context.user.sunet_id}@stanford.edu")
+    user_id = "#{dest.user.sunet_id}@stanford.edu"
+    GlobusClient.delete_access_rule(path: dest.destination_path, user_id:)
     dest.update!(deleted_at: Time.zone.now)
   end
-  private_class_method :cleanup_destination
 end

--- a/app/services/globus_cleanup.rb
+++ b/app/services/globus_cleanup.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Removes globus access rules for completed accessioning jobs
+# Run regularly via cron, scheduled with whenever gem
+class GlobusCleanup
+  def self.run
+    GlobusDestination.find_stale do |dest|
+      next unless dest.batch_context.job_runs.any?(&:accessioning_complete?)
+
+      cleanup_destination(dest)
+      Rails.logger.info("GlobusCleanup done for batch_context #{dest.batch_context.id}, globus_destination #{dest.id})")
+    rescue StandardError => e # catch any "Access rule not found" errors from Globus
+      Honeybadger.notify(e, context: { message: 'GlobusCleanup failed', globus_destination_id: dest.id, batch_context_id: dest.batch_context.id })
+    end
+  end
+
+  # Delete the given globus destination
+  def self.cleanup_destination(dest)
+    GlobusClient.delete_access_rule(path: dest.destination_path, user_id: "#{dest.batch_context.user.sunet_id}@stanford.edu")
+    dest.update!(deleted_at: Time.zone.now)
+  end
+  private_class_method :cleanup_destination
+end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -39,6 +39,8 @@ set :sidekiq_systemd_use_hooks, true
 # Manage sneakers via systemd (from dlss-capistrano gem)
 set :sneakers_systemd_use_hooks, true
 
+set :whenever_identifier, -> { "#{fetch(:application)}_#{fetch(:stage)}" }
+
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Learn more: http://github.com/javan/whenever
+require_relative 'environment'
+
+set :output, 'log/cron.log'
+
+# These define jobs that checkin with Honeybadger.
+# If changing the schedule of one of these jobs, also update at https://app.honeybadger.io/projects/52900/check_ins
+job_type :runner_hb,
+         'cd :path && bin/rails runner -e :environment ":task" :output && curl --silent https://api.honeybadger.io/v1/check_in/:check_in'
+
+# extract and then load everything into the database
+every 1.day, at: '1:00am' do
+  set :check_in, Settings.honeybadger_checkins.globus_cleanup
+  runner_hb 'GlobusCleanup.run'
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -27,10 +27,15 @@ rabbitmq:
   username: guest
   password: guest
 
-globus: 
+globus:
   enabled: false
   directory: '/globus'
   endpoint_id: endpoint_uuid
   client_id: client_id
   client_secret: client_secret
   test_mode: false # if test_mode=true, simulates the globus endpoint creation
+
+# checkin identifiers for honeybadger (actual identifiers are in shared_configs per environment as needed)
+# see https://app.honeybadger.io/projects/52900/check_ins
+honeybadger_checkins:
+  globus_cleanup: nil

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -38,4 +38,4 @@ globus:
 # checkin identifiers for honeybadger (actual identifiers are in shared_configs per environment as needed)
 # see https://app.honeybadger.io/projects/52900/check_ins
 honeybadger_checkins:
-  globus_cleanup: nil
+  globus_cleanup: ~

--- a/lib/tasks/globus.rake
+++ b/lib/tasks/globus.rake
@@ -4,7 +4,7 @@ namespace :globus do
   desc 'Delete Globus access rules and empty directories'
   task :prune_access, [:sunet_id] => :environment do |_task, args|
     sunet_id = args[:sunet_id]
-    globus_destinations = GlobusDestination.where(user: User.find_by(sunet_id:))
+    globus_destinations = GlobusDestination.joins(:user).where(user: { sunet_id: args[:sunet_id] })
     puts "No GlobusDestinations found for #{sunet_id}" if globus_destinations.empty?
     globus_destinations.each do |dest|
       next if dest.deleted_at.present?

--- a/spec/factories/batch_contexts.rb
+++ b/spec/factories/batch_contexts.rb
@@ -45,5 +45,9 @@ FactoryBot.define do
     trait :with_deleted_globus_destination do
       globus_destination { association :globus_destination, :deleted }
     end
+
+    trait :with_stale_globus_destination do
+      globus_destination { association :globus_destination, :stale }
+    end
   end
 end

--- a/spec/factories/globus_destination.rb
+++ b/spec/factories/globus_destination.rb
@@ -12,5 +12,10 @@ FactoryBot.define do
     trait :deleted do
       deleted_at { Time.zone.now }
     end
+
+    trait :stale do
+      created_at { 1.month.ago }
+      deleted_at { nil }
+    end
   end
 end

--- a/spec/factories/job_runs.rb
+++ b/spec/factories/job_runs.rb
@@ -14,5 +14,9 @@ FactoryBot.define do
       job_type { 'discovery_report' }
       output_location { '/path/to/report' }
     end
+
+    trait :accessioning_complete do
+      state { 'accessioning_complete' }
+    end
   end
 end

--- a/spec/models/globus_destination_spec.rb
+++ b/spec/models/globus_destination_spec.rb
@@ -80,4 +80,15 @@ RSpec.describe GlobusDestination do
       end
     end
   end
+
+  describe '.stale' do
+    let(:stale_destinations) { described_class.find_stale }
+    let(:active_globus_destination) { create(:globus_destination, user:, created_at: 1.day.ago) }
+    let(:stale_globus_destination) { create(:globus_destination, :stale, user:) }
+
+    it 'returns only stale globus_desintation' do
+      expect(stale_destinations).to include(stale_globus_destination)
+      expect(stale_destinations).not_to include(active_globus_destination)
+    end
+  end
 end

--- a/spec/services/globus_cleanup_spec.rb
+++ b/spec/services/globus_cleanup_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe GlobusCleanup do
+  let(:user) { create(:user, sunet_id: 'ima_user') }
+
+  let!(:job_run) { create(:job_run, :preassembly) }
+  let!(:job_run_complete) { create(:job_run, :preassembly, :accessioning_complete) }
+
+  describe '.run' do
+    before do
+      allow(described_class).to receive(:cleanup_destination)
+      create(:globus_destination, user:, batch_context: job_run.batch_context, created_at: 1.day.ago)
+      create(:globus_destination, user:, batch_context: job_run.batch_context, created_at: 1.month.ago)
+    end
+
+    context 'when no complete accessioning jobs' do
+      before { create(:globus_destination, :stale, user:, batch_context: job_run.batch_context) }
+
+      it 'does not delete any globus destinations' do
+        described_class.run
+        expect(described_class).not_to have_received(:cleanup_destination)
+      end
+    end
+
+    context 'when one complete accessioning job' do
+      let!(:stale_globus_destination) { create(:globus_destination, :stale, user:, batch_context: job_run_complete.batch_context) }
+
+      it 'deletes stale globus destination' do
+        described_class.run
+        expect(described_class).to have_received(:cleanup_destination).once.with(stale_globus_destination)
+      end
+    end
+  end
+
+  describe '.cleanup_destination' do
+    let(:stale_globus_destination) { create(:globus_destination, :stale, user:, batch_context: job_run.batch_context) }
+
+    before { allow(GlobusClient).to receive(:delete_access_rule) }
+
+    it 'marks destination as deleted and deletes access rule' do
+      expect(stale_globus_destination.deleted_at).to be_nil
+      described_class.cleanup_destination(stale_globus_destination)
+      expect(GlobusClient).to have_received(:delete_access_rule).once
+      expect(stale_globus_destination.deleted_at).not_to be_nil
+    end
+  end
+end

--- a/spec/services/globus_cleanup_spec.rb
+++ b/spec/services/globus_cleanup_spec.rb
@@ -29,6 +29,20 @@ RSpec.describe GlobusCleanup do
         described_class.run
         expect(described_class).to have_received(:cleanup_destination).once.with(stale_globus_destination)
       end
+
+      context 'when cleanup_destination throws an error' do
+        before do
+          allow(described_class).to receive(:cleanup_destination).and_raise(StandardError)
+          allow(Honeybadger).to receive(:notify)
+        end
+
+        it 'notifies honeybadger' do
+          described_class.run
+          expect(Honeybadger).to have_received(:notify).with(StandardError,
+                                                             context: { message: 'GlobusCleanup failed', globus_destination_id: stale_globus_destination.id,
+                                                                        batch_context_id: stale_globus_destination.batch_context.id })
+        end
+      end
     end
   end
 


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #1189 - job to cleanup globus destinations

See https://github.com/sul-dlss/shared_configs/pull/2078 for the HB checkin key for prod

~~Question: do we still need `lib/tasks/globus.rake` after this done?~~ yes we do

# How was this change tested? 🤨

Updated tests
Tested in QA