### PR TITLE
Globus feature flag

### DIFF
--- a/app/views/batch_contexts/_new_bc_form.erb
+++ b/app/views/batch_contexts/_new_bc_form.erb
@@ -6,7 +6,9 @@
         <h3>Complete the form below</h3>
     </div>
     <div class="col" style="text-align: right;">
-      <button class="btn btn-sul-dlss" data-globus-target="requestGlobusLink" data-action="click->globus#createDestination">Request Globus Link</button>
+      <% if Settings.globus.enabled %>
+        <button class="btn btn-sul-dlss" data-globus-target="requestGlobusLink" data-action="click->globus#createDestination">Request Globus Link</button>
+      <% end %>
     </div>
 </div>
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -28,6 +28,7 @@ rabbitmq:
   password: guest
 
 globus: 
+  enabled: false
   directory: '/globus'
   endpoint_id: endpoint_uuid
   client_id: client_id

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,2 +1,5 @@
 # writable directory where job run artifacts will live
 job_output_parent_dir:  'log/test_jobs'
+
+globus:
+  enabled: true


### PR DESCRIPTION
# Why was this change made? 🤔

Don't display the Request Globus Link button if Settings.globus.enabled is false. It defaults to false, and will be enabled in QA and Stage as shared_configs PRs.

Fixes #1357

# How was this change tested? 🤨

Local dev.

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



