### PR TITLE
Control wrapping of location

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -83,10 +83,13 @@
   }
 
   .copy-button {
-    margin-left: 10px;
+    margin: 0 10px 0 5px;
   }
 
   .copy-nowrap {
     white-space: nowrap;
-    overflow: hidden;
+  }
+
+  .staging-location {
+    white-space: normal;
   }

--- a/app/views/batch_contexts/_settings.html.erb
+++ b/app/views/batch_contexts/_settings.html.erb
@@ -11,8 +11,7 @@
         </tr>
         <tr>
             <td>Staging Location</td>
-            <td><div class="copy-nowrap"><%= batch_context.staging_location %>
-                <a class="copy-button" data-controller="copy" data-copy-clip-value="<%= batch_context.staging_location %>" data-action="copy#copy" aria-label="Copy staging location" href=""><span class="fas fa-copy"></span></a></div>
+            <td><div class="copy-nowrap"><span class="staging-location"><%= batch_context.staging_location %></span><a class="copy-button" data-controller="copy" data-copy-clip-value="<%= batch_context.staging_location %>" data-action="copy#copy" aria-label="Copy staging location" href=""><span class="fas fa-copy"></span></a></div>
                 <% if batch_context.active_globus_url %>
                     <%= link_to 'Globus', batch_context.active_globus_url, target: 'blank' %>
                 <% end %>


### PR DESCRIPTION
# Why was this change made? 🤔
Resolves #1361 to not overflow table cell with long staging locations. HOLD in case @andrewjbtw would like to see it with various staging locations in QA/stage. 

Will break the path to fit in the cell:
![Screenshot 2023-10-11 at 10 55 45 AM](https://github.com/sul-dlss/pre-assembly/assets/1619369/094fd956-9ef3-4920-a77d-3b7e91b2b62d)

![Screenshot 2023-10-11 at 10 55 54 AM](https://github.com/sul-dlss/pre-assembly/assets/1619369/a5efc007-6312-4867-9b1c-c78520e4fa07)

If a path is just short enough that it fits but the copy icon does not, in Chrome (but not Firefox) it looks like this:
![Screenshot 2023-10-11 at 10 55 29 AM](https://github.com/sul-dlss/pre-assembly/assets/1619369/3e42f7d6-085d-4834-98b4-ef2a4dfc1d2e)

Example reported by @andrewjbtw, now fixed:
![Screenshot 2023-10-11 at 11 09 53 AM](https://github.com/sul-dlss/pre-assembly/assets/1619369/234cf427-ed65-4aea-bac9-04b5932207f0)



# How was this change tested? 🤨
Local. 

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



