### PR TITLE
connect batch context to globus destination via path

### DIFF
--- a/app/controllers/batch_contexts_controller.rb
+++ b/app/controllers/batch_contexts_controller.rb
@@ -19,9 +19,10 @@ class BatchContextsController < ApplicationController
   def create
     params = batch_contexts_params
 
-    # allow the staging location to be a Globus URL
-    if params[:staging_location].start_with?('https://')
-      globus_dest = GlobusDestination.find_with_globus_url(params[:staging_location])
+    # allow the staging location to be a previously created Globus URL or a Globus destination path
+    # and then it connects it to the BatchContext being created
+    if params[:staging_location].start_with?('https://') || params[:staging_location].start_with?(Settings.globus.directory)
+      globus_dest = GlobusDestination.find_with_globus_url(params[:staging_location]) || GlobusDestination.find_with_globus_path(params[:staging_location])
       params[:staging_location] = globus_dest.staging_location if globus_dest
       params[:globus_destination] = globus_dest
     end

--- a/app/models/globus_destination.rb
+++ b/app/models/globus_destination.rb
@@ -26,6 +26,18 @@ class GlobusDestination < ApplicationRecord
     find_by(user:, directory:)
   end
 
+  # A helper to look up the GlobusDestination object using a Globus destination path.
+  # @param url [String] a Globus path
+  # @return [GlobusDestination, nil] the GlobusDestination found or nil
+  def self.find_with_globus_path(path)
+    return unless path.start_with?(Settings.globus.directory)
+
+    # the second delete_prefix is just in case the configured Settings.globus.directory has no trailing slash
+    sunet_id, directory = path.delete_prefix(Settings.globus.directory).delete_prefix('/').split('/')
+    user = User.find_by(sunet_id:)
+    find_by(user:, directory:)
+  end
+
   # Extract the path from either destination_path or origin_path depending on
   # whether origin_id or destination_id has the configured globus-endpoint-id.
   # This allows users to paste in a Globus viewer URL that they may have been

--- a/spec/models/globus_destination_spec.rb
+++ b/spec/models/globus_destination_spec.rb
@@ -51,8 +51,7 @@ RSpec.describe GlobusDestination do
       let(:url) { globus_destination.url }
 
       it 'finds object' do
-        expect(found).not_to be_nil
-        expect(found.user.sunet_id).to eq('ima_user')
+        expect(found).to eq globus_destination
       end
     end
 
@@ -68,12 +67,39 @@ RSpec.describe GlobusDestination do
       let(:url) { 'https://app.globus.org/file-manager?&origin_id=some-endpoint-uuid&origin_path=/ima_user/2023-09-21-12-59-59-123/&destination_id=my-laptop&destination_path=/my/dir&add_identity=d28a330f-9d3c-4832-950c-492fb7771a9e' }
 
       it 'finds object' do
-        expect(found).not_to be_nil
+        expect(found).to eq globus_destination
       end
     end
 
     context 'with invalid Globus URL' do
       let(:url) { 'https://example.com' }
+
+      it 'does not find' do
+        expect(found).to be_nil
+      end
+    end
+  end
+
+  describe '#find_with_globus_path' do
+    subject(:globus_destination) { build(:globus_destination, user:, directory: '2023-09-21-12-59-59-123') }
+
+    let(:found) { described_class.find_with_globus_path(path) }
+
+    before do
+      user.save
+      globus_destination.save
+    end
+
+    context 'with our full globus destination path' do
+      let(:path) { globus_destination.staging_location }
+
+      it 'finds object' do
+        expect(found).to eq globus_destination
+      end
+    end
+
+    context 'with invalid globus destination path' do
+      let(:path) { '/other/path' }
 
       it 'does not find' do
         expect(found).to be_nil


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #1368 - if a user creates a Globus Destination and then has a validation error, the "Staging location" will show the full path and not the URL anymore.  When they submit the job, the globus destination will then not be connected to the batch context.  This fixes it by allowing the batch context to be connected to a globus destination either via globus URL or destination path.

~~[HOLD] for testing on QA~~

# How was this change tested? 🤨

New integration test.
QA