### PR TITLE
cleanup unused and disconnected globus destinations

### DIFF
--- a/app/models/batch_context.rb
+++ b/app/models/batch_context.rb
@@ -103,6 +103,11 @@ class BatchContext < ApplicationRecord
     globus_destination.url
   end
 
+  # helper method to check if any associated job_runs have completed accessioning
+  def accessioning_complete?
+    job_runs.present? && job_runs.any?(&:accessioning_complete?)
+  end
+
   private
 
   def object_manifest_path

--- a/app/models/globus_destination.rb
+++ b/app/models/globus_destination.rb
@@ -9,9 +9,9 @@ class GlobusDestination < ApplicationRecord
   scope :active, -> { where(deleted_at: nil) }
   scope :older_than, ->(time) { where('created_at < ?', time) }
 
-  # A helper method to find potential Globus Destinations to cleanup (will also depend on accessioning status)
-  def self.find_stale
-    active.older_than(1.week.ago)
+  # A helper method to find potential Globus Destinations to cleanup
+  def self.find_stale(timeframe)
+    active.older_than(timeframe)
   end
 
   # A helper to look up the GlobusDestination object using a Globus URL.

--- a/app/services/globus_cleanup.rb
+++ b/app/services/globus_cleanup.rb
@@ -14,9 +14,6 @@ class GlobusCleanup
       next unless dest.batch_context&.accessioning_complete?
 
       cleanup_destination(dest)
-      Rails.logger.info("GlobusCleanup done for batch_context #{dest.batch_context.id}, globus_destination #{dest.id})")
-    rescue StandardError => e # catch any "Access rule not found" errors from Globus
-      Honeybadger.notify(e, context: { message: 'GlobusCleanup failed', globus_destination_id: dest.id, batch_context_id: dest.batch_context.id })
     end
   end
 
@@ -26,9 +23,6 @@ class GlobusCleanup
       next if dest.batch_context.present?
 
       cleanup_destination(dest)
-      Rails.logger.info("GlobusCleanup done for globus_destination #{dest.id})")
-    rescue StandardError => e # catch any "Access rule not found" errors from Globus
-      Honeybadger.notify(e, context: { message: 'GlobusCleanup failed', globus_destination_id: dest.id })
     end
   end
 
@@ -37,5 +31,8 @@ class GlobusCleanup
     user_id = "#{dest.user.sunet_id}@stanford.edu"
     GlobusClient.delete_access_rule(path: dest.destination_path, user_id:)
     dest.update!(deleted_at: Time.zone.now)
+    Rails.logger.info("GlobusCleanup done for globus_destination #{dest.id})")
+  rescue StandardError => e # catch any "Access rule not found" errors from Globus
+    Honeybadger.notify(e, context: { message: 'GlobusCleanup failed', globus_destination_id: dest.id })
   end
 end

--- a/spec/factories/batch_contexts.rb
+++ b/spec/factories/batch_contexts.rb
@@ -45,9 +45,5 @@ FactoryBot.define do
     trait :with_deleted_globus_destination do
       globus_destination { association :globus_destination, :deleted }
     end
-
-    trait :with_stale_globus_destination do
-      globus_destination { association :globus_destination, :stale }
-    end
   end
 end

--- a/spec/factories/globus_destination.rb
+++ b/spec/factories/globus_destination.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
     end
 
     trait :stale do
-      created_at { 1.month.ago }
+      created_at { 2.months.ago }
       deleted_at { nil }
     end
   end

--- a/spec/models/batch_context_spec.rb
+++ b/spec/models/batch_context_spec.rb
@@ -137,6 +137,33 @@ RSpec.describe BatchContext do
     end
   end
 
+  describe '#accessioning_complete?' do
+    context 'when no associated job_runs' do
+      it 'is false' do
+        expect(bc.job_runs.present?).to be false
+        expect(bc.accessioning_complete?).to be false
+      end
+    end
+
+    context 'when no completed job_runs' do
+      before { create(:job_run, :preassembly, batch_context: bc, state: 'running') }
+
+      it 'is false' do
+        expect(bc.job_runs.present?).to be true
+        expect(bc.accessioning_complete?).to be false
+      end
+    end
+
+    context 'when completed job_runs' do
+      before { create(:job_run, :preassembly, batch_context: bc, state: 'accessioning_complete') }
+
+      it 'is true' do
+        expect(bc.job_runs.present?).to be true
+        expect(bc.accessioning_complete?).to be true
+      end
+    end
+  end
+
   describe '#active_globus_url' do
     context 'when no globus_destination' do
       it 'is nil' do

--- a/spec/models/globus_destination_spec.rb
+++ b/spec/models/globus_destination_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe GlobusDestination do
   end
 
   describe '.stale' do
-    let(:stale_destinations) { described_class.find_stale }
+    let(:stale_destinations) { described_class.find_stale(1.week.ago) }
     let(:active_globus_destination) { create(:globus_destination, user:, created_at: 1.day.ago) }
     let(:stale_globus_destination) { create(:globus_destination, :stale, user:) }
 

--- a/spec/services/globus_cleanup_spec.rb
+++ b/spec/services/globus_cleanup_spec.rb
@@ -8,16 +8,47 @@ RSpec.describe GlobusCleanup do
 
   describe '.run' do
     before do
-      allow(described_class).to receive(:cleanup_destination)
-      create(:globus_destination, user:, batch_context: job_run.batch_context, created_at: 1.day.ago)
-      create(:globus_destination, user:, batch_context: job_run.batch_context, created_at: 1.month.ago)
+      allow(described_class).to receive(:cleanup_stale_completed)
+      allow(described_class).to receive(:cleanup_stale_unused)
     end
+
+    it 'calls both cleanup methods' do
+      described_class.run
+      expect(described_class).to have_received(:cleanup_stale_completed)
+      expect(described_class).to have_received(:cleanup_stale_unused)
+    end
+  end
+
+  describe '.cleanup_stale_completed' do
+    before { allow(described_class).to receive(:cleanup_destination) }
 
     context 'when no complete accessioning jobs' do
       before { create(:globus_destination, :stale, user:, batch_context: job_run.batch_context) }
 
       it 'does not delete any globus destinations' do
-        described_class.run
+        described_class.cleanup_stale_completed
+        expect(described_class).not_to have_received(:cleanup_destination)
+      end
+    end
+
+    context 'when one complete accessioning job more than 1 week old' do
+      let!(:stale_globus_destination) { create(:globus_destination, :stale, user:, batch_context: job_run_complete.batch_context) }
+
+      it 'deletes stale globus destination' do
+        described_class.cleanup_stale_completed
+        expect(described_class).to have_received(:cleanup_destination).once.with(stale_globus_destination)
+      end
+    end
+  end
+
+  describe '.cleanup_stale_unused' do
+    before { allow(described_class).to receive(:cleanup_destination) }
+
+    context 'when no unused globus destination' do
+      before { create(:globus_destination, :stale, user:, batch_context: job_run.batch_context) }
+
+      it 'does not delete any globus destinations' do
+        described_class.cleanup_stale_unused
         expect(described_class).not_to have_received(:cleanup_destination)
       end
     end
@@ -26,31 +57,8 @@ RSpec.describe GlobusCleanup do
       let!(:disconnected_stale_globus_destination) { create(:globus_destination, :stale, user:, batch_context: nil) }
 
       it 'deletes stale globus destination' do
-        described_class.run
+        described_class.cleanup_stale_unused
         expect(described_class).to have_received(:cleanup_destination).once.with(disconnected_stale_globus_destination)
-      end
-    end
-
-    context 'when one complete accessioning job more than 1 week old' do
-      let!(:stale_globus_destination) { create(:globus_destination, :stale, user:, batch_context: job_run_complete.batch_context) }
-
-      it 'deletes stale globus destination' do
-        described_class.run
-        expect(described_class).to have_received(:cleanup_destination).once.with(stale_globus_destination)
-      end
-
-      context 'when cleanup_destination throws an error' do
-        before do
-          allow(described_class).to receive(:cleanup_destination).and_raise(StandardError)
-          allow(Honeybadger).to receive(:notify)
-        end
-
-        it 'notifies honeybadger' do
-          described_class.run
-          expect(Honeybadger).to have_received(:notify).with(StandardError,
-                                                             context: { message: 'GlobusCleanup failed', batch_context_id: stale_globus_destination.batch_context.id,
-                                                                        globus_destination_id: stale_globus_destination.id })
-        end
       end
     end
   end
@@ -58,13 +66,29 @@ RSpec.describe GlobusCleanup do
   describe '.cleanup_destination' do
     let(:stale_globus_destination) { create(:globus_destination, :stale, user:, batch_context: job_run.batch_context) }
 
-    before { allow(GlobusClient).to receive(:delete_access_rule) }
+    context 'when GlobusClient returns a response' do
+      before { allow(GlobusClient).to receive(:delete_access_rule) }
 
-    it 'marks destination as deleted and deletes access rule' do
-      expect(stale_globus_destination.deleted_at).to be_nil
-      described_class.cleanup_destination(stale_globus_destination)
-      expect(GlobusClient).to have_received(:delete_access_rule).once
-      expect(stale_globus_destination.deleted_at).not_to be_nil
+      it 'marks destination as deleted and deletes access rule' do
+        expect(stale_globus_destination.deleted_at).to be_nil
+        described_class.cleanup_destination(stale_globus_destination)
+        expect(GlobusClient).to have_received(:delete_access_rule).once
+        expect(stale_globus_destination.deleted_at).not_to be_nil
+      end
+    end
+
+    context 'when GlobusClient throws an error' do
+      before do
+        allow(GlobusClient).to receive(:delete_access_rule).and_raise(StandardError)
+        allow(Honeybadger).to receive(:notify)
+      end
+
+      it 'notifies honeybadger' do
+        described_class.cleanup_destination(stale_globus_destination)
+        expect(Honeybadger).to have_received(:notify).with(StandardError,
+                                                           context: { message: 'GlobusCleanup failed',
+                                                                      globus_destination_id: stale_globus_destination.id })
+      end
     end
   end
 end


### PR DESCRIPTION
# Why was this change made? 🤔

Previous work in #1354 cleans up Globus destinations that were created more than 1 week ago for completed accessioning jobs .  Discussion with Andrew indicates we should also cleanup disconnected Globus destinations that are more than 1 month old.  These are destinations that were created but for which an associated job was never even created.

This PR adds that second form of cleanup to the first.

There is also a previously created rake task that clears ALL Globus destinations for a specific user, but the hope is that this is a last resort that would not be needed if we perform these automated cleanups.  See https://github.com/sul-dlss/pre-assembly/blob/main/lib/tasks/globus.rake

~~HOLD for testing on QA~~

# How was this change tested? 🤨

New specs and tested on QA