### PR TITLE
Align gis staging paths with existing pre-assembly structure

### DIFF
--- a/app/lib/pre_assembly/assembly_directory.rb
+++ b/app/lib/pre_assembly/assembly_directory.rb
@@ -21,14 +21,8 @@ module PreAssembly
     end
 
     # @return [String] the base druid tree folder for this object
-    # for geo objects, we do not have a full druid tree
-    # for all other objects, we do have a full druid tree
     def druid_tree_dir
-      @druid_tree_dir ||= if content_structure == 'geo' # /staging/area/ab123bc4567
-                            File.join(assembly_staging_dir, DruidTools::Druid.new(druid_id, assembly_staging_dir).id)
-                          else # /staging/area/ab/123/bc/4567/ab123bc4567
-                            DruidTools::Druid.new(druid_id, assembly_staging_dir).path
-                          end
+      @druid_tree_dir ||= DruidTools::Druid.new(druid_id, assembly_staging_dir).path
     end
 
     def create_object_directories
@@ -57,11 +51,7 @@ module PreAssembly
 
     # @return [String] the content subfolder
     def content_dir
-      @content_dir ||= if content_structure == 'geo'
-                         File.join(druid_tree_dir, 'temp')
-                       else
-                         File.join(druid_tree_dir, 'content')
-                       end
+      @content_dir ||= File.join(druid_tree_dir, 'content')
     end
   end
 end

--- a/spec/features/preassembly_run/geo_spec.rb
+++ b/spec/features/preassembly_run/geo_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Pre-assemble geo object' do
   let(:project_name) { "pdf-#{RandomWord.nouns.next}" }
   let(:staging_location) { Rails.root.join('spec/fixtures/geo') }
   let(:bare_druid) { 'gn330dv6119' }
-  let(:object_staging_dir) { Rails.root.join(Settings.gis_assembly_staging_dir, bare_druid) } # no druid tree for geo objects
+  let(:object_staging_dir) { Rails.root.join(DruidTools::Druid.new(bare_druid, Settings.gis_assembly_staging_dir).path) }
   let(:dro_access) { { view: 'world' } }
   let(:item) do
     Cocina::RSpec::Factories.build(:dro, type: Cocina::Models::ObjectType.geo).new(access: dro_access)
@@ -53,7 +53,7 @@ RSpec.describe 'Pre-assemble geo object' do
     expect(yaml[:status]).to eq 'success'
 
     # we got all the expected content files
-    expect(Dir.children(File.join(object_staging_dir, 'temp')).size).to eq 2
+    expect(Dir.children(File.join(object_staging_dir, 'content')).size).to eq 2
 
     expect(PreAssembly::FromStagingLocation::StructuralBuilder).to have_received(:build)
       .with(cocina_dro: item,

--- a/spec/lib/pre_assembly/assembly_directory_spec.rb
+++ b/spec/lib/pre_assembly/assembly_directory_spec.rb
@@ -38,17 +38,17 @@ RSpec.describe PreAssembly::AssemblyDirectory do
 
     describe '#druid_tree_dir' do
       it 'has the correct folders (using the geo style)' do
-        expect(object.druid_tree_dir).to eq('tmp/gisassembly/gn330dv6119')
+        expect(object.druid_tree_dir).to eq('tmp/gisassembly/gn/330/dv/6119/gn330dv6119')
       end
     end
 
     describe '#path_for' do
       it 'has the correct path for a file in the root of the folder' do
-        expect(object.path_for('/staging_path/file.txt')).to eq('tmp/gisassembly/gn330dv6119/temp/file.txt')
+        expect(object.path_for('/staging_path/file.txt')).to eq('tmp/gisassembly/gn/330/dv/6119/gn330dv6119/content/file.txt')
       end
 
       it 'has the correct path for a file in a subfolder' do
-        expect(object.path_for('/staging_path/some_folder/file.txt')).to eq('tmp/gisassembly/gn330dv6119/temp/some_folder/file.txt')
+        expect(object.path_for('/staging_path/some_folder/file.txt')).to eq('tmp/gisassembly/gn/330/dv/6119/gn330dv6119/content/some_folder/file.txt')
       end
     end
   end


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #1410 by removing the machinery that cares about gis `temp` and druid directories in favor of the standard druid trees and `content` path. The remaining GIS specific code is required in order to start `gisAssemblyWF` instead of accessioning.

# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



