### PR TITLE
[HOLD] Switch :root to .btn to fix color contrast regression

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -1,18 +1,17 @@
  .btn {
     --cardinal-red: #8c1515;
     /* cardinal-red from https://identity.stanford.edu/design-elements/color/primary-colors/ */
-    --bs-btn-color: #fff;
   }
 
   .btn-sul-dlss {
     background-color: var(--cardinal-red);
-    color: var(--bs-btn-color);
+    --bs-btn-color: #fff;
+    --bs-btn-hover-bg: var(--cardinal-red);
+    --bs-btn-hover-color: #fff;
   }
 
   .btn-sul-dlss:hover {
-    background-color: var(--cardinal-red);
     filter: brightness(85%);
-    color: var(--bs-btn-color);
   }
 
   .brand {

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -1,4 +1,4 @@
- :root {
+ .btn {
     --cardinal-red: #8c1515;
     /* cardinal-red from https://identity.stanford.edu/design-elements/color/primary-colors/ */
     --bs-btn-color: #fff;
@@ -10,6 +10,7 @@
   }
 
   .btn-sul-dlss:hover {
+    background-color: var(--cardinal-red);
     filter: brightness(85%);
     color: var(--bs-btn-color);
   }


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #1424 

![Screenshot 2024-04-10 at 8 47 54 AM](https://github.com/sul-dlss/pre-assembly/assets/2294288/8b5fc1f2-4549-417f-923e-2c30562090b5)

https://github.com/twbs/bootstrap/commit/9a1f4ed9e5cba6424247928b786858edd38223da is believed to have caused the change described in the ticket. This switches `:root` to `.btn` to apply the correct css styling.

# How was this change tested? 🤨

stage review

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



