### PR TITLE
Remove unnecessary capistrano setting

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -23,9 +23,8 @@ set :deploy_to, '/opt/app/preassembly/pre-assembly'
 # Default value for :log_level is :debug
 # set :log_level, :debug
 
-# need this for ubuntu and resque-pool
 # Default value for :pty is false
-set :pty, true
+# set :pty, true
 
 # Default value for :linked_files is []
 append :linked_files, 'config/honeybadger.yml', 'config/database.yml'


### PR DESCRIPTION


# Why was this change made? 🤔
We no longer need this as we don't use resque. Most of our projects accept the default


# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



