### PR TITLE
remove book order UI option and get from cocina

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,8 +4,7 @@ module ApplicationHelper
   def content_structure
     [
       ['Image', 'simple_image'],
-      ['Book (ltr)', 'simple_book'],
-      ['Book (rtl)', 'simple_book_rtl'],
+      ['Book', 'simple_book'],
       ['Document', 'document'],
       ['File', 'file'],
       ['Geo', 'geo'],

--- a/app/javascript/controllers/ocr_controller.js
+++ b/app/javascript/controllers/ocr_controller.js
@@ -31,7 +31,7 @@ export default class extends Controller {
 
   // list of content structures that are allowed to run OCR
   ocrAllowed() {
-    return ['simple_image', 'simple_book', 'simple_book_rtl', 'document']
+    return ['simple_image', 'simple_book', 'document']
   }
 
   // if the user indicates they are providing OCR and have reviewed it, hide the option to run SDR OCR

--- a/app/lib/pre_assembly/digital_object.rb
+++ b/app/lib/pre_assembly/digital_object.rb
@@ -41,11 +41,6 @@ module PreAssembly
     # @return [Symbol]
     def content_md_creation_style
       # map the object type to structural styles supported by the FileSetBuilder class
-
-      # special case: content_structure of 'simple_book_rtl' always maps to simple_book
-      #  with the reading order set separately when creating content metadata
-      return :simple_book if content_structure == 'simple_book_rtl'
-
       {
         Cocina::Models::ObjectType.image => :simple_image,
         Cocina::Models::ObjectType.object => :file,
@@ -173,16 +168,13 @@ module PreAssembly
                                                    manually_corrected_ocr: batch.batch_context.manually_corrected_ocr)
     end
 
-    # The reading order for books is determined by the content structure set, defaulting to 'ltr'
+    # The reading order for books is determined by what the user set when registering the object.
     # This is passed to the content metadata creator, which uses it if the content structure is book
+    # Assume left-to-right if missing in the cocina structural (which really shouldn't happen for this content type)
     def reading_order
       return unless content_md_creation_style == :simple_book
 
-      if content_structure == 'simple_book_rtl'
-        'right-to-left'
-      else
-        'left-to-right'
-      end
+      existing_cocina_object.structural&.hasMemberOrders&.first&.viewingDirection || 'left-to-right'
     end
 
     ####

--- a/app/models/batch_context.rb
+++ b/app/models/batch_context.rb
@@ -43,7 +43,7 @@ class BatchContext < ApplicationRecord
     'document' => 6,
     'maps' => 7,
     'webarchive_seed' => 8,
-    'simple_book_rtl' => 9,
+    'simple_book_rtl' => 9, # Deprecated
     'geo' => 10
   }
 

--- a/spec/features/preassembly_run/book_using_file_manifest_spec.rb
+++ b/spec/features/preassembly_run/book_using_file_manifest_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Pre-assemble Book Using File Manifest' do
   let(:object_staging_dir) { Rails.root.join(Settings.assembly_staging_dir, 'bb', '000', 'kk', '0000', bare_druid) }
   let(:dro_access) { { view: 'world' } }
   let(:item) do
-    Cocina::RSpec::Factories.build(:dro, type: Cocina::Models::ObjectType.book, reading_order: 'right-to-left').new(access: dro_access)
+    Cocina::RSpec::Factories.build(:dro, type: Cocina::Models::ObjectType.book).new(access: dro_access, structural: { hasMemberOrders: [{ viewingDirection: 'right-to-left' }] })
   end
   let(:dsc_object_version) { instance_double(Dor::Services::Client::ObjectVersion, openable?: true, current: 1, status:) }
   let(:status) { instance_double(Dor::Services::Client::ObjectVersion::VersionStatus, open?: true) }

--- a/spec/features/preassembly_run/book_using_file_manifest_spec.rb
+++ b/spec/features/preassembly_run/book_using_file_manifest_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Pre-assemble Book Using File Manifest' do
   let(:object_staging_dir) { Rails.root.join(Settings.assembly_staging_dir, 'bb', '000', 'kk', '0000', bare_druid) }
   let(:dro_access) { { view: 'world' } }
   let(:item) do
-    Cocina::RSpec::Factories.build(:dro, type: Cocina::Models::ObjectType.image).new(access: dro_access)
+    Cocina::RSpec::Factories.build(:dro, type: Cocina::Models::ObjectType.book, reading_order: 'right-to-left').new(access: dro_access)
   end
   let(:dsc_object_version) { instance_double(Dor::Services::Client::ObjectVersion, openable?: true, current: 1, status:) }
   let(:status) { instance_double(Dor::Services::Client::ObjectVersion::VersionStatus, open?: true) }
@@ -36,7 +36,7 @@ RSpec.describe 'Pre-assemble Book Using File Manifest' do
 
     fill_in 'Project name', with: project_name
     select 'Pre Assembly Run', from: 'Job type'
-    select 'Book (rtl)', from: 'Content structure'
+    select 'Book', from: 'Content structure'
     fill_in 'Staging location', with: staging_location
     select 'Default', from: 'Processing configuration'
     check 'batch_context_using_file_manifest'

--- a/spec/lib/pre_assembly/digital_object_spec.rb
+++ b/spec/lib/pre_assembly/digital_object_spec.rb
@@ -431,7 +431,7 @@ RSpec.describe PreAssembly::DigitalObject do
       let(:cocina_type) { Cocina::Models::ObjectType.book }
       let(:content_structure) { 'simple_book' }
       let(:dro) do
-        Cocina::RSpec::Factories.build(:dro, type: cocina_type, reading_order: 'right-to-left').new(access: { view: 'world' })
+        Cocina::RSpec::Factories.build(:dro, type: cocina_type).new(access: { view: 'world' }, structural: { hasMemberOrders: [{ viewingDirection: 'right-to-left' }] })
       end
       let(:expected) do
         { contains: [{ type: 'https://cocina.sul.stanford.edu/models/resources/page',

--- a/spec/lib/pre_assembly/digital_object_spec.rb
+++ b/spec/lib/pre_assembly/digital_object_spec.rb
@@ -427,10 +427,12 @@ RSpec.describe PreAssembly::DigitalObject do
       end
     end
 
-    describe 'book (rtl) structural metadata' do
+    describe 'book structural metadata, with reading order as right-to-left in cocina' do
       let(:cocina_type) { Cocina::Models::ObjectType.book }
       let(:content_structure) { 'simple_book' }
-
+      let(:dro) do
+        Cocina::RSpec::Factories.build(:dro, type: cocina_type, reading_order: 'right-to-left').new(access: { view: 'world' })
+      end
       let(:expected) do
         { contains: [{ type: 'https://cocina.sul.stanford.edu/models/resources/page',
                        externalIdentifier: 'bc234fg5678_1',
@@ -469,7 +471,7 @@ RSpec.describe PreAssembly::DigitalObject do
       end
 
       before do
-        allow(bc).to receive(:content_structure).and_return('simple_book_rtl')
+        allow(bc).to receive(:content_structure).and_return('simple_book')
         add_object_files(extension: 'jp2')
       end
 


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #1451 

We do not need to ask pre-assembly users which order (ltr or rtl) their book is in, since this is set at registration time and placed into cocina.  We can use this value from cocina instead when building the rest of the structural.

~~HOLD to run on QA with integration tests~~

~~Note: requires https://github.com/sul-dlss/cocina-models/pull/715 and then bump to a new release to get the specs to work~~

# How was this change tested? 🤨

Unit tests.  

~~Should deploy to QA and run integration tests too.~~