### PR TITLE
Restructure OCR selections on batch context form

### DIFF
--- a/app/controllers/batch_contexts_controller.rb
+++ b/app/controllers/batch_contexts_controller.rb
@@ -45,7 +45,7 @@ class BatchContextsController < ApplicationController
     params.require(:batch_context)
           .permit(:project_name, :content_structure, :staging_style_symlink,
                   :processing_configuration, :staging_location, :all_files_public,
-                  :run_ocr, :manually_corrected_ocr,
+                  :run_ocr, :manually_corrected_ocr, :ocr_available,
                   :using_file_manifest, job_runs_attributes: [:job_type], ocr_languages: [])
           .merge(user: current_user)
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,7 +18,8 @@ module ApplicationHelper
   def processing_configuration
     [
       ['Default', 'default'],
-      ['Group by filename', 'filename']
+      ['Group by filename', 'filename'],
+      ['Group by filename (with pre-existing OCR)', 'filename_with_ocr']
     ]
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,7 +5,7 @@ module ApplicationHelper
     [
       ['Image', 'simple_image'],
       ['Book', 'simple_book'],
-      ['Document', 'document'],
+      ['Document/PDF', 'document'],
       ['File', 'file'],
       ['Geo', 'geo'],
       ['Media', 'media'],

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,7 +15,15 @@ module ApplicationHelper
     ]
   end
 
-  def avaliable_ocr_languages
+  def processing_configuration
+    [
+      ['Default', 'default'],
+      ['Group by filename', 'filename'],
+      ['Group by filename (with pre-existing OCR)', 'filename_with_ocr']
+    ]
+  end
+
+  def avalaible_ocr_languages
     ABBYY_LANGUAGES.map { |lang| [lang, lang.gsub(/[ ()]/, '')] }
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,8 +18,7 @@ module ApplicationHelper
   def processing_configuration
     [
       ['Default', 'default'],
-      ['Group by filename', 'filename'],
-      ['Group by filename (with pre-existing OCR)', 'filename_with_ocr']
+      ['Group by filename', 'filename']
     ]
   end
 

--- a/app/javascript/controllers/ocr_controller.js
+++ b/app/javascript/controllers/ocr_controller.js
@@ -148,7 +148,7 @@ export default class extends Controller {
       this.selectedLanguagesTarget.classList.add('d-none');
     } else {
       this.selectedLanguagesTarget.classList.remove('d-none');
-      this.selectedLanguagesTarget.innerHTML = `<div>Selected Language(s)</div>
+      this.selectedLanguagesTarget.innerHTML = `<div>Selected language(s)</div>
                                                 <ul class="list-unstyled border rounded mb-3 p-1">${this.renderLanguagePills()}</ul>`;
     }
 

--- a/app/javascript/controllers/ocr_controller.js
+++ b/app/javascript/controllers/ocr_controller.js
@@ -77,6 +77,14 @@ export default class extends Controller {
     const ocr_available = this.ocrAvailableTarget.querySelector('input[type="radio"]:checked').value == 'true'
     this.manuallyCorrectedOcrTarget.hidden = !ocr_available
     this.runOcrTarget.hidden = ocr_available
+    if (ocr_available)
+      {
+        this.ocrLanguageWrapperTarget.classList.add('d-none')
+      }
+      else
+      {
+        this.runOcrChanged()
+      }
   }
 
   // if the user indicates they are providing OCR and have reviewed it, show/hide the run OCR option (for documents) and set the OCR available option

--- a/app/javascript/controllers/ocr_controller.js
+++ b/app/javascript/controllers/ocr_controller.js
@@ -2,8 +2,8 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
 
-  static targets = ['contentStructure', 'ocrSettings', 'manuallyCorrectedOcrOptions', 'ocrAvailable',
-    'ocrAvailableOptions', 'manuallyCorrectedOcr', 'runOcr', 'ocrLanguages', 'ocrDropdown', 'runOcrDocumentNotes',
+  static targets = ['contentStructure', 'ocrSettings', 'ocrAvailable',
+    'manuallyCorrectedOcr', 'runOcr', 'ocrLanguages', 'ocrDropdown', 'runOcrDocumentNotes',
     'runOcrImageNotes', 'selectedLanguages', 'languageWarning', 'dropdownContent', 'ocrLanguageWrapper']
 
   static values = { languages: Array }
@@ -72,18 +72,20 @@ export default class extends Controller {
     this.runOcrChanged()
   }
 
-  // if the user indicates they have ocr available (show/hide the manually corrected and run OCR option (for images/books)
+  // if the user indicates they have ocr available, show/hide the manually corrected and run OCR option (for images/books)
   ocrAvailableChanged() {
     const ocr_available = this.ocrAvailableTarget.querySelector('input[type="radio"]:checked').value == 'true'
     this.manuallyCorrectedOcrTarget.hidden = !ocr_available
     this.runOcrTarget.hidden = ocr_available
   }
 
-  // if the user indicates they are providing OCR and have reviewed it, show/hide the run OCR option (for documents)
+  // if the user indicates they are providing OCR and have reviewed it, show/hide the run OCR option (for documents) and set the OCR available option
   manuallyCorrectedOcrChanged() {
     if (!this.isDocument()) return
 
-    this.runOcrTarget.hidden = this.manuallyCorrectedOcrTarget.querySelector('input[type="radio"]:checked').value == 'true'
+    const manuallyCorrectedOcr = this.manuallyCorrectedOcrTarget.querySelector('input[type="radio"]:checked').value == 'true'
+    this.ocrAvailableTarget.querySelector(`input[type=radio][value="${manuallyCorrectedOcr}"]`).checked = true
+    this.runOcrTarget.hidden = manuallyCorrectedOcr
   }
 
   // if the user indicates they want to run SDR OCR, show any relevant notes/warnings and language selector

--- a/app/javascript/controllers/ocr_controller.js
+++ b/app/javascript/controllers/ocr_controller.js
@@ -4,8 +4,7 @@ export default class extends Controller {
 
   static targets = ['contentStructure', 'ocrSettings', 'manuallyCorrectedOcrOptions', 'ocrAvailable',
     'ocrAvailableOptions', 'manuallyCorrectedOcr', 'runOcr', 'ocrLanguages', 'ocrDropdown', 'runOcrDocumentNotes',
-    'runOcrImageNotes', 'selectedLanguages', 'languageWarning', 'dropdownContent', 'ocrLanguageWrapper',
-    'processingConfiguration']
+    'runOcrImageNotes', 'selectedLanguages', 'languageWarning', 'dropdownContent', 'ocrLanguageWrapper']
 
   static values = { languages: Array }
 
@@ -17,11 +16,6 @@ export default class extends Controller {
   // list of content structures that are allowed to run OCR
   ocrAllowed() {
     return ['simple_image', 'simple_book', 'document']
-  }
-
-  groupByFilenameTypes()
-  {
-    return ['simple_image', 'simple_book', 'maps']
   }
 
   selectedContentStructure() {
@@ -41,13 +35,14 @@ export default class extends Controller {
   }
 
   labelRunOcr() {
-    return `Would you like to auto-generate OCR files for the ${this.selectedContentStructure().label.toLowerCase()}(s)?`
+    return `Would you like to auto-generate OCR files for the ${this.ocrFileTypeLabel()}?`
+  }
+
+  ocrFileTypeLabel() {
+    return this.isDocument() ? 'PDF documents' : 'images'
   }
 
   contentStructureChanged () {
-    // set the processing configuration based on the content structure
-    this.setProcessingConfiguration()
-
     // Hide the OCR settings if the selected content structure is not in the list of allowed content structures
     if (this.ocrAllowed().indexOf(this.contentStructureTarget.value) < 0) {
       this.ocrSettingsTarget.hidden = true
@@ -111,15 +106,6 @@ export default class extends Controller {
     Object.values(this.ocrDropdownTarget.children).forEach(child => {
       child.disabled = !runocr;
     })
-  }
-
-  // set the default processing configuration based on the content structure
-  setProcessingConfiguration() {
-      if (this.groupByFilenameTypes().indexOf(this.selectedContentStructure().value) >= 0) {
-        this.processingConfigurationTarget.value = 'filename'
-      } else {
-        this.processingConfigurationTarget.value = 'default'
-      }
   }
 
   languageDropdown(event) {

--- a/app/lib/pre_assembly/batch.rb
+++ b/app/lib/pre_assembly/batch.rb
@@ -23,6 +23,7 @@ module PreAssembly
              :using_file_manifest,
              :project_name,
              :staging_style_symlink,
+             :ocr_available,
              to: :batch_context
 
     def initialize(job_run, file_manifest: nil)

--- a/app/lib/pre_assembly/digital_object.rb
+++ b/app/lib/pre_assembly/digital_object.rb
@@ -11,6 +11,7 @@ module PreAssembly
     delegate :staging_location,
              :processing_configuration,
              :content_structure,
+             :ocr_available,
              :project_name,
              :file_manifest,
              to: :batch
@@ -119,6 +120,7 @@ module PreAssembly
       else
         build_from_staging_location(objects: object_files.sort,
                                     processing_configuration:,
+                                    ocr_available:,
                                     reading_order:)
       end
     end
@@ -159,8 +161,8 @@ module PreAssembly
       object_client.update(params: updated_cocina)
     end
 
-    def build_from_staging_location(objects:, processing_configuration:, reading_order:)
-      filesets = FromStagingLocation::FileSetBuilder.build(processing_configuration:, objects:, style: content_md_creation_style)
+    def build_from_staging_location(objects:, processing_configuration:, reading_order:, ocr_available:)
+      filesets = FromStagingLocation::FileSetBuilder.build(processing_configuration:, ocr_available:, objects:, style: content_md_creation_style)
       FromStagingLocation::StructuralBuilder.build(cocina_dro: existing_cocina_object,
                                                    filesets:,
                                                    all_files_public: batch.batch_context.all_files_public?,

--- a/app/lib/pre_assembly/from_staging_location/file.rb
+++ b/app/lib/pre_assembly/from_staging_location/file.rb
@@ -24,8 +24,7 @@ module PreAssembly
         'application/json' => { preserve: 'yes', shelve: 'yes', publish: 'yes' }
       }.freeze
 
-      # if the user tells us they are providing OCR, we will set the transcription role and corrected_for_accessibility to true
-      #  since the user has verified the OCR is correct in the UI
+      # if the user tells us they are providing OCR, we will set the transcription role and possibly also corrected_for_accessibility
       ATTRIBUTES_FOR_TYPE_WITH_OCR = {
         'image/tif' => { preserve: 'yes', shelve: 'no', publish: 'no' },
         'image/tiff' => { preserve: 'yes', shelve: 'no', publish: 'no' },
@@ -39,9 +38,9 @@ module PreAssembly
       }.freeze
 
       # @param [Assembly::ObjectFile] file
-      def initialize(file:, processing_configuration:)
+      def initialize(file:, ocr_available:)
         @file = file
-        @processing_configuration = processing_configuration
+        @ocr_available = ocr_available
       end
 
       delegate :sha1, :md5, :provider_md5, :mimetype, :filesize, :relative_path, to: :file
@@ -52,10 +51,10 @@ module PreAssembly
 
       private
 
-      attr_reader :file, :processing_configuration
+      attr_reader :file, :ocr_available
 
       def file_attributes_for_mimetype(mimetype)
-        return ATTRIBUTES_FOR_TYPE_WITH_OCR[mimetype] if processing_configuration == :filename_with_ocr && ATTRIBUTES_FOR_TYPE_WITH_OCR.key?(mimetype)
+        return ATTRIBUTES_FOR_TYPE_WITH_OCR[mimetype] if ocr_available && ATTRIBUTES_FOR_TYPE_WITH_OCR.key?(mimetype)
 
         ATTRIBUTES_FOR_TYPE[mimetype] || ATTRIBUTES_FOR_TYPE['default']
       end

--- a/app/lib/pre_assembly/from_staging_location/file_set.rb
+++ b/app/lib/pre_assembly/from_staging_location/file_set.rb
@@ -8,10 +8,11 @@ module PreAssembly
 
       # @param [Array<Assembly::ObjectFile>] resource_files
       # @param [Symbol] style one of: :simple_image, :file, :simple_book, :book_as_image, :book_with_pdf, :map, :geo, or :'3d'
-      def initialize(resource_files:, style:, processing_configuration:)
+      # @param [Boolean] ocr_available
+      def initialize(resource_files:, style:, ocr_available:)
         @resource_files = resource_files
         @style = style
-        @processing_configuration = processing_configuration
+        @ocr_available = ocr_available
       end
 
       # otherwise look at the style to determine the resource_type_description
@@ -24,12 +25,12 @@ module PreAssembly
       end
 
       def files
-        resource_files.map { |file| File.new(file:, processing_configuration:) }
+        resource_files.map { |file| File.new(file:, ocr_available:) }
       end
 
       private
 
-      attr_reader :resource_files, :style, :processing_configuration
+      attr_reader :resource_files, :style, :ocr_available
 
       # rubocop:disable Metrics/AbcSize
       # rubocop:disable Metrics/CyclomaticComplexity

--- a/app/lib/pre_assembly/from_staging_location/file_set_builder.rb
+++ b/app/lib/pre_assembly/from_staging_location/file_set_builder.rb
@@ -25,16 +25,25 @@ module PreAssembly
         case processing_configuration
         when :default # one resource per object
           objects.collect { |obj| FileSet.new(resource_files: [obj], style:, ocr_available:) }
-        when :filename # one resource per distinct filename (excluding extension)
+        when :filename, :filename_with_ocr # one resource per distinct filename (excluding extension)
           build_for_filename
         else
-          raise 'Invalid processing_configuration: must be :default or :filename'
+          raise 'Invalid processing_configuration: must be :default, :filename, or :filename_with_ocr'
         end
       end
 
       private
 
-      attr_reader :processing_configuration, :objects, :style, :ocr_available
+      attr_reader :processing_configuration, :objects, :style
+
+      # until the new OCR settings are available, we have to look in the processing configuration
+      def ocr_available
+        if Settings.ocr.enabled
+          @ocr_available
+        else
+          processing_configuration == :filename_with_ocr
+        end
+      end
 
       def build_for_filename
         # loop over distinct filenames, this determines how many resources we will have and

--- a/app/lib/pre_assembly/from_staging_location/file_set_builder.rb
+++ b/app/lib/pre_assembly/from_staging_location/file_set_builder.rb
@@ -7,14 +7,15 @@ module PreAssembly
       # @param [Symbol] processing_configuration one of: :default or :filename
       # @param [Array<Assembly::ObjectFile>] objects
       # @param [Symbol] style one of: :simple_image, :file, :simple_book, :book_as_image, :book_with_pdf, :map, :geo, or :'3d'
-      def self.build(processing_configuration:, objects:, style:)
-        new(processing_configuration:, objects:, style:).build
+      def self.build(processing_configuration:, objects:, style:, ocr_available:)
+        new(processing_configuration:, objects:, style:, ocr_available:).build
       end
 
-      def initialize(processing_configuration:, objects:, style:)
+      def initialize(processing_configuration:, objects:, style:, ocr_available:)
         @processing_configuration = processing_configuration.to_sym
         @objects = objects
         @style = style
+        @ocr_available = ocr_available
       end
 
       # @return [Array<FileSet>] a list of filesets in the object
@@ -23,17 +24,17 @@ module PreAssembly
 
         case processing_configuration
         when :default # one resource per object
-          objects.collect { |obj| FileSet.new(resource_files: [obj], style:, processing_configuration:) }
-        when :filename, :filename_with_ocr # one resource per distinct filename (excluding extension)
+          objects.collect { |obj| FileSet.new(resource_files: [obj], style:, ocr_available:) }
+        when :filename # one resource per distinct filename (excluding extension)
           build_for_filename
         else
-          raise 'Invalid processing_configuration: must be :default, :filename, or :filename_with_ocr'
+          raise 'Invalid processing_configuration: must be :default or :filename'
         end
       end
 
       private
 
-      attr_reader :processing_configuration, :objects, :style
+      attr_reader :processing_configuration, :objects, :style, :ocr_available
 
       def build_for_filename
         # loop over distinct filenames, this determines how many resources we will have and
@@ -42,7 +43,7 @@ module PreAssembly
         distinct_filenames.map do |distinct_filename|
           FileSet.new(resource_files: objects.collect { |obj| obj if obj.filename_without_ext == distinct_filename }.compact,
                       style:,
-                      processing_configuration:)
+                      ocr_available:)
         end
       end
     end

--- a/app/lib/pre_assembly/from_staging_location/structural_builder.rb
+++ b/app/lib/pre_assembly/from_staging_location/structural_builder.rb
@@ -4,27 +4,31 @@ module PreAssembly
   module FromStagingLocation
     # Updates the Cocina::DROStructural metadata with the new structure derived from a staging location
     class StructuralBuilder
+      # rubocop:disable Metrics/ParameterLists
       # @param [Array<Fileset>] filesets
       # @param [Cocina::Models::DRO] cocina_dro
       # @param [String] reading_order
       # @param [Boolean] all_files_public
       # @param [Boolean] manually_corrected_ocr set by user when creating the job
-      def self.build(filesets:, cocina_dro:, all_files_public:, reading_order: nil, manually_corrected_ocr: false)
+      def self.build(filesets:, cocina_dro:, all_files_public:, reading_order: nil, manually_corrected_ocr: false, ocr_available: false)
         new(filesets:,
             cocina_dro:,
             reading_order:,
             all_files_public:,
-            manually_corrected_ocr:).build
+            manually_corrected_ocr:,
+            ocr_available:).build
       end
 
-      def initialize(filesets:, cocina_dro:, all_files_public:, reading_order:, manually_corrected_ocr:)
+      def initialize(filesets:, cocina_dro:, all_files_public:, reading_order:, manually_corrected_ocr:, ocr_available:)
         @filesets = filesets
         @cocina_dro = cocina_dro
         @reading_order = reading_order
         @all_files_public = all_files_public
         @manually_corrected_ocr = manually_corrected_ocr
+        @ocr_available = ocr_available
       end
-      attr_reader :filesets, :cocina_dro, :reading_order, :all_files_public, :manually_corrected_ocr
+      # rubocop:enable Metrics/ParameterLists
+      attr_reader :filesets, :cocina_dro, :reading_order, :all_files_public, :manually_corrected_ocr, :ocr_available
 
       # rubocop:disable Metrics/AbcSize
       # rubocop:disable Metrics/MethodLength

--- a/app/models/batch_context.rb
+++ b/app/models/batch_context.rb
@@ -17,10 +17,13 @@ class BatchContext < ApplicationRecord
   has_many :job_runs, dependent: :destroy
   has_one :globus_destination, dependent: :destroy
   after_initialize :normalize_staging_location, :default_enums
+  before_save :set_processing_configuration, if: proc { Settings.ocr.enabled }
   before_save :output_dir_exists!, if: proc { persisted? }
   before_create :output_dir_no_exists!
 
-  validates :staging_location, :processing_configuration, :content_structure, presence: true
+  validates :staging_location, :content_structure, presence: true
+  # we only need this validation when OCR is disabled (once enabled, the processing_configuration is set automatically based on content type)
+  validates :processing_configuration, presence: true, unless: proc { Settings.ocr.enabled }
   validates :project_name, presence: true, format: { with: /\A[\w-]+\z/,
                                                      message: 'only allows A-Z, a-z, 0-9, hyphen and underscore' }
   validates :staging_style_symlink, :using_file_manifest, inclusion: { in: [true, false] }
@@ -52,6 +55,18 @@ class BatchContext < ApplicationRecord
     'media_cm_style' => 2, # Deprecated
     'filename_with_ocr' => 3 # Deprecated
   }
+  # sets required processing_configuration values for a given content structure
+  CONTENT_STRUCTURE_TO_PROCESSING_CONFIGURATION = {
+    'simple_image' => 'filename',
+    'simple_book' => 'filename',
+    'document' => 'default',
+    'file' => 'default',
+    'geo' => 'default',
+    'media' => 'default',
+    '3d' => 'default',
+    'maps' => 'filename',
+    'webarchive_seed' => 'default'
+  }.freeze
 
   accepts_nested_attributes_for :job_runs
 
@@ -110,6 +125,11 @@ class BatchContext < ApplicationRecord
   end
 
   private
+
+  # set the processing configuration based on the content structure
+  def set_processing_configuration
+    self.processing_configuration = CONTENT_STRUCTURE_TO_PROCESSING_CONFIGURATION[content_structure]
+  end
 
   def object_manifest_path
     staging_location_with_path(OBJECT_MANIFEST_FILE_NAME)

--- a/app/models/batch_context.rb
+++ b/app/models/batch_context.rb
@@ -13,6 +13,9 @@ class BatchContext < ApplicationRecord
   # the manifest specifying objects and associated folders on disk: required to run any job
   OBJECT_MANIFEST_FILE_NAME = 'manifest.csv'
 
+  # virtual form attribute, does not need to persist in the database
+  attribute :ocr_available, :boolean, default: false
+
   belongs_to :user
   has_many :job_runs, dependent: :destroy
   has_one :globus_destination, dependent: :destroy

--- a/app/models/batch_context.rb
+++ b/app/models/batch_context.rb
@@ -136,7 +136,6 @@ class BatchContext < ApplicationRecord
   end
 
   def default_enums
-    self[:content_structure] ||= 0
     self[:processing_configuration] ||= 0
   end
 

--- a/app/views/batch_contexts/_new_bc_form.erb
+++ b/app/views/batch_contexts/_new_bc_form.erb
@@ -81,12 +81,10 @@
                 </div>
             </div>
         </div>
-    <% else # if OCR is not enabled, use the regular drop down menu %>
+    <% else # if OCR is not enabled, use the regular drop down menus %>
        <%= form.input :content_structure, label: 'Content type', collection: content_structure %>
+       <%= form.input :processing_configuration, collection: processing_configuration %>
     <% end %>
-    <%= form.input :processing_configuration, input_html: { data: { "ocr-target": "processingConfiguration" } },
-                   collection: processing_configuration
-    %>
 
     <%= form.input :staging_location, input_html: { data: { "globus-target": "stagingLocation" } } %>
 

--- a/app/views/batch_contexts/_new_bc_form.erb
+++ b/app/views/batch_contexts/_new_bc_form.erb
@@ -18,7 +18,7 @@
     <%= form.simple_fields_for :job_runs do |jt| %>
         <%= jt.input :job_type, collection:
             [
-                ["Pre Assembly Run", "preassembly"],
+                ["Preassembly Run", "preassembly"],
                 ["Discovery Report", "discovery_report"]
             ]
         %>
@@ -28,21 +28,26 @@
         <%= form.input :content_structure, input_html: { data: { action: "change->ocr#content_structure_changed", "ocr-target": "contentStructure" } }, collection: content_structure %>
 
         <div data-ocr-target="ocrSettings" hidden>
-            <div data-ocr-target="manuallyCorrectedOcr">
-            <%= form.input :manually_corrected_ocr, input_html: { data: { action: "change->ocr#manually_corrected_ocr_changed", "ocr-target": "manuallyCorrectedOcrOptions" } },
-                as: :radio_buttons,
-                collection: [['Yes', true], ['No', false]] %>
+            <div data-ocr-target="ocrAvailable" hidden>
+                <%= form.input :ocr_available, label: 'Do you have OCR files for the images?', input_html: { data: { action: "change->ocr#ocr_available_changed", "ocr-target": "ocrAvailableOptions" } },
+                    as: :radio_buttons,
+                    collection: [['Yes', true], ['No', false]] %>
             </div>
-            <div data-ocr-target="runOcr">
-            <%= form.input :run_ocr, input_html: { data: { action: "change->ocr#run_ocr_changed", "ocr-target": "runOcrOptions" } },
-                as: :radio_buttons,
-                collection: [['Yes. Run ABBYY OCR.', true], ['No. Do not run ABBYY OCR.', false]] %>
+            <div data-ocr-target="manuallyCorrectedOcr" hidden>
+                <%= form.input :manually_corrected_ocr, input_html: { data: { action: "change->ocr#manually_corrected_ocr_changed", "ocr-target": "manuallyCorrectedOcrOptions" } },
+                    as: :radio_buttons,
+                    collection: [['Yes', true], ['No', false]] %>
+            </div>
+            <div data-ocr-target="runOcr" hidden>
+                <%= form.input :run_ocr, input_html: { data: { action: "change->ocr#run_ocr_changed", "ocr-target": "runOcrOptions" } },
+                    as: :radio_buttons,
+                    collection: [['Yes', true], ['No', false]] %>
+                <div data-ocr-target="runOcrImageNotes" hidden>
+                    <p><i>Warning:</i> Avoid auto-generating OCR files for images that do not contain any text, as it may have adverse effects.</p>
+                </div>
                 <div data-ocr-target="runOcrDocumentNotes" hidden>
-                    <p><i>Warning:</i> If your document is already WCAG/PDFUA compliant, ABBYY may create a less accessible version.
-                    Your original document will not be overwritten.</p>
-                    <p><i>Note:</i> Automatic tools can achieve only a minimal level of compliance with accessibility standards (WCAG, PDF/UA).
-                    To be fully compliant, it is encouraged that documents be manually remediated and uploaded.
-                    See <%= link_to 'https://uit.stanford.edu/accessibility/guides/pdf'%></p>
+                    <p><i>Note:</i> Auto-generating OCR files alone will not fully meet accessibility standards. To comply with <%= link_to "Stanford's Accessibility policy", 'https://uit.stanford.edu/accessibility/policy' %>, you are encouraged to correct the PDF documents by following the <%= link_to 'PDF accessibility guides', 'https://uit.stanford.edu/accessibility/guides/pdf'%>.</p>
+                    <p><i>Warning:</i> Avoid auto-generating OCR files for PDF documents that do not contain any text, as it may have adverse effects.</p>
                 </div>
             </div>
             <div class="ocr-language d-none" data-ocr-target="ocrLanguageWrapper">

--- a/app/views/batch_contexts/_new_bc_form.erb
+++ b/app/views/batch_contexts/_new_bc_form.erb
@@ -25,21 +25,21 @@
     <% end %>
 
     <% if Settings.ocr.enabled # if OCR is enabled, the content_structure drop down menu will hide/show ocr menus via stimulus %>
-        <%= form.input :content_structure, input_html: { data: { action: "change->ocr#content_structure_changed", "ocr-target": "contentStructure" } }, collection: content_structure %>
+        <%= form.input :content_structure, label: 'Content type', input_html: { data: { action: "change->ocr#contentStructureChanged", "ocr-target": "contentStructure" } }, collection: content_structure %>
 
         <div data-ocr-target="ocrSettings" hidden>
             <div data-ocr-target="ocrAvailable" hidden>
-                <%= form.input :ocr_available, label: 'Do you have OCR files for the images?', input_html: { data: { action: "change->ocr#ocr_available_changed", "ocr-target": "ocrAvailableOptions" } },
+                <%= form.input :ocr_available, label: 'Do you have OCR files for the images?', input_html: { data: { action: "change->ocr#ocrAvailableChanged", "ocr-target": "ocrAvailableOptions" } },
                     as: :radio_buttons,
                     collection: [['Yes', true], ['No', false]] %>
             </div>
             <div data-ocr-target="manuallyCorrectedOcr" hidden>
-                <%= form.input :manually_corrected_ocr, input_html: { data: { action: "change->ocr#manually_corrected_ocr_changed", "ocr-target": "manuallyCorrectedOcrOptions" } },
+                <%= form.input :manually_corrected_ocr, input_html: { data: { action: "change->ocr#manuallyCorrectedOcrChanged", "ocr-target": "manuallyCorrectedOcrOptions" } },
                     as: :radio_buttons,
                     collection: [['Yes', true], ['No', false]] %>
             </div>
             <div data-ocr-target="runOcr" hidden>
-                <%= form.input :run_ocr, input_html: { data: { action: "change->ocr#run_ocr_changed", "ocr-target": "runOcrOptions" } },
+                <%= form.input :run_ocr, input_html: { data: { action: "change->ocr#runOcrChanged", "ocr-target": "runOcrOptions" } },
                     as: :radio_buttons,
                     collection: [['Yes', true], ['No', false]] %>
                 <div data-ocr-target="runOcrImageNotes" hidden>
@@ -65,7 +65,7 @@
                         </div>
                     </div>
                     <div id="ocr-languages" data-ocr-target="dropdownContent" class="dropdown-content d-none languages-group border rounded">
-                        <% avaliable_ocr_languages.each do |language| %>
+                        <% avalaible_ocr_languages.each do |language| %>
                             <label class="d-block">
                                 <%= form.check_box 'ocr_languages', { multiple: true, data: { 'ocr-target': 'ocrLanguages', 'ocr-label': language[0], 'ocr-value': language[1], action: 'change->ocr#languageUpdate' } }, language[1], nil %>
                                 <%= language[0] %>
@@ -82,20 +82,16 @@
             </div>
         </div>
     <% else # if OCR is not enabled, use the regular drop down menu %>
-       <%= form.input :content_structure, collection: content_structure %>
+       <%= form.input :content_structure, label: 'Content type', collection: content_structure %>
     <% end %>
+    <%= form.input :processing_configuration, input_html: { data: { "ocr-target": "processingConfiguration" } },
+                   collection: processing_configuration
+    %>
 
     <%= form.input :staging_location, input_html: { data: { "globus-target": "stagingLocation" } } %>
 
     <%# the 'staging_style_symlink` is hidden, since we do not currently want users to access it (it may cause problems with some accessioning steps)%>
     <%= form.hidden_field :staging_style_symlink, value: false %>
-    <%= form.input :processing_configuration, collection:
-        [
-            ["Default", "default"],
-            ["Group by filename", "filename"],
-            ["Group by filename (with pre-existing OCR)", "filename_with_ocr"]
-        ]
-    %>
 
     <%= form.input :using_file_manifest, as: :boolean, label: 'I have a file manifest'%>
 

--- a/app/views/batch_contexts/_new_bc_form.erb
+++ b/app/views/batch_contexts/_new_bc_form.erb
@@ -91,7 +91,10 @@
     <%# the 'staging_style_symlink` is hidden, since we do not currently want users to access it (it may cause problems with some accessioning steps)%>
     <%= form.hidden_field :staging_style_symlink, value: false %>
 
-    <%= form.input :using_file_manifest, as: :boolean, label: 'I have a file manifest'%>
+    <%= form.input :using_file_manifest,
+                   as: :radio_buttons,
+                   collection: [['Yes', true], ['No', false]],
+                   label: 'Do you have a file manifest?' %>
 
     <%= form.input :all_files_public,
                    as: :radio_buttons,

--- a/app/views/batch_contexts/_new_bc_form.erb
+++ b/app/views/batch_contexts/_new_bc_form.erb
@@ -29,12 +29,12 @@
 
         <div data-ocr-target="ocrSettings" hidden>
             <div data-ocr-target="ocrAvailable" hidden>
-                <%= form.input :ocr_available, label: 'Do you have OCR files for the images?', input_html: { data: { action: "change->ocr#ocrAvailableChanged", "ocr-target": "ocrAvailableOptions" } },
+                <%= form.input :ocr_available, label: 'Do you have OCR files for the images?', input_html: { data: { action: "change->ocr#ocrAvailableChanged" } },
                     as: :radio_buttons,
                     collection: [['Yes', true], ['No', false]] %>
             </div>
             <div data-ocr-target="manuallyCorrectedOcr" hidden>
-                <%= form.input :manually_corrected_ocr, input_html: { data: { action: "change->ocr#manuallyCorrectedOcrChanged", "ocr-target": "manuallyCorrectedOcrOptions" } },
+                <%= form.input :manually_corrected_ocr, input_html: { data: { action: "change->ocr#manuallyCorrectedOcrChanged" } },
                     as: :radio_buttons,
                     collection: [['Yes', true], ['No', false]] %>
             </div>

--- a/app/views/batch_contexts/_settings.html.erb
+++ b/app/views/batch_contexts/_settings.html.erb
@@ -6,7 +6,7 @@
     </thead>
     <tbody>
         <tr>
-            <td>Content Structure</td>
+            <td>Content Type</td>
             <td><%= batch_context.content_structure %></td>
         </tr>
         <tr>

--- a/app/views/batch_contexts/_settings.html.erb
+++ b/app/views/batch_contexts/_settings.html.erb
@@ -7,7 +7,7 @@
     <tbody>
         <tr>
             <td>Content Type</td>
-            <td><%= batch_context.content_structure %></td>
+            <td><%= content_structure.to_h.key(batch_context.content_structure) %></td>
         </tr>
         <tr>
             <td>Staging Location</td>
@@ -19,7 +19,7 @@
         </tr>
         <tr>
             <td>Processing configuration</td>
-            <td><%= batch_context.processing_configuration %></td>
+            <td><%= processing_configuration.to_h.key(batch_context.processing_configuration) %></td>
         </tr>
         <tr>
             <td>Using File Manifest</td>

--- a/app/views/batch_contexts/index.html.erb
+++ b/app/views/batch_contexts/index.html.erb
@@ -8,7 +8,7 @@
       <tr class="table-secondary">
         <th scope="col">Name</th>
         <th scope="col">Creator</th>
-        <th scope="col">Content Structure</th>
+        <th scope="col">Content Type</th>
         <th scope="col">Staging Location</th>
         <th scope="col">Processing Configuration</th>
         <th scope="col">Using File Manifest</th>

--- a/app/views/job_runs/_details.html.erb
+++ b/app/views/job_runs/_details.html.erb
@@ -7,7 +7,7 @@
     <tbody>
         <tr>
             <td>Job type</td>
-            <td><%= @job_run.job_type %></td>
+            <td><%= @job_run.job_type.humanize %></td>
         </tr>
         <tr>
             <td>Created by</td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,7 @@ en:
             accessioning_complete: 'Job completed'
     attributes:
       batch_context:
+        content_structure: 'Content type'
         all_files_public: "Preserve, Shelve, Publish settings"
   helpers:
     submit:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,7 +45,7 @@ en:
             accessioning_complete: 'Job completed'
     attributes:
       batch_context:
-        all_files_public: "Preserve, Shelve, Publish Settings"
+        all_files_public: "Preserve, Shelve, Publish settings"
   helpers:
     submit:
       batch_context:

--- a/db/migrate/20240529215747_add_ocr_available.rb
+++ b/db/migrate/20240529215747_add_ocr_available.rb
@@ -1,0 +1,5 @@
+class AddOcrAvailable < ActiveRecord::Migration[7.1]
+  def change
+      add_column :batch_contexts, :ocr_available, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_17_191635) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_29_215747) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -39,6 +39,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_17_191635) do
     t.boolean "run_ocr", default: false
     t.boolean "manually_corrected_ocr", default: false
     t.jsonb "ocr_languages", default: []
+    t.boolean "ocr_available", default: false
     t.index ["user_id", "project_name"], name: "index_batch_contexts_on_user_id_and_project_name", unique: true
     t.index ["user_id"], name: "index_batch_contexts_on_user_id"
   end

--- a/spec/features/batch_context/globus_spec.rb
+++ b/spec/features/batch_context/globus_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Use Globus staging location', :js do
   it 'can create BatchContext with Globus URL' do
     visit '/'
     fill_in 'Project name', with: "test-#{Time.now.to_i}"
-    select 'Image', from: 'Content structure'
+    select 'Image', from: 'Content type'
     select 'Group by filename', from: 'Processing configuration'
 
     # click to create a Globus share and get the new GlobusDestination
@@ -47,7 +47,7 @@ RSpec.describe 'Use Globus staging location', :js do
   it 'can create BatchContext with Globus destination path' do
     visit '/'
     fill_in 'Project name', with: "test-#{Time.now.to_i}"
-    select 'Image', from: 'Content structure'
+    select 'Image', from: 'Content type'
     select 'Group by filename', from: 'Processing configuration'
 
     # click to create a Globus share and get the new GlobusDestination

--- a/spec/features/batch_context/globus_spec.rb
+++ b/spec/features/batch_context/globus_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Use Globus staging location', :js do
     visit '/'
     fill_in 'Project name', with: "test-#{Time.now.to_i}"
     select 'Image', from: 'Content type'
-    select 'Group by filename', from: 'Processing configuration'
+    select('Group by filename', from: 'Processing configuration') unless Settings.ocr.enabled
 
     # click to create a Globus share and get the new GlobusDestination
     click_button 'Request Globus Link'
@@ -48,7 +48,7 @@ RSpec.describe 'Use Globus staging location', :js do
     visit '/'
     fill_in 'Project name', with: "test-#{Time.now.to_i}"
     select 'Image', from: 'Content type'
-    select 'Group by filename', from: 'Processing configuration'
+    select('Group by filename', from: 'Processing configuration') unless Settings.ocr.enabled
 
     # click to create a Globus share and get the new GlobusDestination
     click_button 'Request Globus Link'

--- a/spec/features/discovery_report/build_manifest_image_spec.rb
+++ b/spec/features/discovery_report/build_manifest_image_spec.rb
@@ -31,8 +31,7 @@ RSpec.describe 'Discovery Report from (build) manifest' do
 
     fill_in 'Project name', with: project_name
     select 'Discovery Report', from: 'Job type'
-    select 'Image', from: 'Content structure'
-    select 'Group by filename', from: 'Processing configuration'
+    select 'Image', from: 'Content type'
     fill_in 'Staging location', with: staging_location
 
     click_button 'Submit'

--- a/spec/features/discovery_report/completed_with_errors_spec.rb
+++ b/spec/features/discovery_report/completed_with_errors_spec.rb
@@ -31,8 +31,7 @@ RSpec.describe 'Discovery Report completes with errors', :js do
 
     fill_in 'Project name', with: project_name
     select 'Discovery Report', from: 'Job type'
-    select 'Image', from: 'Content structure'
-    select 'Group by filename', from: 'Processing configuration'
+    select 'Image', from: 'Content type'
     fill_in 'Staging location', with: staging_location
 
     click_button 'Submit'

--- a/spec/features/discovery_report/discovery_report_failed_spec.rb
+++ b/spec/features/discovery_report/discovery_report_failed_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe 'Discovery Report fails' do
 
     fill_in 'Project name', with: project_name
     select 'Discovery Report', from: 'Job type'
-    select 'Group by filename', from: 'Processing configuration'
+    select 'Image', from: 'Content type'
+    select('Group by filename', from: 'Processing configuration') unless Settings.ocr.enabled
     fill_in 'Staging location', with: staging_location
     check 'batch_context_using_file_manifest'
 

--- a/spec/features/discovery_report/discovery_report_failed_spec.rb
+++ b/spec/features/discovery_report/discovery_report_failed_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Discovery Report fails' do
     select 'Image', from: 'Content type'
     select('Group by filename', from: 'Processing configuration') unless Settings.ocr.enabled
     fill_in 'Staging location', with: staging_location
-    check 'batch_context_using_file_manifest'
+    choose 'batch_context_using_file_manifest_true'
 
     click_button 'Submit'
     exp_str = 'Success! Your job is queued. A link to job output will be emailed to you upon completion.'

--- a/spec/features/discovery_report/file_manifest_book_spec.rb
+++ b/spec/features/discovery_report/file_manifest_book_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Discovery Report from file_manifest.csv' do
     fill_in 'Project name', with: project_name
     select 'Discovery Report', from: 'Job type'
     fill_in 'Staging location', with: staging_location
-    select 'Book', from: 'Content structure'
+    select 'Book', from: 'Content type'
     select 'Default', from: 'Processing configuration'
     check 'batch_context_using_file_manifest'
 

--- a/spec/features/discovery_report/file_manifest_book_spec.rb
+++ b/spec/features/discovery_report/file_manifest_book_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Discovery Report from file_manifest.csv' do
     fill_in 'Staging location', with: staging_location
     select 'Book', from: 'Content type'
     select('Default', from: 'Processing configuration') unless Settings.ocr.enabled
-    check 'batch_context_using_file_manifest'
+    choose 'batch_context_using_file_manifest_true'
 
     click_button 'Submit'
     exp_str = 'Success! Your job is queued. A link to job output will be emailed to you upon completion.'

--- a/spec/features/discovery_report/file_manifest_book_spec.rb
+++ b/spec/features/discovery_report/file_manifest_book_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Discovery Report from file_manifest.csv' do
     select 'Discovery Report', from: 'Job type'
     fill_in 'Staging location', with: staging_location
     select 'Book', from: 'Content type'
-    select 'Default', from: 'Processing configuration'
+    select('Default', from: 'Processing configuration') unless Settings.ocr.enabled
     check 'batch_context_using_file_manifest'
 
     click_button 'Submit'

--- a/spec/features/discovery_report/hierarchical_files_spec.rb
+++ b/spec/features/discovery_report/hierarchical_files_spec.rb
@@ -31,8 +31,7 @@ RSpec.describe 'Discovery Report for hierarchical files with build manifest' do
 
     fill_in 'Project name', with: project_name
     select 'Discovery Report', from: 'Job type'
-    select 'File', from: 'Content structure'
-    select 'Default', from: 'Processing configuration'
+    select 'File', from: 'Content type'
     fill_in 'Staging location', with: staging_location
 
     click_button 'Submit'
@@ -67,8 +66,12 @@ RSpec.describe 'Discovery Report for hierarchical files with build manifest' do
 
     fill_in 'Project name', with: project_name
     select 'Discovery Report', from: 'Job type'
+<<<<<<< HEAD
     select 'Image', from: 'Content structure' # wrong, needs to be File for an object with hierarchy
     select 'Group by filename', from: 'Processing configuration'
+=======
+    select 'Image', from: 'Content type' # wrong, needs to be File for an object with hierarchy
+>>>>>>> ef187421 (set processing configuration based on content type)
     fill_in 'Staging location', with: staging_location
 
     click_button 'Submit'

--- a/spec/features/discovery_report/hierarchical_files_spec.rb
+++ b/spec/features/discovery_report/hierarchical_files_spec.rb
@@ -66,12 +66,7 @@ RSpec.describe 'Discovery Report for hierarchical files with build manifest' do
 
     fill_in 'Project name', with: project_name
     select 'Discovery Report', from: 'Job type'
-<<<<<<< HEAD
-    select 'Image', from: 'Content structure' # wrong, needs to be File for an object with hierarchy
-    select 'Group by filename', from: 'Processing configuration'
-=======
     select 'Image', from: 'Content type' # wrong, needs to be File for an object with hierarchy
->>>>>>> ef187421 (set processing configuration based on content type)
     fill_in 'Staging location', with: staging_location
 
     click_button 'Submit'

--- a/spec/features/preassembly_run/book_using_file_manifest_spec.rb
+++ b/spec/features/preassembly_run/book_using_file_manifest_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Pre-assemble Book Using File Manifest' do
     select 'Book', from: 'Content type'
     fill_in 'Staging location', with: staging_location
     select('Default', from: 'Processing configuration') unless Settings.ocr.enabled
-    check 'batch_context_using_file_manifest'
+    choose 'batch_context_using_file_manifest_true'
 
     perform_enqueued_jobs do
       click_button 'Submit'

--- a/spec/features/preassembly_run/book_using_file_manifest_spec.rb
+++ b/spec/features/preassembly_run/book_using_file_manifest_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Pre-assemble Book Using File Manifest' do
     select 'Preassembly Run', from: 'Job type'
     select 'Book', from: 'Content type'
     fill_in 'Staging location', with: staging_location
-    select 'Default', from: 'Processing configuration'
+    select('Default', from: 'Processing configuration') unless Settings.ocr.enabled
     check 'batch_context_using_file_manifest'
 
     perform_enqueued_jobs do

--- a/spec/features/preassembly_run/book_using_file_manifest_spec.rb
+++ b/spec/features/preassembly_run/book_using_file_manifest_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Pre-assemble Book Using File Manifest' do
 
     fill_in 'Project name', with: project_name
     select 'Preassembly Run', from: 'Job type'
-    select 'Book', from: 'Content structure'
+    select 'Book', from: 'Content type'
     fill_in 'Staging location', with: staging_location
     select 'Default', from: 'Processing configuration'
     check 'batch_context_using_file_manifest'

--- a/spec/features/preassembly_run/book_using_file_manifest_spec.rb
+++ b/spec/features/preassembly_run/book_using_file_manifest_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Pre-assemble Book Using File Manifest' do
     expect(page).to have_css('h1', text: 'Complete the form below')
 
     fill_in 'Project name', with: project_name
-    select 'Pre Assembly Run', from: 'Job type'
+    select 'Preassembly Run', from: 'Job type'
     select 'Book', from: 'Content structure'
     fill_in 'Staging location', with: staging_location
     select 'Default', from: 'Processing configuration'

--- a/spec/features/preassembly_run/dark_file_object_spec.rb
+++ b/spec/features/preassembly_run/dark_file_object_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Pre-assemble object with dark files' do
 
     fill_in 'Project name', with: project_name
     select 'Preassembly Run', from: 'Job type'
-    select 'File', from: 'Content structure'
+    select 'File', from: 'Content type'
     fill_in 'Staging location', with: staging_location
 
     perform_enqueued_jobs do

--- a/spec/features/preassembly_run/dark_file_object_spec.rb
+++ b/spec/features/preassembly_run/dark_file_object_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Pre-assemble object with dark files' do
     expect(page).to have_css('h1', text: 'Complete the form below')
 
     fill_in 'Project name', with: project_name
-    select 'Pre Assembly Run', from: 'Job type'
+    select 'Preassembly Run', from: 'Job type'
     select 'File', from: 'Content structure'
     fill_in 'Staging location', with: staging_location
 

--- a/spec/features/preassembly_run/document_spec.rb
+++ b/spec/features/preassembly_run/document_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Pre-assemble document object' do
 
     fill_in 'Project name', with: project_name
     select 'Preassembly Run', from: 'Job type'
-    select 'Document', from: 'Content structure'
+    select 'Document', from: 'Content type'
     fill_in 'Staging location', with: staging_location
 
     perform_enqueued_jobs do

--- a/spec/features/preassembly_run/document_spec.rb
+++ b/spec/features/preassembly_run/document_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Pre-assemble document object' do
     expect(page).to have_css('h1', text: 'Complete the form below')
 
     fill_in 'Project name', with: project_name
-    select 'Pre Assembly Run', from: 'Job type'
+    select 'Preassembly Run', from: 'Job type'
     select 'Document', from: 'Content structure'
     fill_in 'Staging location', with: staging_location
 

--- a/spec/features/preassembly_run/geo_spec.rb
+++ b/spec/features/preassembly_run/geo_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Pre-assemble geo object' do
 
     fill_in 'Project name', with: project_name
     select 'Preassembly Run', from: 'Job type'
-    select 'Geo', from: 'Content structure'
+    select 'Geo', from: 'Content type'
     fill_in 'Staging location', with: staging_location
 
     perform_enqueued_jobs do

--- a/spec/features/preassembly_run/geo_spec.rb
+++ b/spec/features/preassembly_run/geo_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Pre-assemble geo object' do
     expect(page).to have_css('h1', text: 'Complete the form below')
 
     fill_in 'Project name', with: project_name
-    select 'Pre Assembly Run', from: 'Job type'
+    select 'Preassembly Run', from: 'Job type'
     select 'Geo', from: 'Content structure'
     fill_in 'Staging location', with: staging_location
 

--- a/spec/features/preassembly_run/hierarchial_files_with_manifest_spec.rb
+++ b/spec/features/preassembly_run/hierarchial_files_with_manifest_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe 'Pre-assemble Image object' do
       expect(page).to have_css('h1', text: 'Complete the form below')
 
       fill_in 'Project name', with: project_name
-      select 'Pre Assembly Run', from: 'Job type'
+      select 'Preassembly Run', from: 'Job type'
       select 'File', from: 'Content structure'
       fill_in 'Staging location', with: staging_location
       check 'batch_context_using_file_manifest'
@@ -138,7 +138,7 @@ RSpec.describe 'Pre-assemble Image object' do
       expect(page).to have_css('h1', text: 'Complete the form below')
 
       fill_in 'Project name', with: project_name
-      select 'Pre Assembly Run', from: 'Job type'
+      select 'Preassembly Run', from: 'Job type'
       select 'Media', from: 'Content structure'
       fill_in 'Staging location', with: staging_location
       check 'batch_context_using_file_manifest'

--- a/spec/features/preassembly_run/hierarchial_files_with_manifest_spec.rb
+++ b/spec/features/preassembly_run/hierarchial_files_with_manifest_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe 'Pre-assemble Image object' do
 
       fill_in 'Project name', with: project_name
       select 'Preassembly Run', from: 'Job type'
-      select 'File', from: 'Content structure'
+      select 'File', from: 'Content type'
       fill_in 'Staging location', with: staging_location
       check 'batch_context_using_file_manifest'
 
@@ -139,7 +139,7 @@ RSpec.describe 'Pre-assemble Image object' do
 
       fill_in 'Project name', with: project_name
       select 'Preassembly Run', from: 'Job type'
-      select 'Media', from: 'Content structure'
+      select 'Media', from: 'Content type'
       fill_in 'Staging location', with: staging_location
       check 'batch_context_using_file_manifest'
 

--- a/spec/features/preassembly_run/hierarchial_files_with_manifest_spec.rb
+++ b/spec/features/preassembly_run/hierarchial_files_with_manifest_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe 'Pre-assemble Image object' do
       select 'Preassembly Run', from: 'Job type'
       select 'File', from: 'Content type'
       fill_in 'Staging location', with: staging_location
-      check 'batch_context_using_file_manifest'
+      choose 'batch_context_using_file_manifest_true'
 
       perform_enqueued_jobs do
         click_button 'Submit'
@@ -141,7 +141,7 @@ RSpec.describe 'Pre-assemble Image object' do
       select 'Preassembly Run', from: 'Job type'
       select 'Media', from: 'Content type'
       fill_in 'Staging location', with: staging_location
-      check 'batch_context_using_file_manifest'
+      choose 'batch_context_using_file_manifest_true'
 
       perform_enqueued_jobs do
         click_button 'Submit'

--- a/spec/features/preassembly_run/hierarchical_files_spec.rb
+++ b/spec/features/preassembly_run/hierarchical_files_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Pre-assemble Image object' do
 
       fill_in 'Project name', with: project_name
       select 'Preassembly Run', from: 'Job type'
-      select 'File', from: 'Content structure'
+      select 'File', from: 'Content type'
       fill_in 'Staging location', with: staging_location
 
       perform_enqueued_jobs do
@@ -89,8 +89,7 @@ RSpec.describe 'Pre-assemble Image object' do
 
       fill_in 'Project name', with: project_name
       select 'Preassembly Run', from: 'Job type'
-      select 'Image', from: 'Content structure'
-      select 'Group by filename', from: 'Processing configuration'
+      select 'Image', from: 'Content type'
       fill_in 'Staging location', with: staging_location
 
       perform_enqueued_jobs do

--- a/spec/features/preassembly_run/hierarchical_files_spec.rb
+++ b/spec/features/preassembly_run/hierarchical_files_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Pre-assemble Image object' do
       expect(page).to have_css('h1', text: 'Complete the form below')
 
       fill_in 'Project name', with: project_name
-      select 'Pre Assembly Run', from: 'Job type'
+      select 'Preassembly Run', from: 'Job type'
       select 'File', from: 'Content structure'
       fill_in 'Staging location', with: staging_location
 
@@ -88,7 +88,7 @@ RSpec.describe 'Pre-assemble Image object' do
       expect(page).to have_css('h1', text: 'Complete the form below')
 
       fill_in 'Project name', with: project_name
-      select 'Pre Assembly Run', from: 'Job type'
+      select 'Preassembly Run', from: 'Job type'
       select 'Image', from: 'Content structure'
       select 'Group by filename', from: 'Processing configuration'
       fill_in 'Staging location', with: staging_location

--- a/spec/features/preassembly_run/image_spec.rb
+++ b/spec/features/preassembly_run/image_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Pre-assemble Image object' do
     expect(page).to have_css('h1', text: 'Complete the form below')
 
     fill_in 'Project name', with: project_name
-    select 'Pre Assembly Run', from: 'Job type'
+    select 'Preassembly Run', from: 'Job type'
     select 'Image', from: 'Content structure'
     select 'Group by filename', from: 'Processing configuration'
     fill_in 'Staging location', with: staging_location

--- a/spec/features/preassembly_run/image_spec.rb
+++ b/spec/features/preassembly_run/image_spec.rb
@@ -35,8 +35,7 @@ RSpec.describe 'Pre-assemble Image object' do
 
     fill_in 'Project name', with: project_name
     select 'Preassembly Run', from: 'Job type'
-    select 'Image', from: 'Content structure'
-    select 'Group by filename', from: 'Processing configuration'
+    select 'Image', from: 'Content type'
     fill_in 'Staging location', with: staging_location
 
     perform_enqueued_jobs do

--- a/spec/features/preassembly_run/media_audio_spec.rb
+++ b/spec/features/preassembly_run/media_audio_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Pre-assemble Media Audio object' do
     select 'Media', from: 'Content type'
     fill_in 'Staging location', with: staging_location
     select('Default', from: 'Processing configuration') unless Settings.ocr.enabled
-    check 'batch_context_using_file_manifest'
+    choose 'batch_context_using_file_manifest_true'
 
     perform_enqueued_jobs do
       click_button 'Submit'

--- a/spec/features/preassembly_run/media_audio_spec.rb
+++ b/spec/features/preassembly_run/media_audio_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Pre-assemble Media Audio object' do
     expect(page).to have_css('h1', text: 'Complete the form below')
 
     fill_in 'Project name', with: project_name
-    select 'Pre Assembly Run', from: 'Job type'
+    select 'Preassembly Run', from: 'Job type'
     select 'Media', from: 'Content structure'
     fill_in 'Staging location', with: staging_location
     select 'Default', from: 'Processing configuration'

--- a/spec/features/preassembly_run/media_audio_spec.rb
+++ b/spec/features/preassembly_run/media_audio_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Pre-assemble Media Audio object' do
 
     fill_in 'Project name', with: project_name
     select 'Preassembly Run', from: 'Job type'
-    select 'Media', from: 'Content structure'
+    select 'Media', from: 'Content type'
     fill_in 'Staging location', with: staging_location
     select 'Default', from: 'Processing configuration'
     check 'batch_context_using_file_manifest'

--- a/spec/features/preassembly_run/media_audio_spec.rb
+++ b/spec/features/preassembly_run/media_audio_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Pre-assemble Media Audio object' do
     select 'Preassembly Run', from: 'Job type'
     select 'Media', from: 'Content type'
     fill_in 'Staging location', with: staging_location
-    select 'Default', from: 'Processing configuration'
+    select('Default', from: 'Processing configuration') unless Settings.ocr.enabled
     check 'batch_context_using_file_manifest'
 
     perform_enqueued_jobs do

--- a/spec/features/preassembly_run/media_video_spec.rb
+++ b/spec/features/preassembly_run/media_video_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Pre-assemble Media Video object' do
     expect(page).to have_css('h1', text: 'Complete the form below')
 
     fill_in 'Project name', with: project_name
-    select 'Pre Assembly Run', from: 'Job type'
+    select 'Preassembly Run', from: 'Job type'
     select 'Media', from: 'Content structure'
     fill_in 'Staging location', with: staging_location
     select 'Default', from: 'Processing configuration'

--- a/spec/features/preassembly_run/media_video_spec.rb
+++ b/spec/features/preassembly_run/media_video_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Pre-assemble Media Video object' do
     select 'Media', from: 'Content type'
     fill_in 'Staging location', with: staging_location
     select('Default', from: 'Processing configuration') unless Settings.ocr.enabled
-    check 'batch_context_using_file_manifest'
+    choose 'batch_context_using_file_manifest_true'
 
     perform_enqueued_jobs do
       click_button 'Submit'

--- a/spec/features/preassembly_run/media_video_spec.rb
+++ b/spec/features/preassembly_run/media_video_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Pre-assemble Media Video object' do
     select 'Preassembly Run', from: 'Job type'
     select 'Media', from: 'Content type'
     fill_in 'Staging location', with: staging_location
-    select 'Default', from: 'Processing configuration'
+    select('Default', from: 'Processing configuration') unless Settings.ocr.enabled
     check 'batch_context_using_file_manifest'
 
     perform_enqueued_jobs do

--- a/spec/features/preassembly_run/media_video_spec.rb
+++ b/spec/features/preassembly_run/media_video_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Pre-assemble Media Video object' do
 
     fill_in 'Project name', with: project_name
     select 'Preassembly Run', from: 'Job type'
-    select 'Media', from: 'Content structure'
+    select 'Media', from: 'Content type'
     fill_in 'Staging location', with: staging_location
     select 'Default', from: 'Processing configuration'
     check 'batch_context_using_file_manifest'

--- a/spec/features/preassembly_run/no_files_spec.rb
+++ b/spec/features/preassembly_run/no_files_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Run preassembly on object with no files' do
     expect(page).to have_css('h1', text: 'Complete the form below')
 
     fill_in 'Project name', with: project_name
-    select 'Pre Assembly Run', from: 'Job type'
+    select 'Preassembly Run', from: 'Job type'
     select 'Image', from: 'Content structure'
     select 'Group by filename', from: 'Processing configuration'
     fill_in 'Staging location', with: staging_location

--- a/spec/features/preassembly_run/no_files_spec.rb
+++ b/spec/features/preassembly_run/no_files_spec.rb
@@ -35,8 +35,7 @@ RSpec.describe 'Run preassembly on object with no files' do
 
     fill_in 'Project name', with: project_name
     select 'Preassembly Run', from: 'Job type'
-    select 'Image', from: 'Content structure'
-    select 'Group by filename', from: 'Processing configuration'
+    select 'Image', from: 'Content type'
     fill_in 'Staging location', with: staging_location
 
     perform_enqueued_jobs do

--- a/spec/features/preassembly_run/preassembly_failed_spec.rb
+++ b/spec/features/preassembly_run/preassembly_failed_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Pre-assemble job fails' do
     expect(page).to have_css('h1', text: 'Complete the form below')
 
     fill_in 'Project name', with: project_name
-    select 'Pre Assembly Run', from: 'Job type'
+    select 'Preassembly Run', from: 'Job type'
     select 'Image', from: 'Content structure'
     select 'Group by filename', from: 'Processing configuration'
     fill_in 'Staging location', with: staging_location

--- a/spec/features/preassembly_run/preassembly_failed_spec.rb
+++ b/spec/features/preassembly_run/preassembly_failed_spec.rb
@@ -20,8 +20,7 @@ RSpec.describe 'Pre-assemble job fails' do
 
     fill_in 'Project name', with: project_name
     select 'Preassembly Run', from: 'Job type'
-    select 'Image', from: 'Content structure'
-    select 'Group by filename', from: 'Processing configuration'
+    select 'Image', from: 'Content type'
     fill_in 'Staging location', with: staging_location
 
     perform_enqueued_jobs do

--- a/spec/features/preassembly_run/public_tif_spec.rb
+++ b/spec/features/preassembly_run/public_tif_spec.rb
@@ -37,8 +37,7 @@ RSpec.describe 'Pre-assemble public object (shelved and published)' do
 
     fill_in 'Project name', with: project_name
     select 'Preassembly Run', from: 'Job type'
-    select 'Image', from: 'Content structure'
-    select 'Group by filename', from: 'Processing configuration'
+    select 'Image', from: 'Content type'
     fill_in 'Staging location', with: staging_location
     choose 'Preserve=Yes, Shelve=Yes, Publish=Yes'
 

--- a/spec/features/preassembly_run/public_tif_spec.rb
+++ b/spec/features/preassembly_run/public_tif_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Pre-assemble public object (shelved and published)' do
     expect(page).to have_css('h1', text: 'Complete the form below')
 
     fill_in 'Project name', with: project_name
-    select 'Pre Assembly Run', from: 'Job type'
+    select 'Preassembly Run', from: 'Job type'
     select 'Image', from: 'Content structure'
     select 'Group by filename', from: 'Processing configuration'
     fill_in 'Staging location', with: staging_location

--- a/spec/lib/pre_assembly/from_staging_location/structural_builder_spec.rb
+++ b/spec/lib/pre_assembly/from_staging_location/structural_builder_spec.rb
@@ -9,12 +9,13 @@ RSpec.describe PreAssembly::FromStagingLocation::StructuralBuilder do
                             manually_corrected_ocr:)
     end
 
-    let(:filesets) { PreAssembly::FromStagingLocation::FileSetBuilder.build(processing_configuration:, objects:, style: :document) }
+    let(:filesets) { PreAssembly::FromStagingLocation::FileSetBuilder.build(processing_configuration:, ocr_available:, objects:, style: :document) }
     let(:processing_configuration) { :default }
     let(:cocina_dro) do
       Cocina::RSpec::Factories.build(:dro, collection_ids: ['druid:bb000kk0000']).new(access: dro_access)
     end
     let(:manually_corrected_ocr) { false }
+    let(:ocr_available) { false }
 
     context 'with flat file structure' do
       let(:base_path) { 'spec/fixtures/pdf_document/content/' }
@@ -110,8 +111,9 @@ RSpec.describe PreAssembly::FromStagingLocation::StructuralBuilder do
         end
       end
 
-      context 'with filename_with_ocr processing configuration PDF files included' do
-        let(:processing_configuration) { :filename_with_ocr }
+      context 'with filename processing configuration and OCR provided PDF files included' do
+        let(:processing_configuration) { :filename }
+        let(:ocr_available) { true }
         let(:objects) { [PreAssembly::ObjectFile.new("#{base_path}document.pdf", { relative_path: 'document.pdf' })] }
         let(:dro_access) { { view: 'world', download: 'world' } }
         let(:all_files_public) { false }
@@ -161,9 +163,10 @@ RSpec.describe PreAssembly::FromStagingLocation::StructuralBuilder do
         end
       end
 
-      context 'with filename_with_ocr processing configuration XML files included' do
+      context 'with filename processing configuration with XML OCR files included' do
         let(:base_path) { 'spec/fixtures/book-file-manifest/bb000kk0000/' }
-        let(:processing_configuration) { :filename_with_ocr }
+        let(:processing_configuration) { :filename }
+        let(:ocr_available) { true }
         let(:objects) do
           [
             PreAssembly::ObjectFile.new("#{base_path}page_0001.jpg", { relative_path: 'page_0001.jpg' }),
@@ -174,7 +177,7 @@ RSpec.describe PreAssembly::FromStagingLocation::StructuralBuilder do
         let(:all_files_public) { false }
 
         context 'with non manually corrected OCR' do
-          it 'adds all the OCR file with transcription role but not corrected for accessibility' do
+          it 'adds the OCR file with transcription role but not corrected for accessibility' do
             file_sets = structural.contains
             expect(file_sets.size).to eq 1
             files = file_sets.flat_map { |file_set| file_set.structural.contains }
@@ -202,8 +205,9 @@ RSpec.describe PreAssembly::FromStagingLocation::StructuralBuilder do
 
         context 'with manually corrected OCR' do
           let(:manually_corrected_ocr) { true }
+          let(:ocr_available) { true }
 
-          it 'adds all the OCR file with transcription role but not corrected for accessibility' do
+          it 'adds the OCR file with transcription role and corrected for accessibility' do
             file_sets = structural.contains
             expect(file_sets.size).to eq 1
             files = file_sets.flat_map { |file_set| file_set.structural.contains }

--- a/spec/models/batch_context_spec.rb
+++ b/spec/models/batch_context_spec.rb
@@ -120,7 +120,6 @@ RSpec.describe BatchContext do
 
   it 'enums default to their default values' do
     bc = described_class.new
-    expect(bc.content_structure).to eq 'simple_image'
     expect(bc.processing_configuration).to eq 'default'
   end
 


### PR DESCRIPTION
# Why was this change made? 🤔

~~Please go to #1455 first~~

Fixes #1450 and fixes #1454 and fixes #1464 - restructure OCR options and language on pre-assembly batch context form as described in https://docs.google.com/document/d/1ScvlgCI-YhyV2LaaDLTVOWTvuGe4bM1tmgzVbAHTDw8/edit#heading=h.1itvjzsh0nue

Notes (because this PR does a lot of stuff):
- Change form labels (e.g. "Content structure" to "Content type")
- Change form values (e.g. "Pre Assembly Run" to "Preassembly Run")
- Changes how the user tells us OCR is available to a radio button (from a processing configuration)
- Adds other radio buttons related to OCR which are conditionally shown or hidden and affect how structural is built later
- Removes the processing configuration menu completely since it can be determined based on the content type
- Shows the display name of the content type in the Job Run detail page instead of the value (e.g. "Image" instead of "simple_image")
- Builds structural metadata with correct "role=transcription" and new cocina attributes for manually reviewed OCR based on user radio button selection.
- Removes default "content type" value in form (user must now select)

Many but not all of these changes are only done if the OCR feature flag is enabled, but some (like label/value renaming) are done either way.  This means the integration tests will need be updated once this merged, as is done here: https://github.com/sul-dlss/infrastructure-integration-test/pull/739

Comments:
- warnings/notes are shown when the user selects they want to run OCR (select "yes") instead of before they select... seems to make more sense?  YES, fine

Questions:
- Is it true that the new pre-assembly form updates remove the "Group by filename (with pre-existing ocr)" processing configuration option since this is now implicitly implied when you select "I have OCR files" with the new radio button?  YES
- if this option is gone and the content type requires a specific processing configuration ... do we even need to ask or show the processing configuration choice?  can't we just determine it by the content type now?  CAN HIDE IT

To do:
- [x] it looks like the document content type doesn't have the "I have OCR files" option, so this means the "I have verified the accessibility" option for documents essentially has to auto set the "I have OCR files" (for documents only) ... verify structural is created correctly in this scenario
- [x] change "would you like to auto-generate OCR files for the book(s)?" label to match what is in the PDF doc
- [x] remove processing configuration menu and set auotmatically, but only when OCR feature flag is on

# How was this change tested? 🤨

Localhost and existing CI and QA
PO signed off
