### PR TITLE
Comment out ancient settings that are no longer needed

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -3,10 +3,10 @@
 set :application, 'pre-assembly'
 set :repo_url, 'ssh://git@github.com/sul-dlss/pre-assembly'
 
-set :ssh_options,
-    keys: [Capistrano::OneTimeKey.temporary_ssh_private_key_path],
-    forward_agent: true,
-    auth_methods: %w[publickey password]
+# set :ssh_options,
+#     keys: [Capistrano::OneTimeKey.temporary_ssh_private_key_path],
+#     forward_agent: true,
+#     auth_methods: %w[publickey password]
 
 # Default branch is :main
 ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }.call


### PR DESCRIPTION
Also, this will break deploys when we move off of the Capistrano-OneTimeKey gem.
