### PR TITLE
move all alert text to partial for consistency

### DIFF
--- a/app/views/batch_contexts/_alert.html.erb
+++ b/app/views/batch_contexts/_alert.html.erb
@@ -8,12 +8,15 @@
       <div class="d-flex align-items-center gap-2">
         <div>
           <span class="fw-semibold d-block"><%= title %></span>
-          <% if text == 'ocr_document' && alert_type == 'info' %>
+          <% case text %>
+           <% when :ocr_document %>
+            Avoid auto-generating OCR files for PDF documents that do not contain any text, as it may have adverse effects.
+           <% when :ocr_image %>
+            Avoid auto-generating OCR files for images that do not contain any text, as it may have adverse effects.
+          <% when :ocr_accessibility %>
             Auto-generating OCR files alone will not fully meet accessibility standards. To comply with <%= link_to "Stanford's Accessibility policy", 'https://uit.stanford.edu/accessibility/policy' %>, you are encouraged to correct the PDF documents by following the <%= link_to 'PDF accessibility guides', 'https://uit.stanford.edu/accessibility/guides/pdf'%>.
-          <% elsif text == 'ocr_image' || text == 'ocr_document' %>
-            Avoid auto-generating OCR files for <%= text == 'ocr_image' ? 'images' : 'PDF documents' %> that do not contain any text, as it may have adverse effects.
-          <% else %>
-            <%= text %>
+          <% when :languages %>
+            Selecting more than eight OCR languages may have an adverse effect on the speed and quality of recognition. Please reduce the number of languages.
           <% end %>
         </div>
       </div>

--- a/app/views/batch_contexts/_new_bc_form.erb
+++ b/app/views/batch_contexts/_new_bc_form.erb
@@ -43,11 +43,11 @@
                     as: :radio_buttons,
                     collection: [['Yes', true], ['No', false]] %>
                 <div data-ocr-target="runOcrImageNotes" hidden>
-                    <%= render 'alert', alert_type: 'warning', text: 'ocr_image' %>
+                    <%= render 'alert', alert_type: 'info', text: :ocr_image %>
                 </div>
                 <div data-ocr-target="runOcrDocumentNotes" hidden>
-                    <%= render 'alert', alert_type: 'info', text: 'ocr_document' %>
-                    <%= render 'alert', alert_type: 'warning', text: 'ocr_document' %>
+                    <%= render 'alert', alert_type: 'info', text: :ocr_document %>
+                    <%= render 'alert', alert_type: 'warning', text: :ocr_accessibility %>
                 </div>
             </div>
             <div class="ocr-language d-none" data-ocr-target="ocrLanguageWrapper">
@@ -76,8 +76,7 @@
                 <div data-ocr-target="selectedLanguages">
                 </div>
                 <div class="d-none mb-2" data-ocr-target="languageWarning">
-                    <%= render 'alert', alert_type: 'warning', text: 'Selecting more than eight OCR languages may have an adverse effect on the
-                    speed and quality of recognition. Please reduce the number of languages.' %>
+                    <%= render 'alert', alert_type: 'warning', text: :languages %>
                 </div>
             </div>
         </div>

--- a/app/views/batch_contexts/_new_bc_form.erb
+++ b/app/views/batch_contexts/_new_bc_form.erb
@@ -46,8 +46,8 @@
                     <%= render 'alert', alert_type: 'warning', text: :ocr_image %>
                 </div>
                 <div data-ocr-target="runOcrDocumentNotes" hidden>
-                    <%= render 'alert', alert_type: 'warning', text: :ocr_document %>
                     <%= render 'alert', alert_type: 'info', text: :ocr_accessibility %>
+                    <%= render 'alert', alert_type: 'warning', text: :ocr_document %>
                 </div>
             </div>
             <div class="ocr-language d-none" data-ocr-target="ocrLanguageWrapper">

--- a/app/views/batch_contexts/_new_bc_form.erb
+++ b/app/views/batch_contexts/_new_bc_form.erb
@@ -43,11 +43,11 @@
                     as: :radio_buttons,
                     collection: [['Yes', true], ['No', false]] %>
                 <div data-ocr-target="runOcrImageNotes" hidden>
-                    <%= render 'alert', alert_type: 'info', text: :ocr_image %>
+                    <%= render 'alert', alert_type: 'warning', text: :ocr_image %>
                 </div>
                 <div data-ocr-target="runOcrDocumentNotes" hidden>
-                    <%= render 'alert', alert_type: 'info', text: :ocr_document %>
-                    <%= render 'alert', alert_type: 'warning', text: :ocr_accessibility %>
+                    <%= render 'alert', alert_type: 'warning', text: :ocr_document %>
+                    <%= render 'alert', alert_type: 'info', text: :ocr_accessibility %>
                 </div>
             </div>
             <div class="ocr-language d-none" data-ocr-target="ocrLanguageWrapper">


### PR DESCRIPTION
# Why was this change made? 🤔

Alternate approach to keep all text in the partial for consistency and pass in a key to decide which to show.


# How was this change tested? 🤨

Localhost