### PR TITLE
Ditch capistrano-rvm

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -11,7 +11,7 @@ require 'capistrano/bundler'
 require 'capistrano/honeybadger'
 require 'capistrano/passenger'
 require 'capistrano/rails'
-require 'capistrano/rvm' # need this for ubuntu
+# require 'capistrano/rvm'
 require 'dlss/capistrano'
 require 'whenever/capistrano'
 

--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,6 @@ group :deployment do
   gem 'capistrano-bundler'
   gem 'capistrano-passenger'
   gem 'capistrano-rails'
-  gem 'capistrano-rvm', require: false # for ubuntu
   gem 'dlss-capistrano', require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,9 +127,6 @@ GEM
     capistrano-rails (1.6.3)
       capistrano (~> 3.1)
       capistrano-bundler (>= 1.1, < 3)
-    capistrano-rvm (0.1.2)
-      capistrano (~> 3.0)
-      sshkit (~> 1.2)
     capistrano-shared_configs (0.2.2)
     capybara (3.40.0)
       addressable
@@ -564,7 +561,6 @@ DEPENDENCIES
   capistrano-bundler
   capistrano-passenger
   capistrano-rails
-  capistrano-rvm
   capybara
   config
   cssbundling-rails (~> 1.2)


### PR DESCRIPTION
# Why was this change made?

This commit removes capistrano-rvm, which we no longer need. This is the only app in our portfolio that still uses it. I suspect we missed this when we nuked it a couple years ago. Plus, it breaks SSH stuff in dlss-capistrano 5.1.x.

# How was this change tested?

CI
