### PR TITLE
show human friendly content type and processing configuration in projects table view

### DIFF
--- a/app/views/batch_contexts/index.html.erb
+++ b/app/views/batch_contexts/index.html.erb
@@ -21,14 +21,14 @@
         <tr>
           <td><%= link_to batch_context.project_name, batch_context %></td>
           <td><%= batch_context.user.email %></td>
-          <td><%= batch_context.content_structure %></td>
+          <td><%= content_structure.to_h.key(batch_context.content_structure) %></td>
           <td>
             <%= batch_context.staging_location %>
             <% if batch_context.active_globus_url %>
               <br /><%= link_to 'globus link', batch_context.active_globus_url %>
             <% end %>
           </td>
-          <td><%= batch_context.processing_configuration %></td>
+          <td><%= processing_configuration.to_h.key(batch_context.processing_configuration) %></td>
           <td><%= batch_context.using_file_manifest ? 'yes' : 'no' %></td>
           <td><%= batch_context.job_runs.count %></td>
           <td><%= batch_context.created_at.in_time_zone('Pacific Time (US & Canada)').to_formatted_s(:long) %></td>


### PR DESCRIPTION
# Why was this change made? 🤔

I changed this in the detail view, but not the table view...

i.e. instead of "document" show "Document/PDF" for content types and "Group by filename" instead of "filename" for porcessing configurations...


# How was this change tested? 🤨

Localhost