### PR TITLE
Enable Gemspec/AddRuntimeDependency to quiet warning

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -535,3 +535,6 @@ Style/SuperArguments: # new in 1.64
   Enabled: true
 Rails/WhereRange: # new in 2.25
   Enabled: true
+
+Gemspec/AddRuntimeDependency: # new in 1.65
+  Enabled: true


### PR DESCRIPTION
# Why was this change made? 🤔

Small rubocop update.

# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



