### PR TITLE
do not bother asking the user if a file manifest is supplied for media type

### DIFF
--- a/app/javascript/controllers/caption_controller.js
+++ b/app/javascript/controllers/caption_controller.js
@@ -3,7 +3,8 @@ import { Controller } from '@hotwired/stimulus'
 export default class extends Controller {
   static targets = ['contentStructure', 'ocrSettings', 'ocrAvailable', 'sttSettings', 'sttAvailable', 'runStt',
     'manuallyCorrectedOcr', 'manuallyCorrectedStt', 'runOcr', 'ocrLanguages', 'ocrDropdown', 'runOcrDocumentNotes',
-    'runOcrImageNotes', 'runSttNotes', 'selectedLanguages', 'languageWarning', 'dropdownContent', 'ocrLanguageWrapper']
+    'runOcrImageNotes', 'runSttNotes', 'selectedLanguages', 'languageWarning', 'dropdownContent', 'ocrLanguageWrapper',
+    'usingFileManifest']
 
   static values = { languages: Array }
 
@@ -66,6 +67,14 @@ export default class extends Controller {
     // Hide the OCR and speech to text settings by default; we will show them if the content structure allows them to
     this.ocrSettingsTarget.hidden = true
     this.sttSettingsTarget.hidden = true
+
+    // if the user selects media as the content structure, file manifest is required, so don't bother showing the control
+    //  we will automatically make it true on the server side
+    if (this.contentStructureTarget.value === 'media') {
+      this.usingFileManifestTarget.hidden = true
+    } else {
+      this.usingFileManifestTarget.hidden = false
+    }
 
     if (this.ocrAvailable()) {
       this.showOcrControls()

--- a/app/views/batch_contexts/_new_bc_form.erb
+++ b/app/views/batch_contexts/_new_bc_form.erb
@@ -3,65 +3,74 @@
      data-caption-stt-enabled="<%=Settings.speech_to_text.enabled%>"
      data-caption-ocr-enabled="<%=Settings.ocr.enabled%>">
 
-<div class="row">
-    <div class="col">
-        <h1 class="h3">Start new job</h1>
-    </div>
-    <div class="col" style="text-align: right;">
-      <% if Settings.globus.enabled %>
-        <button class="btn btn-sul-dlss" data-globus-target="requestGlobusLink" data-action="click->globus#createDestination">Request Globus Link</button>
-      <% end %>
-    </div>
-</div>
-
-<%= simple_form_for @batch_context, :html => {:class => 'p-4'} do |form| %>
-    <%= form.input :project_name %>
-
-    <%= form.simple_fields_for :job_runs do |jt| %>
-        <%= jt.input :job_type, collection:
-            [
-                ["Preassembly Run", "preassembly"],
-                ["Discovery Report", "discovery_report"]
-            ]
-        %>
-    <% end %>
-
-    <%= form.input :content_structure, label: 'Content type', input_html: { data: { action: "change->caption#contentStructureChanged", "caption-target": "contentStructure" } }, collection: content_structure %>
-
-    <div data-caption-target="ocrSettings" hidden>
-        <div data-caption-target="ocrAvailable" hidden>
-            <%= form.input :ocr_available, label: 'Do you have OCR files for the images?', input_html: { data: { action: "change->caption#ocrAvailableChanged" } },
-                as: :radio_buttons,
-                collection: [['Yes', true], ['No', false]] %>
+    <div class="row">
+        <div class="col">
+            <h1 class="h3">Start new job</h1>
         </div>
-        <div data-caption-target="manuallyCorrectedOcr" hidden>
-            <%= form.input :manually_corrected_ocr, input_html: { data: { action: "change->caption#manuallyCorrectedOcrChanged" } },
-                as: :radio_buttons,
-                collection: [['Yes', true], ['No', false]] %>
+        <div class="col" style="text-align: right;">
+        <% if Settings.globus.enabled %>
+            <button class="btn btn-sul-dlss" data-globus-target="requestGlobusLink" data-action="click->globus#createDestination">Request Globus Link</button>
+        <% end %>
         </div>
-        <div data-caption-target="runOcr" hidden>
-            <%= form.input :run_ocr, input_html: { data: { action: "change->caption#runOcrChanged", "caption-target": "runOcrOptions" } },
-                as: :radio_buttons,
-                collection: [['Yes', true], ['No', false]] %>
-            <div data-caption-target="runOcrImageNotes" hidden>
-                <%= render 'alert', alert_type: 'warning', text: :ocr_image %>
+    </div>
+
+    <%= simple_form_for @batch_context, :html => {:class => 'p-4'} do |form| %>
+        <%= form.input :project_name %>
+
+        <%= form.simple_fields_for :job_runs do |jt| %>
+            <%= jt.input :job_type, collection:
+                [
+                    ["Preassembly Run", "preassembly"],
+                    ["Discovery Report", "discovery_report"]
+                ]
+            %>
+        <% end %>
+
+        <%= form.input :content_structure, label: 'Content type', input_html: { data: { action: "change->caption#contentStructureChanged", "caption-target": "contentStructure" } }, collection: content_structure %>
+
+        <div data-caption-target="ocrSettings" hidden>
+            <div data-caption-target="ocrAvailable" hidden>
+                <%= form.input :ocr_available, label: 'Do you have OCR files for the images?', input_html: { data: { action: "change->caption#ocrAvailableChanged" } },
+                    as: :radio_buttons,
+                    collection: [['Yes', true], ['No', false]] %>
             </div>
-            <div data-caption-target="runOcrDocumentNotes" hidden>
-                <%= render 'alert', alert_type: 'info', text: :ocr_accessibility %>
-                <%= render 'alert', alert_type: 'warning', text: :ocr_document %>
+            <div data-caption-target="manuallyCorrectedOcr" hidden>
+                <%= form.input :manually_corrected_ocr, input_html: { data: { action: "change->caption#manuallyCorrectedOcrChanged" } },
+                    as: :radio_buttons,
+                    collection: [['Yes', true], ['No', false]] %>
             </div>
-            <div class="ocr-language d-none" data-caption-target="ocrLanguageWrapper">
-                <div class="dropdown w-100 mb-3 d-inline-block" data-action="click@window->caption#clickOutside">
-                    <div data-caption-target="ocrDropdown">
-                        <div>Content language</div>
-                        <div class="border rounded ocr-search-bar d-flex">
-                            <button aria-label="toggle dropdown" class="btn btn-link text-secondary bg-white" data-action="click->caption#languageDropdown" aria-label="">
-                                <i class="fas fa-search"></i>
-                            </button>
-                            <input data-action="input->caption#search focus->caption#languageDropdown" aria-label="Search available Abbyy languages" />
-                            <button aria-label="toggle dropdown" class="btn btn-link text-secondary bg-white" data-action="click->caption#languageDropdown" id="caret">
-                                <i class="fa-solid fa-caret-down"></i>
-                            </button>
+            <div data-caption-target="runOcr" hidden>
+                <%= form.input :run_ocr, input_html: { data: { action: "change->caption#runOcrChanged", "caption-target": "runOcrOptions" } },
+                    as: :radio_buttons,
+                    collection: [['Yes', true], ['No', false]] %>
+                <div data-caption-target="runOcrImageNotes" hidden>
+                    <%= render 'alert', alert_type: 'warning', text: :ocr_image %>
+                </div>
+                <div data-caption-target="runOcrDocumentNotes" hidden>
+                    <%= render 'alert', alert_type: 'info', text: :ocr_accessibility %>
+                    <%= render 'alert', alert_type: 'warning', text: :ocr_document %>
+                </div>
+                <div class="ocr-language d-none" data-caption-target="ocrLanguageWrapper">
+                    <div class="dropdown w-100 mb-3 d-inline-block" data-action="click@window->caption#clickOutside">
+                        <div data-caption-target="ocrDropdown">
+                            <div>Content language</div>
+                            <div class="border rounded ocr-search-bar d-flex">
+                                <button aria-label="toggle dropdown" class="btn btn-link text-secondary bg-white" data-action="click->caption#languageDropdown" aria-label="">
+                                    <i class="fas fa-search"></i>
+                                </button>
+                                <input data-action="input->caption#search focus->caption#languageDropdown" aria-label="Search available Abbyy languages" />
+                                <button aria-label="toggle dropdown" class="btn btn-link text-secondary bg-white" data-action="click->caption#languageDropdown" id="caret">
+                                    <i class="fa-solid fa-caret-down"></i>
+                                </button>
+                            </div>
+                        </div>
+                        <div id="ocr-languages" data-caption-target="dropdownContent" class="dropdown-content d-none languages-group border rounded bg-white">
+                            <% available_ocr_languages.each do |language| %>
+                                <label class="d-block">
+                                    <%= form.check_box 'ocr_languages', { multiple: true, data: { 'caption-target': 'ocrLanguages', 'ocr-label': language[0], 'ocr-value': language[1], action: 'change->caption#languageUpdate' } }, language[1], nil %>
+                                    <%= language[0] %>
+                                </label>
+                            <% end %>
                         </div>
                     </div>
                     <div id="ocr-languages" data-caption-target="dropdownContent" class="dropdown-content d-none languages-group border rounded bg-white">
@@ -73,63 +82,56 @@
                         <% end %>
                     </div>
                 </div>
-                <div id="ocr-languages" data-caption-target="dropdownContent" class="dropdown-content d-none languages-group border rounded bg-white">
-                    <% available_ocr_languages.each do |language| %>
-                        <label class="d-block">
-                            <%= form.check_box 'ocr_languages', { multiple: true, data: { 'caption-target': 'ocrLanguages', 'ocr-label': language[0], 'ocr-value': language[1], action: 'change->caption#languageUpdate' } }, language[1], nil %>
-                            <%= language[0] %>
-                        </label>
-                    <% end %>
+                <div data-caption-target="selectedLanguages">
+                </div>
+                <div class="d-none mb-2" data-caption-target="languageWarning">
+                    <%= render 'alert', alert_type: 'warning', text: :languages %>
                 </div>
             </div>
-            <div data-caption-target="selectedLanguages">
+        </div>
+
+        <% unless Settings.ocr.enabled # if OCR is not enabled, keep the processing configuration menu %>
+        <%= form.input :processing_configuration, collection: processing_configuration %>
+        <% end %>
+
+        <div data-caption-target="sttSettings" hidden>
+            <div data-caption-target="sttAvailable">
+                <%= form.input :stt_available, label: 'Do you have caption/transcript files for the media?', input_html: { data: { action: "change->caption#sttAvailableChanged" } },
+                    as: :radio_buttons,
+                    collection: [['Yes', true], ['No', false]] %>
             </div>
-            <div class="d-none mb-2" data-caption-target="languageWarning">
-                <%= render 'alert', alert_type: 'warning', text: :languages %>
+            <div data-caption-target="manuallyCorrectedStt" hidden>
+                <%= render 'alert', alert_type: 'info', text: :stt_corrected %>
+            </div>
+            <div data-caption-target="runStt">
+                <%= form.input :run_stt, label: 'Would you like to auto-generate caption/transcript files for the media?',
+                    input_html: { data: { action: "change->caption#runSttChanged" } },
+                    as: :radio_buttons,
+                    collection: [['Yes', true], ['No', false]] %>
+                <div data-caption-target="runSttNotes" hidden>
+                    <%= render 'alert', alert_type: 'info', text: :stt_accessibility %>
+                    <%= render 'alert', alert_type: 'warning', text: :stt_media %>
+                </div>
             </div>
         </div>
-    </div>
 
-    <% unless Settings.ocr.enabled # if OCR is not enabled, keep the processing configuration menu %>
-       <%= form.input :processing_configuration, collection: processing_configuration %>
+        <%= form.input :staging_location, input_html: { data: { "globus-target": "stagingLocation" } } %>
+
+        <%# the 'staging_style_symlink` is hidden, since we do not currently want users to access it (it may cause problems with some accessioning steps)%>
+        <%= form.hidden_field :staging_style_symlink, value: false %>
+
+        <div data-caption-target="usingFileManifest">
+            <%= form.input :using_file_manifest,
+                        as: :radio_buttons,
+                        collection: [['Yes', true], ['No', false]],
+                        label: 'Do you have a file manifest?' %>
+        </div>
+
+        <%= form.input :all_files_public,
+                    as: :radio_buttons,
+                    collection: [['Default', false], ['Preserve=Yes, Shelve=Yes, Publish=Yes', true]] %>
+
+        <%= form.button :submit, class: "btn-sul-dlss" %>
     <% end %>
-
-    <div data-caption-target="sttSettings" hidden>
-        <div data-caption-target="sttAvailable">
-            <%= form.input :stt_available, label: 'Do you have caption/transcript files for the media?', input_html: { data: { action: "change->caption#sttAvailableChanged" } },
-                as: :radio_buttons,
-                collection: [['Yes', true], ['No', false]] %>
-        </div>
-        <div data-caption-target="manuallyCorrectedStt" hidden>
-            <%= render 'alert', alert_type: 'info', text: :stt_corrected %>
-        </div>
-        <div data-caption-target="runStt">
-            <%= form.input :run_stt, label: 'Would you like to auto-generate caption/transcript files for the media?',
-                input_html: { data: { action: "change->caption#runSttChanged" } },
-                as: :radio_buttons,
-                collection: [['Yes', true], ['No', false]] %>
-            <div data-caption-target="runSttNotes" hidden>
-                <%= render 'alert', alert_type: 'info', text: :stt_accessibility %>
-                <%= render 'alert', alert_type: 'warning', text: :stt_media %>
-            </div>
-        </div>
-    </div>
-
-    <%= form.input :staging_location, input_html: { data: { "globus-target": "stagingLocation" } } %>
-
-    <%# the 'staging_style_symlink` is hidden, since we do not currently want users to access it (it may cause problems with some accessioning steps)%>
-    <%= form.hidden_field :staging_style_symlink, value: false %>
-
-    <%= form.input :using_file_manifest,
-                   as: :radio_buttons,
-                   collection: [['Yes', true], ['No', false]],
-                   label: 'Do you have a file manifest?' %>
-
-    <%= form.input :all_files_public,
-                   as: :radio_buttons,
-                   collection: [['Default', false], ['Preserve=Yes, Shelve=Yes, Publish=Yes', true]] %>
-
-    <%= form.button :submit, class: "btn-sul-dlss" %>
-<% end %>
 
 </div>

--- a/spec/models/batch_context_spec.rb
+++ b/spec/models/batch_context_spec.rb
@@ -29,38 +29,90 @@ RSpec.describe BatchContext do
     it { is_expected.to validate_presence_of(:processing_configuration) }
     it { is_expected.to validate_presence_of(:project_name) }
 
-    context 'file_manifest required for media' do
-      context 'when using_file_manifest is not selected' do
-        let(:attr_hash) do
-          {
-            project_name: 'File_manifest_media',
-            staging_location: 'spec/fixtures/media_audio_test',
-            content_structure: 'media',
-            processing_configuration: 'default',
-            using_file_manifest: false
-          }
+    context 'file_manifest setting' do
+      context 'when media content type selected' do
+        context 'when using_file_manifest is not selected' do
+          let(:attr_hash) do
+            {
+              project_name: 'File_manifest_media',
+              staging_location: 'spec/fixtures/media_audio_test',
+              content_structure: 'media',
+              processing_configuration: 'default',
+              using_file_manifest: false
+            }
+          end
+
+          it 'is valid (will be set to true automatically after submission)' do
+            expect(bc.valid?).to be true
+            expect(bc.using_file_manifest).to be true
+          end
         end
 
-        it 'is not valid' do
-          expect(bc.valid?).to be false
-          expect(bc.errors.size).to eq 1
-          expect(bc.errors.first.attribute).to eq :content_structure
+        context 'when using_file_manifest is selected' do
+          let(:attr_hash) do
+            {
+              project_name: 'File_manifest_media',
+              staging_location: 'spec/fixtures/media_audio_test',
+              content_structure: 'media',
+              processing_configuration: 'default',
+              using_file_manifest: true
+            }
+          end
+
+          it 'is valid' do
+            expect(bc.valid?).to be true
+          end
         end
       end
 
-      context 'when using_file_manifest is selected' do
-        let(:attr_hash) do
-          {
-            project_name: 'File_manifest_media',
-            staging_location: 'spec/fixtures/media_audio_test',
-            content_structure: 'media',
-            processing_configuration: 'default',
-            using_file_manifest: true
-          }
+      context 'when non-media content type selected' do
+        context 'when using_file_manifest is not selected' do
+          let(:attr_hash) do
+            {
+              project_name: 'No_file_manifest_images',
+              staging_location: 'spec/fixtures/flat_dir_images',
+              content_structure: 'simple_image',
+              processing_configuration: 'default',
+              using_file_manifest: false
+            }
+          end
+
+          it 'is valid' do
+            expect(bc.valid?).to be true
+            expect(bc.using_file_manifest).to be false
+          end
         end
 
-        it 'is valid' do
-          expect(bc.valid?).to be true
+        context 'when using_file_manifest is selected and file manifest exists' do
+          let(:attr_hash) do
+            {
+              project_name: 'File_manifest_book',
+              staging_location: 'spec/fixtures/book-file-manifest',
+              content_structure: 'simple_book',
+              processing_configuration: 'default',
+              using_file_manifest: true
+            }
+          end
+
+          it 'is valid' do
+            expect(bc.valid?).to be true
+          end
+        end
+
+        context 'when using_file_manifest is selected and file manifest does not exist' do
+          let(:attr_hash) do
+            {
+              project_name: 'File_manifest_book',
+              staging_location: 'spec/fixtures/flat_dir_images',
+              content_structure: 'simple_image',
+              processing_configuration: 'default',
+              using_file_manifest: true
+            }
+          end
+
+          it 'is not valid' do
+            expect(bc.valid?).to be false
+          end
         end
       end
     end
@@ -354,7 +406,7 @@ RSpec.describe BatchContext do
       context 'when not found' do
         it 'adds error' do
           bc.send(:verify_file_manifest_exists)
-          expect(bc.errors.map(&:type)).to include('missing or empty file manifest: spec/fixtures/images_jp2_tif/file_manifest.csv')
+          expect(bc.errors.map(&:type)).to include(': file manifest missing or empty: spec/fixtures/images_jp2_tif/file_manifest.csv')
         end
       end
 
@@ -368,7 +420,7 @@ RSpec.describe BatchContext do
 
         it 'adds error' do
           bc.send(:verify_file_manifest_exists)
-          expect(bc.errors.map(&:type)).to include('missing or empty file manifest: spec/fixtures/manifest_empty/file_manifest.csv')
+          expect(bc.errors.map(&:type)).to include(': file manifest missing or empty: spec/fixtures/manifest_empty/file_manifest.csv')
         end
       end
 


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #1538 - if the user selects "media" as the content structure, hide the "Do you have a file manifest?" question and just mark it as "yes".  If the `file_manifest.csv` is missing, the user will still get a validation error.

**Non-media type (still get the option)**

![Screenshot 2024-11-14 at 11 19 55 AM](https://github.com/user-attachments/assets/d95304dd-bc80-4272-b3c1-724d6fa939cd)


**Media type (no option)**

![Screenshot 2024-11-14 at 11 20 01 AM](https://github.com/user-attachments/assets/15341055-e6df-4775-80ca-1965cf0a396f)

# How was this change tested? 🤨

Localhost and updated spec.