### PR TITLE
Run rabbitmq setup on deploy.

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -49,4 +49,19 @@ set :whenever_identifier, -> { "#{fetch(:application)}_#{fetch(:stage)}" }
 # update shared_configs before restarting app
 before 'deploy:restart', 'shared_configs:update'
 
+namespace :rabbitmq do
+  desc 'Runs rake rabbitmq:setup'
+  task setup: ['deploy:set_rails_env'] do
+    on roles(:worker) do
+      within release_path do
+        with rails_env: fetch(:rails_env) do
+          execute :rake, 'rabbitmq:setup'
+        end
+      end
+    end
+  end
+
+  before 'sneakers_systemd:start', 'rabbitmq:setup'
+end
+
 set :honeybadger_env, fetch(:stage)


### PR DESCRIPTION
closes #1531

# Why was this change made? 🤔
So that rabbit bindings are set on deploy.


# How was this change tested? 🤨
QA

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



