### PR TITLE
Stop using popovers for copy indicator.

### DIFF
--- a/app/javascript/controllers/copy_controller.js
+++ b/app/javascript/controllers/copy_controller.js
@@ -1,4 +1,3 @@
-import bootstrap from 'bootstrap/dist/js/bootstrap'
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
@@ -6,16 +5,25 @@ export default class extends Controller {
     clip: String
   }
 
+  connect () {
+    this.running = false
+  }
+
   copy (event) {
+    if (this.running) return
+    this.running = true
+
+    const el = event.target
+
+    const spanEl = document.createElement('span')
+    spanEl.classList.add('badge', 'bg-primary', 'ms-1', 'z-2', 'position-absolute')
+    spanEl.innerHTML = 'Copied'
+
+    el.after(spanEl)
+
     navigator.clipboard.writeText(this.clipValue)
     event.preventDefault()
 
-    const popover = new bootstrap.Popover(event.target, {
-      content: 'Copied.',
-      placement: 'top',
-      trigger: 'manual'
-    })
-    popover.show()
-    setTimeout(function () { popover.dispose() }, 1500)
+    setTimeout(function () { spanEl.remove(); this.running = false }, 1500)
   }
 }


### PR DESCRIPTION
closes #1558

# Why was this change made? 🤔
Stop using popovers.


# How was this change tested? 🤨
Local
⚡ ⚠ If this change has cross service impact (e.g. changes what is written to shared file systems or how it uses APIs), ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



