### PR TITLE
Remove explicit one-time key setup

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -2,5 +2,4 @@
 
 server 'sul-preassembly-prod.stanford.edu', user: 'preassembly', roles: %w[web app db worker]
 
-Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -2,5 +2,4 @@
 
 server 'sul-preassembly-qa.stanford.edu', user: 'preassembly', roles: %w[web app db worker]
 
-Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -2,5 +2,4 @@
 
 server 'sul-preassembly-stage.stanford.edu', user: 'preassembly', roles: %w[web app db worker]
 
-Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'


### PR DESCRIPTION
This line has been a no-op since dlss-capistrano 5.2.0. Setting up the one-time key is done automatically in dlss-capistrano now.