### PR TITLE
text updates for pre-assembly form

### DIFF
--- a/app/javascript/controllers/caption_controller.js
+++ b/app/javascript/controllers/caption_controller.js
@@ -4,7 +4,7 @@ export default class extends Controller {
   static targets = ['contentStructure', 'ocrSettings', 'ocrAvailable', 'sttSettings', 'sttAvailable', 'runStt',
     'manuallyCorrectedOcr', 'manuallyCorrectedStt', 'runOcr', 'ocrLanguages', 'ocrDropdown', 'runOcrDocumentNotes',
     'runOcrImageNotes', 'runSttNotes', 'selectedLanguages', 'languageWarning', 'dropdownContent', 'ocrLanguageWrapper',
-    'usingFileManifest']
+    'usingFileManifest', 'ocrAvailableImageFormat']
 
   static values = { languages: Array }
 
@@ -48,7 +48,7 @@ export default class extends Controller {
   }
 
   labelImagesManuallyCorrected () {
-    return 'Do the OCR files comply with accessibility standards? More info: <a target=_blank href="https://blog.adobe.com/en/publish/2016/03/08/correcting-ocr-errors">Correcting OCR</a>.'
+    return 'Have the OCR files been manually corrected in order to comply with accessibility standards? More info: <a target=_blank href="https://blog.adobe.com/en/publish/2016/03/08/correcting-ocr-errors">Correcting OCR</a>.'
   }
 
   labelDocumentsManuallyCorrected () {
@@ -97,6 +97,7 @@ export default class extends Controller {
       this.manuallyCorrectedOcrTarget.querySelector('legend').innerHTML = this.labelDocumentsManuallyCorrected()
       this.manuallyCorrectedOcrTarget.hidden = false
       this.ocrAvailableTarget.hidden = true
+      this.ocrAvailableImageFormatTarget.hidden = true
       this.manuallyCorrectedOcrChanged()
     } else { // images and books have the same labels and show the same questions (different from documents)
       this.manuallyCorrectedOcrTarget.querySelector('legend').innerHTML = this.labelImagesManuallyCorrected()
@@ -131,6 +132,7 @@ export default class extends Controller {
   // if the user indicates they have ocr available, show/hide the manually corrected and run OCR option (for images/books)
   ocrAvailableChanged () {
     const ocrAvailable = this.ocrAvailableTarget.querySelector('input[type="radio"]:checked').value === 'true'
+    this.ocrAvailableImageFormatTarget.hidden = !ocrAvailable
     this.manuallyCorrectedOcrTarget.hidden = !ocrAvailable
     this.runOcrTarget.hidden = ocrAvailable
     if (ocrAvailable) {

--- a/app/views/batch_contexts/_alert.html.erb
+++ b/app/views/batch_contexts/_alert.html.erb
@@ -1,18 +1,21 @@
 <div class="bg-white">
-  <div class="alert alert-<%= alert_type %> d-flex shadow-sm align-items-center" role="alert">
+  <div class="alert alert-<%= alert_type %> d-flex shadow-sm align-items-top" role="alert">
     <% icon = alert_type == 'warning' ? 'bi-exclamation-triangle-fill' : 'bi-info-circle-fill' %>
     <% title = alert_type == 'warning' ? 'Warning' : 'Note' %>
-    <div class="bi <%= icon %> fs-3 me-3 align-self-center d-flex justify-content-center text-<%= alert_type %>"></div>
+    <div class="bi <%= icon %> fs-3 me-3 align-self-top d-flex justify-content-center text-<%= alert_type %>"></div>
     <div class="text-body">
       <div class="fw-semibold"><%= title %></div>
       <div>
         <% case text %>
-          <% when :ocr_document %>
-          Avoid auto-generating OCR files for PDF documents that do not contain any text, as it may have adverse effects.
-          <% when :ocr_image %>
-          Avoid auto-generating OCR files for images that do not contain any text, as it may have adverse effects.
+        <% when :ocr_image_format %>
+          OCR files must be in ALTO XML format and enumerated in a file manifest.
+        <% when :ocr_document %>
+          Avoid auto-generating OCR files for PDF documents that do not contain any typed or printed text, or for PDF documents that already contain highlightable text (including most PDFs created using word processing software).
+        <% when :ocr_image %>
+          Avoid auto-generating OCR files for images that do not contain any typed or printed text, as it may have adverse effects.
         <% when :ocr_accessibility %>
-          Auto-generating OCR files alone will not fully meet accessibility standards. To comply with <%= link_to "Stanford's Accessibility policy", 'https://uit.stanford.edu/accessibility/policy' %>, you are encouraged to correct the PDF documents by following the <%= link_to 'PDF accessibility guides', 'https://uit.stanford.edu/accessibility/guides/pdf' %>.
+          <p>Auto-generating OCR files alone will not fully meet accessibility standards. To comply with <%= link_to "Stanford's Accessibility policy", 'https://uit.stanford.edu/accessibility/policy' %>, you are encouraged to correct the PDF documents by following the <%= link_to 'PDF accessibility guides', 'https://uit.stanford.edu/accessibility/guides/pdf' %>.</p>
+          <p>PDF OCR is not currently searchable via the embedded viewer on purl and SearchWorks pages. In order to use the viewer search functionality, the PDF must be converted to images prior to Preassembly and accessioned using the Image or Book content type.</p>
         <% when :stt_accessibility %>
           Auto-generating caption/transcript files alone will not fully meet accessibility standards. To fully comply with <%= link_to "Stanford's Accessibility policy", 'https://uit.stanford.edu/accessibility/policy' %>, you are encouraged to correct the caption/transcript files for any errors.
         <% when :stt_media %>

--- a/app/views/batch_contexts/_new_bc_form.erb
+++ b/app/views/batch_contexts/_new_bc_form.erb
@@ -34,6 +34,9 @@
                     as: :radio_buttons,
                     collection: [['Yes', true], ['No', false]] %>
             </div>
+            <div data-caption-target="ocrAvailableImageFormat" hidden>
+                <%= render 'alert', alert_type: 'info', text: :ocr_image_format %>
+            </div>
             <div data-caption-target="manuallyCorrectedOcr" hidden>
                 <%= form.input :manually_corrected_ocr, input_html: { data: { action: "change->caption#manuallyCorrectedOcrChanged" } },
                     as: :radio_buttons,


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #1604 - updated text from https://docs.google.com/document/d/1am2uuQcw5nuOb-vYQmIem8uO03v8RSd3XJ5i_jtQsf8/edit?tab=t.x4p80epulov5

Please verify it was applied correctly - sometimes partial updates were indicated, i did my best to parse the intention.

Note, since some of these alerts started getting pretty long, I thought it looked better with the alert/note icon at the top instead of centered.  See a couple examples below.

**Old style (centered icons):**

<img width="740" height="579" alt="Screenshot 2025-07-23 at 4 57 56 PM" src="https://github.com/user-attachments/assets/fc71e6c5-05d0-457e-a0ed-c933980ae6f7" />


**New style (icon on the top):**

<img width="625" height="641" alt="Screenshot 2025-07-23 at 4 57 35 PM" src="https://github.com/user-attachments/assets/bca9ccde-0624-41b7-88e7-84f765df2b92" />



# How was this change tested? 🤨

Localhost