### PR TITLE
Prevent shelve=yes publish=no preserve=no

### DIFF
--- a/app/lib/pre_assembly/digital_object.rb
+++ b/app/lib/pre_assembly/digital_object.rb
@@ -71,6 +71,9 @@ module PreAssembly
                  message: 'cannot accession when object is already in the process of accessioning' }
       end
 
+      # trigger manifest validation before opening a version in DSA; memoized so the result is reused later
+      file_manifest&.manifest
+
       unless open?
         if openable?
           version_client.open(description: 'Accessioned via Preassembly')

--- a/app/lib/pre_assembly/file_manifest.rb
+++ b/app/lib/pre_assembly/file_manifest.rb
@@ -112,6 +112,9 @@ module PreAssembly
       shelve   = row[:shelve] == 'yes'
 
       raise 'file_manifest has preserve and shelve both being set to no for a single file' if !preserve && !shelve
+      if shelve && !publish && !preserve
+        raise 'file_manifest has shelve=yes with publish=no and preserve=no for a single file, which will result in the file being deleted from all systems after accessioning'
+      end
 
       { sdrPreserve: preserve, publish:, shelve: }
     end

--- a/spec/fixtures/media_missing/file_manifest_shelve_only.csv
+++ b/spec/fixtures/media_missing/file_manifest_shelve_only.csv
@@ -1,0 +1,3 @@
+druid,filename,resource_label,sequence,publish,preserve,shelve,resource_type,role,file_language
+aa111aa1111,aa111aa1111_001_a_pm.wav,"Tape 1, Side A",1,no,no,yes,media,,
+aa111aa1111,aa111aa1111_001_a_sh.wav,,,no,yes,no,,,

--- a/spec/lib/pre_assembly/digital_object_spec.rb
+++ b/spec/lib/pre_assembly/digital_object_spec.rb
@@ -78,6 +78,30 @@ RSpec.describe PreAssembly::DigitalObject do
                              message: 'cannot accession when object is already in the process of accessioning')
       end
     end
+
+    context 'when the file manifest has shelve=yes with publish=no and preserve=no' do
+      let(:bc) { create(:batch_context, staging_location: 'spec/fixtures/media_missing', content_structure: 'media') }
+      let(:version_status) { instance_double(Dor::Services::Client::ObjectVersion::VersionStatus, open?: false, openable?: true, accessioning?: false) }
+      let(:object_client) { instance_double(Dor::Services::Client::Object, version: version_client, find: Cocina::RSpec::Factories.build(:dro)) }
+
+      before do
+        allow(version_client).to receive(:open)
+        allow(job_run.batch).to receive(:file_manifest).and_return(
+          PreAssembly::FileManifest.new(
+            staging_location: 'spec/fixtures/media_missing',
+            csv_filename: 'spec/fixtures/media_missing/file_manifest_shelve_only.csv'
+          )
+        )
+        allow(PreAssembly::AssemblyDirectory).to receive(:create)
+        allow(object).to receive(:stage_files)
+      end
+
+      it 'returns an error without opening a version' do
+        expect(status).to eq(status: 'error', pre_assem_finished: false,
+                             message: 'file_manifest has shelve=yes with publish=no and preserve=no for a single file, which will result in the file being deleted from all systems after accessioning')
+        expect(version_client).not_to have_received(:open)
+      end
+    end
   end
 
   describe '#stage_files' do

--- a/spec/lib/pre_assembly/file_manifest_spec.rb
+++ b/spec/lib/pre_assembly/file_manifest_spec.rb
@@ -24,6 +24,15 @@ RSpec.describe PreAssembly::FileManifest do
       end
     end
 
+    context 'when shelve=yes, publish=no, preserve=no (file will be deleted from all systems after accessioning)' do
+      let(:csv_filename) { "#{staging_location}/file_manifest_shelve_only.csv" }
+
+      it 'throws an exception' do
+        expect { described_class.new(staging_location:, csv_filename:).manifest }
+          .to raise_error(RuntimeError, 'file_manifest has shelve=yes with publish=no and preserve=no for a single file, which will result in the file being deleted from all systems after accessioning') # rubocop:disable Layout/LineLength
+      end
+    end
+
     context 'when blank rows' do
       let(:csv_filename) { "#{staging_location}/file_manifest_blank_rows.csv" }
 


### PR DESCRIPTION
# Why was this change made? 🤔

We want to prevent file from being accessioned with `shelve=yes` `publish=no` and `preserve=no` because it results in the file being deleted from all systems at the end of accessioning.

See https://github.com/sul-dlss/cocina-models/issues/1067 for context on why this is a bad idea.

# How was this change tested? 🤨

@andrewjbtw did some testing in stage to verify the desired behavior. There are a couple new unit tests too.

# Does your change introduce accessibility violations? 🩺

No


