### PR TITLE
Build filesets for geo

### DIFF
--- a/app/lib/pre_assembly/from_staging_location/file_set_builder.rb
+++ b/app/lib/pre_assembly/from_staging_location/file_set_builder.rb
@@ -20,8 +20,6 @@ module PreAssembly
 
       # @return [Array<FileSet>] a list of filesets in the object
       def build
-        return [] if style == :geo # geo does not need any files in structural metadata, will be created in geo specific workflows
-
         case processing_configuration
         when :default # one resource per object
           objects.collect { |obj| FileSet.new(resource_files: [obj], style:, ocr_available:) }

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_30_001217) do
+ActiveRecord::Schema[8.0].define(version: 2024_10_30_001217) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension "pg_catalog.plpgsql"
 
   create_table "accessions", force: :cascade do |t|
     t.string "druid", null: false

--- a/spec/features/preassembly_run/geo_spec.rb
+++ b/spec/features/preassembly_run/geo_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'Pre-assemble geo object' do
 
     expect(PreAssembly::FromStagingLocation::StructuralBuilder).to have_received(:build)
       .with(cocina_dro: item,
-            filesets: [], # a blank array for any geo object
+            filesets: Array,
             all_files_public: false,
             reading_order: nil,
             manually_corrected_ocr: false)

--- a/spec/lib/pre_assembly/digital_object_spec.rb
+++ b/spec/lib/pre_assembly/digital_object_spec.rb
@@ -547,22 +547,6 @@ RSpec.describe PreAssembly::DigitalObject do
       end
     end
 
-    describe 'geo structural metadata' do
-      let(:bc) { create(:batch_context, staging_location: 'spec/fixtures/geo') }
-      let(:cocina_type) { Cocina::Models::ObjectType.geo }
-      let(:content_structure) { 'geo' }
-
-      let(:expected) { { contains: [], hasMemberOrders: [], isMemberOf: [] } }
-
-      before do
-        add_object_files(extension: 'zip')
-      end
-
-      it 'generates blank structural metadata' do
-        expect(object.send(:build_structural).to_h).to eq expected
-      end
-    end
-
     describe 'grouped by filename, simple book structural metadata without file attributes' do
       let(:cocina_type) { Cocina::Models::ObjectType.book }
       let(:content_structure) { 'simple_book' }


### PR DESCRIPTION
# Why was this change made? 🤔

Geo should be treated like other objects.  It's assembly workflow no longer creates structural metadata.

# How was this change tested? 🤨
CI

